### PR TITLE
Refactor CRM tasks to use polymorphic associations

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -2,68 +2,245 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Client;
+use App\Models\Lead;
+use App\Models\Opportunity;
 use App\Models\Task;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 
 class TaskController extends Controller
 {
     public function index()
     {
-        $tasks = Task::with('company', 'opportunity')->paginate(10);
-        return Inertia::render('Tasks/Index', ['tasks' => $tasks]);
+        $companyId = Auth::user()->company_id;
+
+        $tasks = Task::with(['company', 'taskable'])
+            ->where('company_id', $companyId)
+            ->latest()
+            ->paginate(10);
+
+        return Inertia::render('Tasks/Index', [
+            'tasks' => $tasks,
+        ]);
     }
 
-    public function create()
+    public function create(?string $taskableType = null, ?int $taskableId = null)
     {
-        return Inertia::render('Tasks/Create');
+        $companyId = Auth::user()->company_id;
+        $types = $this->allowedTaskableTypes();
+
+        $prefill = null;
+        if ($taskableType && isset($types[$taskableType]) && $taskableId) {
+            $prefill = [
+                'type' => $taskableType,
+                'id' => $taskableId,
+            ];
+        }
+
+        return Inertia::render('Tasks/Create', [
+            'leads' => Lead::where('company_id', $companyId)
+                ->orderBy('name')
+                ->get(['id', 'name as label']),
+            'opportunities' => Opportunity::where('company_id', $companyId)
+                ->orderBy('description')
+                ->get(['id', 'description as label']),
+            'clients' => Client::where('company_id', $companyId)
+                ->orderBy('name')
+                ->get(['id', 'name as label']),
+            'projects' => $this->projectsForCompany($companyId),
+            'typeOptions' => $this->taskableTypeOptions(array_keys($types)),
+            'statusOptions' => $this->statusOptions(),
+            'prefillTaskable' => $prefill,
+        ]);
     }
 
     public function store(Request $request)
     {
-        $request->validate([
+        $companyId = Auth::user()->company_id;
+        $types = $this->allowedTaskableTypes();
+
+        $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'due_date' => 'required|date',
-            'status' => 'required|string', // Puede ser 'pendiente', 'en progreso', 'completada', etc.
-            'taskable_type' => 'required|string', // puede ser Lead, Opportunity, Activity, etc.
-            'taskable_id' => 'required|integer',
-            'company_id' => 'required|exists:companies,id',
+            'status' => 'required|string|max:255',
+            'taskable_type' => ['required', 'string', Rule::in(array_keys($types))],
+            'taskable_id' => ['required', 'integer'],
         ]);
 
-        Task::create($request->all());
-        return redirect()->route('tasks.index')->with('success', 'Tarea creada con éxito.');
+        $taskable = $this->resolveTaskable($validated['taskable_type'], (int) $validated['taskable_id'], $types);
+        $this->ensureTaskableBelongsToCompany($taskable, $companyId);
+
+        Task::create([
+            'title' => $validated['title'],
+            'description' => Arr::get($validated, 'description'),
+            'due_date' => $validated['due_date'],
+            'status' => $validated['status'],
+            'company_id' => $companyId,
+            'taskable_type' => $types[$validated['taskable_type']],
+            'taskable_id' => $taskable->getKey(),
+        ]);
+
+        return Redirect::route('tasks.index')->with('success', 'Tarea creada con éxito.');
     }
 
     public function show(Task $task)
     {
-        return Inertia::render('Tasks/Show', ['task' => $task]);
+        $task->load(['company', 'taskable']);
+
+        return Inertia::render('Tasks/Show', [
+            'task' => $task,
+        ]);
     }
 
     public function edit(Task $task)
     {
-        return Inertia::render('Tasks/Edit', ['task' => $task]);
+        $companyId = Auth::user()->company_id;
+        $types = $this->allowedTaskableTypes();
+
+        $task->load('taskable');
+
+        return Inertia::render('Tasks/Edit', [
+            'task' => $task,
+            'leads' => Lead::where('company_id', $companyId)
+                ->orderBy('name')
+                ->get(['id', 'name as label']),
+            'opportunities' => Opportunity::where('company_id', $companyId)
+                ->orderBy('description')
+                ->get(['id', 'description as label']),
+            'clients' => Client::where('company_id', $companyId)
+                ->orderBy('name')
+                ->get(['id', 'name as label']),
+            'projects' => $this->projectsForCompany($companyId),
+            'typeOptions' => $this->taskableTypeOptions(array_keys($types)),
+            'statusOptions' => $this->statusOptions(),
+        ]);
     }
 
     public function update(Request $request, Task $task)
     {
-        $request->validate([
+        $companyId = Auth::user()->company_id;
+        $types = $this->allowedTaskableTypes();
+
+        $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'due_date' => 'required|date',
-            'status' => 'required|string',
-            'taskable_type' => 'required|string',
-            'taskable_id' => 'required|integer',
-            'company_id' => 'required|exists:companies,id',
+            'status' => 'required|string|max:255',
+            'taskable_type' => ['required', 'string', Rule::in(array_keys($types))],
+            'taskable_id' => ['required', 'integer'],
         ]);
 
-        $task->update($request->all());
-        return redirect()->route('tasks.index')->with('success', 'Tarea actualizada con éxito.');
+        $taskable = $this->resolveTaskable($validated['taskable_type'], (int) $validated['taskable_id'], $types);
+        $this->ensureTaskableBelongsToCompany($taskable, $companyId);
+
+        $task->update([
+            'title' => $validated['title'],
+            'description' => Arr::get($validated, 'description'),
+            'due_date' => $validated['due_date'],
+            'status' => $validated['status'],
+            'company_id' => $companyId,
+            'taskable_type' => $types[$validated['taskable_type']],
+            'taskable_id' => $taskable->getKey(),
+        ]);
+
+        return Redirect::route('tasks.index')->with('success', 'Tarea actualizada con éxito.');
     }
 
     public function destroy(Task $task)
     {
         $task->delete();
-        return redirect()->route('tasks.index')->with('success', 'Tarea eliminada con éxito.');
+
+        return Redirect::route('tasks.index')->with('success', 'Tarea eliminada con éxito.');
+    }
+
+    /**
+     * @return array<string, class-string<Model>>
+     */
+    protected function allowedTaskableTypes(): array
+    {
+        $types = [
+            'lead' => Lead::class,
+            'opportunity' => Opportunity::class,
+            'client' => Client::class,
+        ];
+
+        $projectClass = 'App\\Models\\Project';
+
+        if (class_exists($projectClass)) {
+            $types['project'] = $projectClass;
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param  array<string, class-string<Model>>  $types
+     */
+    protected function resolveTaskable(string $type, int $id, array $types): Model
+    {
+        $class = $types[$type] ?? null;
+
+        abort_if($class === null, 422, 'Tipo de relación inválido.');
+
+        return $class::findOrFail($id);
+    }
+
+    protected function ensureTaskableBelongsToCompany(Model $taskable, int $companyId): void
+    {
+        if (isset($taskable->company_id) && (int) $taskable->company_id !== $companyId) {
+            abort(403, 'No puedes asociar tareas con registros de otra compañía.');
+        }
+    }
+
+    protected function taskableTypeOptions(array $keys): array
+    {
+        return array_map(function (string $key) {
+            return [
+                'value' => $key,
+                'label' => Str::headline($key),
+            ];
+        }, $keys);
+    }
+
+    protected function statusOptions(): array
+    {
+        return [
+            'pendiente',
+            'en progreso',
+            'completada',
+        ];
+    }
+
+    protected function projectsForCompany(int $companyId): array
+    {
+        $projectClass = 'App\\Models\\Project';
+
+        if (! class_exists($projectClass)) {
+            return [];
+        }
+
+        $model = new $projectClass();
+        $table = $model->getTable();
+
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'company_id')) {
+            return [];
+        }
+
+        /** @var \Illuminate\Database\Eloquent\Builder $query */
+        $query = $projectClass::query();
+
+        return $query->where('company_id', $companyId)
+            ->orderBy('name')
+            ->get(['id', 'name as label'])
+            ->toArray();
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -27,4 +27,9 @@ class Client extends Model
     {
         return $this->hasMany(Budget::class);
     }
+
+    public function tasks()
+    {
+        return $this->morphMany(Task::class, 'taskable');
+    }
 }

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -31,6 +31,6 @@ class Lead extends Model
 
     public function tasks()
     {
-        return $this->hasMany(Task::class);
+        return $this->morphMany(Task::class, 'taskable');
     }
 }

