### PR TITLE
Fix email configuration fallback block

### DIFF
--- a/resources/js/Pages/DashboardAdmin.vue
+++ b/resources/js/Pages/DashboardAdmin.vue
@@ -45,7 +45,7 @@
                     </div>
                 </div>
             </div>
-            <div v-else class="bg-white p-6 rounded-lg shadow-md mb-6">
+            <div v-if="!emailConfig" class="bg-white p-6 rounded-lg shadow-md mb-6">
                 <div class="flex justify-between items-center mb-4">
                     <h2 class="text-lg text-blue-500 font-semibold">Configuración de Correo</h2>
                 </div>


### PR DESCRIPTION
## Summary
- replace the dangling `v-else` on the admin dashboard page with an explicit `v-if="!emailConfig"`
- ensure the no-email-configuration notice renders without breaking Vue compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de527c72388323a31b33ae6831d4cf