### PR TITLE
Fix client dashboard data dependencies

### DIFF
--- a/resources/js/Pages/DashboardClientes.vue
+++ b/resources/js/Pages/DashboardClientes.vue
@@ -148,8 +148,14 @@ import DoughnutChart from '@/Components/DoughnutChart.vue';
 import BarChart from '@/Components/BarChart.vue';
 
 const props = defineProps({
-    clients: Array,
-    invoices: Array,
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+    invoices: {
+        type: Array,
+        default: () => [],
+    },
 });
 
 const nameFilter = ref('');

--- a/routes/web/Clients.php
+++ b/routes/web/Clients.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Http\Controllers\ClientController;
+use App\Models\Client;
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -9,7 +12,12 @@ Route::middleware(['route.features.access:6'])->group(function(){
 
 
 Route::get('/dashboard/clients', function () {
-    return Inertia::render('DashboardClientes', ['clients' => \App\Models\Client::where('company_id', \Illuminate\Support\Facades\Auth::user()->company_id)->get()]);
+    $companyId = Auth::user()->company_id;
+
+    return Inertia::render('DashboardClientes', [
+        'clients' => Client::where('company_id', $companyId)->get(),
+        'invoices' => Invoice::where('company_id', $companyId)->get(),
+    ]);
 })->name('dashboard.clients');
 
 


### PR DESCRIPTION
## Summary
- load the company invoices alongside clients for the dashboard view
- provide default empty arrays for client and invoice props to avoid runtime errors when data is missing

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*


------
https://chatgpt.com/codex/tasks/task_e_68de53a61bd08323855247150ac9167b