--- a/app/Models/Opportunity.php
+++ b/app/Models/Opportunity.php
@@ -33,6 +33,6 @@ class Opportunity extends Model
 
     public function tasks()
     {
-        return $this->hasMany(Task::class);
+        return $this->morphMany(Task::class, 'taskable');
     }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -4,26 +4,77 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Str;
 
 class Task extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['lead_id', 'opportunity_id', 'title', 'description', 'due_date', 'status', 'company_id'];
+    protected $fillable = [
+        'company_id',
+        'title',
+        'description',
+        'due_date',
+        'status',
+        'taskable_id',
+        'taskable_type',
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+    ];
+
+    protected $appends = [
+        'taskable_label',
+        'taskable_type_label',
+        'taskable_type_key',
+    ];
 
     public function company()
     {
         return $this->belongsTo(Company::class);
     }
 
-
-    public function lead()
+    public function taskable(): MorphTo
     {
-        return $this->belongsTo(Lead::class);
+        return $this->morphTo();
     }
 
-    public function opportunity()
+    public function getTaskableLabelAttribute(): ?string
     {
-        return $this->belongsTo(Opportunity::class);
+        $taskable = $this->relationLoaded('taskable') ? $this->getRelation('taskable') : $this->taskable;
+
+        if (! $taskable) {
+            return null;
+        }
+
+        foreach (['name', 'title', 'description'] as $attribute) {
+            if (! empty($taskable->{$attribute})) {
+                return $attribute === 'description'
+                    ? Str::limit($taskable->{$attribute}, 60)
+                    : $taskable->{$attribute};
+            }
+        }
+
+        return '#' . $taskable->getKey();
+    }
+
+    public function getTaskableTypeLabelAttribute(): ?string
+    {
+        if (! $this->taskable_type) {
+            return null;
+        }
+
+        return Str::headline(class_basename($this->taskable_type));
+    }
+
+    public function getTaskableTypeKeyAttribute(): ?string
+    {
+        if (! $this->taskable_type) {
+            return null;
+        }
+
+        return Str::snake(class_basename($this->taskable_type));
     }
 }

--- a/database/migrations/2024_11_14_190405_create_tasks_table.php
+++ b/database/migrations/2024_11_14_190405_create_tasks_table.php
@@ -10,8 +10,7 @@ class CreateTasksTable extends Migration
     {
         Schema::create('tasks', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('lead_id')->nullable()->constrained()->onDelete('cascade');
-            $table->foreignId('opportunity_id')->nullable()->constrained()->onDelete('cascade');
+            $table->nullableMorphs('taskable');
             $table->string('title');
             $table->text('description')->nullable();
             $table->date('due_date')->nullable();

--- a/resources/js/Pages/Tasks/Edit.vue
+++ b/resources/js/Pages/Tasks/Edit.vue
@@ -2,7 +2,7 @@
     <AppLayout>
         <div class="w-full min-h-screen bg-gray-100 p-6">
             <div class="bg-white p-6 rounded-lg shadow-md max-w-3xl mx-auto">
-                <h1 class="text-2xl font-bold text-blue-500 mb-4">Crear Tarea</h1>
+                <h1 class="text-2xl font-bold text-blue-500 mb-4">Editar Tarea</h1>
 
                 <form @submit.prevent="submit" class="space-y-4">
                     <div>
@@ -102,7 +102,7 @@
                             type="submit"
                             class="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
                         >
-                            Guardar
+                            Actualizar
                         </button>
                     </div>
                 </form>
@@ -112,18 +112,18 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
 
 const props = defineProps({
+    task: { type: Object, required: true },
     leads: { type: Array, default: () => [] },
     opportunities: { type: Array, default: () => [] },
     clients: { type: Array, default: () => [] },
     projects: { type: Array, default: () => [] },
     typeOptions: { type: Array, default: () => [] },
     statusOptions: { type: Array, default: () => ['pendiente', 'en progreso', 'completada'] },
-    prefillTaskable: { type: Object, default: null },
 });
 
 const typeOptions = computed(() => props.typeOptions);
@@ -135,21 +135,13 @@ const groupedOptions = computed(() => ({
     project: props.projects,
 }));
 
-const defaultType = computed(() => {
-    if (props.prefillTaskable?.type) {
-        return props.prefillTaskable.type;
-    }
-
-    return typeOptions.value.length ? typeOptions.value[0].value : '';
-});
-
 const form = ref({
-    title: '',
-    description: '',
-    due_date: '',
-    status: props.statusOptions[0] ?? 'pendiente',
-    taskable_type: defaultType.value,
-    taskable_id: props.prefillTaskable?.id ?? '',
+    title: props.task.title ?? '',
+    description: props.task.description ?? '',
+    due_date: props.task.due_date ?? '',
+    status: props.task.status ?? (props.statusOptions[0] ?? 'pendiente'),
+    taskable_type: props.task.taskable_type_key ?? (typeOptions.value[0]?.value ?? ''),
+    taskable_id: props.task.taskable_id ?? '',
 });
 
 const availableOptions = computed(() => groupedOptions.value[form.value.taskable_type] ?? []);
@@ -163,15 +155,8 @@ watch(
     }
 );
 
-onMounted(() => {
-    if (props.prefillTaskable?.type && props.prefillTaskable?.id) {
-        form.value.taskable_type = props.prefillTaskable.type;
-        form.value.taskable_id = props.prefillTaskable.id;
-    }
-});
-
 const submit = () => {
-    Inertia.post(route('tasks.store'), form.value);
+    Inertia.put(route('tasks.update', props.task.id), form.value);
 };
 
 const cancel = () => {
@@ -179,5 +164,4 @@ const cancel = () => {
 };
 
 const capitalise = (value) => (value ? value.charAt(0).toUpperCase() + value.slice(1) : '');
-
 </script>

--- a/resources/js/Pages/Tasks/Index.vue
+++ b/resources/js/Pages/Tasks/Index.vue
@@ -3,49 +3,116 @@
     <div>
         <h1>Tareas</h1>
         <inertia-link :href="route('tasks.create')" class="btn btn-primary">Crear Tarea</inertia-link>
-        <table>
-            <thead>
+        <table class="min-w-full bg-white shadow-md rounded-lg overflow-hidden">
+            <thead class="bg-gray-100 text-left">
             <tr>
-                <th>Título</th>
-                <th>Descripción</th>
-                <th>Fecha de Vencimiento</th>
-                <th>Estado</th>
-                <th>Acciones</th>
+                <th class="px-4 py-3 text-sm font-semibold text-gray-600">Título</th>
+                <th class="px-4 py-3 text-sm font-semibold text-gray-600">Relacionado con</th>
+                <th class="px-4 py-3 text-sm font-semibold text-gray-600">Fecha de vencimiento</th>
+                <th class="px-4 py-3 text-sm font-semibold text-gray-600">Estado</th>
+                <th class="px-4 py-3 text-sm font-semibold text-gray-600 text-right">Acciones</th>
             </tr>
             </thead>
             <tbody>
-            <tr v-for="task in tasks.data" :key="task.id">
-                <td>{{ task.title }}</td>
-                <td>{{ task.description }}</td>
-                <td>{{ task.due_date }}</td>
-                <td>{{ task.status }}</td>
-                <td>
-                    <inertia-link :href="route('tasks.show', task.id)" class="btn btn-info">Ver</inertia-link>
-                    <inertia-link :href="route('tasks.edit', task.id)" class="btn btn-warning">Editar</inertia-link>
-                    <button @click="deleteTask(task.id)" class="btn btn-danger">Eliminar</button>
+            <tr v-for="task in tasks.data" :key="task.id" class="border-b last:border-b-0 hover:bg-gray-50">
+                <td class="px-4 py-3 text-gray-800">
+                    <p class="font-medium">{{ task.title }}</p>
+                    <p v-if="task.description" class="text-sm text-gray-500">{{ task.description }}</p>
+                </td>
+                <td class="px-4 py-3">
+                    <p class="text-xs uppercase tracking-wide text-gray-400">{{ task.taskable_type_label || 'Sin relación' }}</p>
+                    <p class="text-gray-700">{{ task.taskable_label || '—' }}</p>
+                </td>
+                <td class="px-4 py-3 text-gray-700">{{ task.due_date }}</td>
+                <td class="px-4 py-3">
+                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold"
+                          :class="statusClass(task.status)">
+                        {{ formatStatus(task.status) }}
+                    </span>
+                </td>
+                <td class="px-4 py-3 text-right space-x-2">
+                    <inertia-link :href="route('tasks.show', task.id)" class="text-blue-500 hover:text-blue-700 text-sm">Ver</inertia-link>
+                    <inertia-link :href="route('tasks.edit', task.id)" class="text-yellow-500 hover:text-yellow-600 text-sm">Editar</inertia-link>
+                    <button @click="deleteTask(task.id)" class="text-red-500 hover:text-red-700 text-sm">Eliminar</button>
                 </td>
             </tr>
             </tbody>
         </table>
+
+        <div class="mt-4 flex justify-between items-center" v-if="tasks.links">
+            <button
+                v-if="tasks.prev_page_url"
+                class="px-3 py-1 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                @click="changePage(tasks.current_page - 1)"
+            >Anterior</button>
+            <span class="text-sm text-gray-600">Página {{ tasks.current_page }} de {{ tasks.last_page }}</span>
+            <button
+                v-if="tasks.next_page_url"
+                class="px-3 py-1 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                @click="changePage(tasks.current_page + 1)"
+            >Siguiente</button>
+        </div>
     </div>
     </AppLayout>
 </template>
 
-<script>
+<script setup>
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
+import AppLayout from '@/Layouts/AppLayout.vue';
 
-export default {
-    components: {AppLayout},
-    props: {
-        tasks: Object,
-    },
-    methods: {
-        deleteTask(id) {
-            if (confirm('¿Estás seguro de eliminar esta tarea?')) {
-                Inertia.delete(route('tasks.destroy', id));
-            }
-        },
-    },
+const props = defineProps({
+    tasks: { type: Object, required: true },
+});
+
+const deleteTask = (id) => {
+    if (confirm('¿Estás seguro de eliminar esta tarea?')) {
+        Inertia.delete(route('tasks.destroy', id));
+    }
+};
+
+const changePage = (page) => {
+    Inertia.get(route('tasks.index'), { page }, { preserveScroll: true });
+};
+
+const formatStatus = (status) => {
+    if (!status) {
+        return '';
+    }
+
+    const lower = status.toLowerCase();
+
+    switch (lower) {
+        case 'pendiente':
+            return 'Pendiente';
+        case 'en progreso':
+            return 'En progreso';
+        case 'completada':
+            return 'Completada';
+        default:
+            return status;
+    }
+};
+
+const statusClass = (status) => {
+    const base = 'bg-gray-200 text-gray-700';
+    if (!status) {
+        return base;
+    }
+
+    const lower = status.toLowerCase();
+
+    if (lower === 'pendiente') {
+        return 'bg-yellow-100 text-yellow-700';
+    }
+
+    if (lower === 'en progreso') {
+        return 'bg-blue-100 text-blue-700';
+    }
+
+    if (lower === 'completada') {
+        return 'bg-green-100 text-green-700';
+    }
+
+    return base;
 };
 </script>

--- a/routes/web/CRM.php
+++ b/routes/web/CRM.php
@@ -26,7 +26,7 @@ Route::middleware(['route.features.access:4'])->group(function () {
             'opportunities' => Opportunity::where('company_id', $company->id)->get(),
             'activities' => Activity::where('company_id', $company->id)->get(),
             'notes' => Note::where('company_id', $company->id)->get(),
-            'tasks' => Task::where('company_id', $company->id)->get(),
+            'tasks' => Task::with('taskable')->where('company_id', $company->id)->get(),
         ]);
     })->name('dashboard.crm');
 
@@ -37,7 +37,7 @@ Route::middleware(['route.features.access:4'])->group(function () {
             'opportunities' => Opportunity::where('company_id', $company->id)->get(),
             'activities' => Activity::where('company_id', $company->id)->get(),
             'notes' => Note::where('company_id', $company->id)->get(),
-            'tasks' => Task::where('company_id', $company->id)->get(),
+            'tasks' => Task::with('taskable')->where('company_id', $company->id)->get(),
         ]);
     })->name('crm.all');
 
@@ -92,7 +92,7 @@ Route::middleware(['route.features.access:4'])->group(function () {
 
     Route::middleware(['auth'])->group(function () {
         Route::get('/tasks', [TaskController::class, 'index'])->name('tasks.index');
-        Route::get('/tasks/create', [TaskController::class, 'create'])->name('tasks.create');
+        Route::get('/tasks/create/{taskableType?}/{taskableId?}', [TaskController::class, 'create'])->name('tasks.create');
         Route::post('/tasks', [TaskController::class, 'store'])->name('tasks.store');
         Route::get('/tasks/{task}', [TaskController::class, 'show'])->name('tasks.show');
         Route::get('/tasks/{task}/edit', [TaskController::class, 'edit'])->name('tasks.edit');

--- a/tests/Feature/TaskManagementTest.php
+++ b/tests/Feature/TaskManagementTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Lead;
+use App\Models\Opportunity;
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class TaskManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function a_task_can_be_created_for_a_lead(): void
+    {
+        $company = Company::create([
+            'name' => 'Test Company',
+            'nif' => 'A12345678',
+            'phone' => '123456789',
+            'email' => 'company@example.com',
+            'address' => 'Address 123',
+        ]);
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $lead = Lead::create([
+            'name' => 'Lead Test',
+            'company_name' => 'Company',
+            'email' => Str::random(10) . '@example.com',
+            'phone' => '123456789',
+            'position' => 'Manager',
+            'source' => 'web',
+            'status' => 'Nuevo',
+            'company_id' => $company->id,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('tasks.store'), [
+                'title' => 'Follow up call',
+                'description' => 'Call the lead tomorrow',
+                'due_date' => now()->addDay()->toDateString(),
+                'status' => 'pendiente',
+                'taskable_type' => 'lead',
+                'taskable_id' => $lead->id,
+            ])
+            ->assertRedirect(route('tasks.index'));
+
+        $this->assertDatabaseHas('tasks', [
+            'title' => 'Follow up call',
+            'taskable_type' => Lead::class,
+            'taskable_id' => $lead->id,
+            'company_id' => $company->id,
+        ]);
+    }
+
+    /** @test */
+    public function a_task_can_be_updated_to_target_an_opportunity(): void
+    {
+        $company = Company::create([
+            'name' => 'Another Company',
+            'nif' => 'B12345678',
+            'phone' => '987654321',
+            'email' => 'another@example.com',
+            'address' => 'Other address',
+        ]);
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $lead = Lead::create([
+            'name' => 'Lead Update',
+            'company_name' => 'Company',
+            'email' => Str::random(10) . '@example.com',
+            'phone' => '987654321',
+            'position' => 'CTO',
+            'source' => 'referral',
+            'status' => 'Nuevo',
+            'company_id' => $company->id,
+        ]);
+
+        $opportunity = Opportunity::create([
+            'lead_id' => $lead->id,
+            'description' => 'New opportunity',
+            'value' => 1000,
+            'probability' => 50,
+            'status' => 'Abierta',
+            'expected_close_date' => now()->addWeek()->toDateString(),
+            'company_id' => $company->id,
+        ]);
+
+        $task = Task::create([
+            'title' => 'Initial task',
+            'description' => 'Initial description',
+            'due_date' => now()->addDays(2)->toDateString(),
+            'status' => 'pendiente',
+            'company_id' => $company->id,
+            'taskable_type' => Lead::class,
+            'taskable_id' => $lead->id,
+        ]);
+
+        $this->actingAs($user)
+            ->put(route('tasks.update', $task->id), [
+                'title' => 'Updated task',
+                'description' => 'Updated description',
+                'due_date' => now()->addDays(3)->toDateString(),
+                'status' => 'en progreso',
+                'taskable_type' => 'opportunity',
+                'taskable_id' => $opportunity->id,
+            ])
+            ->assertRedirect(route('tasks.index'));
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $task->id,
+            'title' => 'Updated task',
+            'taskable_type' => Opportunity::class,
+            'taskable_id' => $opportunity->id,
+            'status' => 'en progreso',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- migrate CRM tasks to a polymorphic `taskable` relation and update Eloquent models accordingly
- refactor the task controller, routes, and Vue pages to handle lead/opportunity/client/project selectors with automatic company scoping
- add feature tests covering task creation and updates with the new relationships

## Testing
- php artisan test *(fails: vendor directory not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9764f6cf48323b331b694d597b083