### PR TITLE
Refactor CRUD layouts for catalog, HR, and suppliers

### DIFF
--- a/resources/js/Components/Crud/CrudFilterBar.vue
+++ b/resources/js/Components/Crud/CrudFilterBar.vue
@@ -1,0 +1,10 @@
+<template>
+    <section class="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-sm backdrop-blur">
+        <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
+            <slot />
+            <div class="md:ml-auto">
+                <slot name="actions" />
+            </div>
+        </div>
+    </section>
+</template>

--- a/resources/js/Components/Crud/CrudPageHeader.vue
+++ b/resources/js/Components/Crud/CrudPageHeader.vue
@@ -1,0 +1,40 @@
+<script setup>
+const props = defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    icon: {
+        type: Object,
+        default: null,
+    },
+    accent: {
+        type: String,
+        default: 'from-sky-500 to-indigo-500',
+    },
+});
+</script>
+
+<template>
+    <section class="relative overflow-hidden rounded-3xl bg-gradient-to-r text-white shadow-xl">
+        <div class="absolute inset-0 bg-gradient-to-r opacity-90" :class="accent"></div>
+        <div class="relative flex flex-col gap-6 px-8 py-10 md:flex-row md:items-center">
+            <div v-if="icon" class="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/20 backdrop-blur">
+                <component :is="icon" class="h-9 w-9 text-white" />
+            </div>
+            <div class="max-w-3xl">
+                <h1 class="text-3xl font-semibold tracking-tight md:text-4xl">{{ title }}</h1>
+                <p v-if="description" class="mt-3 text-base text-white/80 md:text-lg">
+                    {{ description }}
+                </p>
+            </div>
+            <div class="md:ml-auto">
+                <slot name="actions" />
+            </div>
+        </div>
+    </section>
+</template>

--- a/resources/js/Components/Crud/CrudStatCard.vue
+++ b/resources/js/Components/Crud/CrudStatCard.vue
@@ -1,0 +1,33 @@
+<script setup>
+const props = defineProps({
+    label: {
+        type: String,
+        required: true,
+    },
+    value: {
+        type: [String, Number],
+        required: true,
+    },
+    icon: {
+        type: Object,
+        default: null,
+    },
+    iconBackground: {
+        type: String,
+        default: 'bg-sky-500/10 text-sky-600',
+    },
+});
+</script>
+
+<template>
+    <div class="flex items-center gap-5 rounded-3xl border border-slate-200/60 bg-white/80 p-5 shadow-sm backdrop-blur">
+        <div v-if="icon" class="flex h-12 w-12 items-center justify-center rounded-2xl" :class="iconBackground">
+            <component :is="icon" class="h-6 w-6" />
+        </div>
+        <div>
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ label }}</p>
+            <p class="mt-2 text-2xl font-semibold text-slate-900">{{ value }}</p>
+            <slot name="description" />
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Crud/CrudTable.vue
+++ b/resources/js/Components/Crud/CrudTable.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-slate-200">
+                <thead class="bg-slate-50/80">
+                    <slot name="head" />
+                </thead>
+                <tbody class="divide-y divide-slate-200/70 bg-white/50">
+                    <slot />
+                </tbody>
+            </table>
+        </div>
+        <div v-if="$slots.footer" class="border-t border-slate-200/70 bg-slate-50/80 px-6 py-4">
+            <slot name="footer" />
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/SelectInput.vue
+++ b/resources/js/Components/SelectInput.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+const props = defineProps({
+    modelValue: {
+        type: [String, Number, Boolean, Object, Array, null],
+        default: '',
+    },
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const select = ref(null);
+
+onMounted(() => {
+    if (select.value?.hasAttribute('autofocus')) {
+        select.value.focus();
+    }
+});
+
+const updateValue = (event) => {
+    emit('update:modelValue', event.target.value);
+};
+</script>
+
+<template>
+    <select
+        ref="select"
+        class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+        :value="modelValue"
+        :disabled="disabled"
+        @input="updateValue"
+    >
+        <slot />
+    </select>
+</template>

--- a/resources/js/Components/TextareaInput.vue
+++ b/resources/js/Components/TextareaInput.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+const props = defineProps({
+    modelValue: {
+        type: [String, Number],
+        default: '',
+    },
+    rows: {
+        type: Number,
+        default: 3,
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const textarea = ref(null);
+
+onMounted(() => {
+    if (textarea.value?.hasAttribute('autofocus')) {
+        textarea.value.focus();
+    }
+});
+
+const updateValue = (event) => emit('update:modelValue', event.target.value);
+</script>
+
+<template>
+    <textarea
+        ref="textarea"
+        class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+        :rows="rows"
+        :value="modelValue"
+        @input="updateValue"
+    />
+</template>

--- a/resources/js/Pages/Employees/Create.vue
+++ b/resources/js/Pages/Employees/Create.vue
@@ -1,113 +1,25 @@
-<template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl text-blue-500 font-semibold mb-6">Crear Empleado</h2>
-
-                <form @submit.prevent="submitForm">
-                    <!-- Nombre -->
-                    <div class="mb-4">
-                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre</label>
-                        <input type="text" v-model="form.name" id="name" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Correo Electrónico -->
-                    <div class="mb-4">
-                        <label for="email" class="block text-sm font-medium text-gray-700">Correo Electrónico</label>
-                        <input type="email" v-model="form.email" id="email" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Teléfono -->
-                    <div class="mb-4">
-                        <label for="phone" class="block text-sm font-medium text-gray-700">Teléfono</label>
-                        <input type="text" v-model="form.phone" id="phone" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Dirección -->
-                    <div class="mb-4">
-                        <label for="address" class="block text-sm font-medium text-gray-700">Dirección</label>
-                        <input type="text" v-model="form.address" id="address" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Cargo -->
-                    <div class="mb-4">
-                        <label for="position" class="block text-sm font-medium text-gray-700">Cargo</label>
-                        <input type="text" v-model="form.job_title" id="position" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Departamento -->
-                    <div class="mb-4">
-                        <label for="department_id" class="block text-sm font-medium text-gray-700">Departamento</label>
-                        <select v-model="form.department_id" id="department_id" class="w-full p-2 mt-2 border border-gray-300 rounded-lg">
-                            <option v-for="department in departments" :key="department.id" :value="department.id">{{ department.name }}</option>
-                        </select>
-                    </div>
-
-                    <!-- Salario -->
-                    <div class="mb-4">
-                        <label for="salary" class="block text-sm font-medium text-gray-700">Salario</label>
-                        <input type="number" v-model="form.salary" id="salary" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Fecha de Contratación -->
-                    <div class="mb-4">
-                        <label for="hire_date" class="block text-sm font-medium text-gray-700">Fecha de Contratación</label>
-                        <input type="date" v-model="form.hire_date" id="hire_date" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Estado -->
-                    <div class="mb-4">
-                        <label for="status" class="block text-sm font-medium text-gray-700">Estado</label>
-                        <select v-model="form.status" id="status" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required>
-                            <option value="activo">Activo</option>
-                            <option value="inactivo">Inactivo</option>
-                        </select>
-                    </div>
-
-                    <!-- DNI -->
-                    <div class="mb-4">
-                        <label for="dni" class="block text-sm font-medium text-gray-700">DNI</label>
-                        <input type="text" v-model="form.dni" id="dni" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Número de Seguridad Social (NNSS) -->
-                    <div class="mb-4">
-                        <label for="nnss" class="block text-sm font-medium text-gray-700">Número de Seguridad Social</label>
-                        <input type="text" v-model="form.nnss" id="nnss" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- IBAN -->
-                    <div class="mb-4">
-                        <label for="iban" class="block text-sm font-medium text-gray-700">IBAN</label>
-                        <input type="text" v-model="form.iban" id="iban" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Fecha de Nacimiento -->
-                    <div class="mb-4">
-                        <label for="birth_date" class="block text-sm font-medium text-gray-700">Fecha de Nacimiento</label>
-                        <input type="date" v-model="form.birth_date" id="birth_date" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Submit -->
-                    <div class="mb-4">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded-lg">Crear Empleado</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </AppLayout>
-</template>
-
 <script setup>
-import { ref } from 'vue';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import { Inertia } from "@inertiajs/inertia";
+import { useForm } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import MenuRRHHIcon from '@/Components/Icons/MenuRRHHIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
 
 const props = defineProps({
-    departments: Array,
+    departments: {
+        type: Array,
+        default: () => [],
+    },
 });
 
-const form = ref({
+const form = useForm({
     name: '',
     email: '',
     phone: '',
@@ -123,11 +35,169 @@ const form = ref({
     birth_date: '',
 });
 
-const submitForm = () => {
-    Inertia.post(route('employees.store'), form.value);
+const submit = () => {
+    form.post(route('employees.store'));
 };
 </script>
 
-<style scoped>
-/* Estilos personalizados */
-</style>
+<template>
+    <AppLayout title="Nou empleat">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Incorpora un nou talent"
+                    description="Completa la fitxa de l'empleat perquè RRHH, finances i la resta d'equips comparteixin la mateixa informació."
+                    :icon="MenuRRHHIcon"
+                />
+
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Equips disponibles"
+                        :value="departments.length"
+                        :icon="MenuRRHHIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Estat inicial"
+                        :value="form.status === 'activo' ? 'Actiu' : 'Inactiu'"
+                        :icon="AddIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    />
+                    <CrudStatCard
+                        label="Data d'alta"
+                        :value="form.hire_date || '—'"
+                        :icon="MenuRRHHIcon"
+                        icon-background="bg-sky-500/10 text-sky-600"
+                    />
+                </div>
+
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Fitxa de l'empleat
+                    </template>
+                    <template #description>
+                        Agrupa les dades personals, contractuals i bancàries per agilitzar els processos interns.
+                    </template>
+
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Identificació i contacte</h3>
+                                <p class="mt-1 text-sm text-slate-500">Informació bàsica perquè l'equip pugui contactar amb l'empleat.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom complet" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" autocomplete="off" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="email" value="Correu electrònic" />
+                                    <TextInput id="email" v-model="form.email" type="email" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.email" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="phone" value="Telèfon" />
+                                    <TextInput id="phone" v-model="form.phone" type="tel" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.phone" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="address" value="Adreça" />
+                                    <TextInput id="address" v-model="form.address" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.address" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="dni" value="DNI" />
+                                    <TextInput id="dni" v-model="form.dni" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.dni" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="birth_date" value="Data de naixement" />
+                                    <TextInput id="birth_date" v-model="form.birth_date" type="date" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.birth_date" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Dades laborals</h3>
+                                <p class="mt-1 text-sm text-slate-500">Defineix el rol, l'equip i la situació contractual.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="job_title" value="Càrrec" />
+                                    <TextInput id="job_title" v-model="form.job_title" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.job_title" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="department_id" value="Departament" />
+                                    <SelectInput id="department_id" v-model="form.department_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona un departament</option>
+                                        <option v-for="department in departments" :key="department.id" :value="department.id">
+                                            {{ department.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.department_id" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="hire_date" value="Data d'incorporació" />
+                                    <TextInput id="hire_date" v-model="form.hire_date" type="date" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.hire_date" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="status" value="Estat" />
+                                    <SelectInput id="status" v-model="form.status" class="mt-2 block w-full">
+                                        <option value="activo">Actiu</option>
+                                        <option value="inactivo">Inactiu</option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.status" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="salary" value="Sou anual (€)" />
+                                    <TextInput id="salary" v-model="form.salary" type="number" min="0" step="0.01" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.salary" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Informació administrativa</h3>
+                                <p class="mt-1 text-sm text-slate-500">Necessària per a nòmines i tràmits oficials.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="nnss" value="Número de Seguretat Social" />
+                                    <TextInput id="nnss" v-model="form.nnss" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.nnss" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="iban" value="IBAN" />
+                                    <TextInput id="iban" v-model="form.iban" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.iban" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Crear empleat
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Employees/Edit.vue
+++ b/resources/js/Pages/Employees/Edit.vue
@@ -1,134 +1,210 @@
+<script setup>
+import { computed } from 'vue';
+import { useForm } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import MenuRRHHIcon from '@/Components/Icons/MenuRRHHIcon.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+
+const props = defineProps({
+    employee: {
+        type: Object,
+        required: true,
+    },
+    departments: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const form = useForm({
+    name: props.employee.name ?? '',
+    email: props.employee.email ?? '',
+    phone: props.employee.phone ?? '',
+    address: props.employee.address ?? '',
+    job_title: props.employee.job_title ?? '',
+    department_id: props.employee.department_id ?? '',
+    salary: props.employee.salary ?? '',
+    hire_date: props.employee.hire_date ?? '',
+    status: props.employee.status ?? 'activo',
+    dni: props.employee.dni ?? '',
+    nnss: props.employee.nnss ?? '',
+    iban: props.employee.iban ?? '',
+    birth_date: props.employee.birth_date ?? '',
+});
+
+const submit = () => {
+    form.put(route('employees.update', props.employee.id));
+};
+
+const departmentName = computed(
+    () => props.departments.find((department) => department.id === form.department_id)?.name ?? '—',
+);
+
+const statusLabel = computed(() => (form.status === 'activo' ? 'Actiu' : 'Inactiu'));
+</script>
+
 <template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl text-blue-500 font-semibold mb-6">Editar Empleado</h2>
+    <AppLayout title="Edita empleat">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Actualitza la fitxa de l'empleat"
+                    description="Revisa i corregeix les dades perquè nòmines, RRHH i finances treballin amb informació fiable."
+                    :icon="MenuRRHHIcon"
+                >
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" @click="submit">
+                            Guardar canvis
+                        </PrimaryButton>
+                    </template>
+                </CrudPageHeader>
 
-                <form @submit.prevent="submitForm">
-                    <!-- Nombre -->
-                    <div class="mb-4">
-                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre</label>
-                        <input type="text" v-model="form.name" id="name" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Departament"
+                        :value="departmentName"
+                        :icon="MenuRRHHIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Estat"
+                        :value="statusLabel"
+                        :icon="InfoIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    />
+                    <CrudStatCard
+                        label="Sou anual"
+                        :value="form.salary ? Number(form.salary).toFixed(2) + ' €' : '—'"
+                        :icon="MenuRRHHIcon"
+                        icon-background="bg-amber-500/10 text-amber-600"
+                    />
+                </div>
 
-                    <!-- Correo Electrónico -->
-                    <div class="mb-4">
-                        <label for="email" class="block text-sm font-medium text-gray-700">Correo Electrónico</label>
-                        <input type="email" v-model="form.email" id="email" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Fitxa de l'empleat
+                    </template>
+                    <template #description>
+                        Repassa les dades personals, laborals i administratives i confirma els canvis.
+                    </template>
 
-                    <!-- Teléfono -->
-                    <div class="mb-4">
-                        <label for="phone" class="block text-sm font-medium text-gray-700">Teléfono</label>
-                        <input type="text" v-model="form.phone" id="phone" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Identificació i contacte</h3>
+                                <p class="mt-1 text-sm text-slate-500">Confirma les dades bàsiques i els canals de comunicació.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom complet" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="email" value="Correu electrònic" />
+                                    <TextInput id="email" v-model="form.email" type="email" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.email" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="phone" value="Telèfon" />
+                                    <TextInput id="phone" v-model="form.phone" type="tel" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.phone" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="address" value="Adreça" />
+                                    <TextInput id="address" v-model="form.address" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.address" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="dni" value="DNI" />
+                                    <TextInput id="dni" v-model="form.dni" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.dni" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="birth_date" value="Data de naixement" />
+                                    <TextInput id="birth_date" v-model="form.birth_date" type="date" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.birth_date" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
 
-                    <!-- Dirección -->
-                    <div class="mb-4">
-                        <label for="address" class="block text-sm font-medium text-gray-700">Dirección</label>
-                        <input type="text" v-model="form.address" id="address" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Dades laborals</h3>
+                                <p class="mt-1 text-sm text-slate-500">Actualitza posició, equip i condicions.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="job_title" value="Càrrec" />
+                                    <TextInput id="job_title" v-model="form.job_title" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.job_title" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="department_id" value="Departament" />
+                                    <SelectInput id="department_id" v-model="form.department_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona un departament</option>
+                                        <option v-for="department in departments" :key="department.id" :value="department.id">
+                                            {{ department.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.department_id" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="hire_date" value="Data d'incorporació" />
+                                    <TextInput id="hire_date" v-model="form.hire_date" type="date" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.hire_date" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="status" value="Estat" />
+                                    <SelectInput id="status" v-model="form.status" class="mt-2 block w-full">
+                                        <option value="activo">Actiu</option>
+                                        <option value="inactivo">Inactiu</option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.status" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="salary" value="Sou anual (€)" />
+                                    <TextInput id="salary" v-model="form.salary" type="number" min="0" step="0.01" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.salary" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
 
-                    <!-- Cargo -->
-                    <div class="mb-4">
-                        <label for="position" class="block text-sm font-medium text-gray-700">Cargo</label>
-                        <input type="text" v-model="form.job_title" id="position" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Informació administrativa</h3>
+                                <p class="mt-1 text-sm text-slate-500">Garantitza la correcta gestió de nòmines i tràmits oficials.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="nnss" value="Número de Seguretat Social" />
+                                    <TextInput id="nnss" v-model="form.nnss" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.nnss" class="mt-2" />
+                                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="iban" value="IBAN" />
+                                    <TextInput id="iban" v-model="form.iban" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.iban" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+                    </template>
 
-                    <!-- Departamento -->
-                    <div class="mb-4">
-                        <label for="department_id" class="block text-sm font-medium text-gray-700">Departamento</label>
-                        <select v-model="form.department_id" id="department_id" class="w-full p-2 mt-2 border border-gray-300 rounded-lg">
-                            <option v-for="department in departments" :key="department.id" :value="department.id">{{ department.name }}</option>
-                        </select>
-                    </div>
-
-                    <!-- Salario -->
-                    <div class="mb-4">
-                        <label for="salary" class="block text-sm font-medium text-gray-700">Salario</label>
-                        <input type="number" v-model="form.salary" id="salary" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Fecha de Contratación -->
-                    <div class="mb-4">
-                        <label for="hire_date" class="block text-sm font-medium text-gray-700">Fecha de Contratación</label>
-                        <input type="date" v-model="form.hire_date" id="hire_date" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required/>
-                    </div>
-
-                    <!-- Estado -->
-                    <div class="mb-4">
-                        <label for="status" class="block text-sm font-medium text-gray-700">Estado</label>
-                        <select v-model="form.status" id="status" class="w-full p-2 mt-2 border border-gray-300 rounded-lg" required>
-                            <option value="activo">Activo</option>
-                            <option value="inactivo">Inactivo</option>
-                        </select>
-                    </div>
-
-                    <!-- DNI -->
-                    <div class="mb-4">
-                        <label for="dni" class="block text-sm font-medium text-gray-700">DNI</label>
-                        <input type="text" v-model="form.dni" id="dni" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Número de Seguridad Social -->
-                    <div class="mb-4">
-                        <label for="nnss" class="block text-sm font-medium text-gray-700">Número de Seguridad Social</label>
-                        <input type="text" v-model="form.nnss" id="nnss" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- IBAN -->
-                    <div class="mb-4">
-                        <label for="iban" class="block text-sm font-medium text-gray-700">IBAN</label>
-                        <input type="text" v-model="form.iban" id="iban" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Fecha de Nacimiento -->
-                    <div class="mb-4">
-                        <label for="birth_date" class="block text-sm font-medium text-gray-700">Fecha de Nacimiento</label>
-                        <input type="date" v-model="form.birth_date" id="birth_date" class="w-full p-2 mt-2 border border-gray-300 rounded-lg"/>
-                    </div>
-
-                    <!-- Submit -->
-                    <div class="mb-4">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded-lg">Actualizar Empleado</button>
-                    </div>
-                </form>
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Guardar canvis
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
             </div>
         </div>
     </AppLayout>
 </template>
-
-<script setup>
-import { ref } from 'vue';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import { Inertia } from "@inertiajs/inertia";
-
-const props = defineProps({
-    employee: Object,
-    departments: Array,
-});
-
-const form = ref({
-    name: props.employee.name,
-    email: props.employee.email,
-    phone: props.employee.phone,
-    address: props.employee.address,
-    job_title: props.employee.job_title,
-    department_id: props.employee.department_id,
-    salary: props.employee.salary,
-    hire_date: props.employee.hire_date,
-    status: props.employee.status,
-    dni: props.employee.dni,
-    nnss: props.employee.nnss,
-    iban: props.employee.iban,
-    birth_date: props.employee.birth_date,
-});
-
-const submitForm = () => {
-    Inertia.put(route('employees.update', props.employee.id), form.value);
-};
-</script>
-
-<style scoped>
-/* Estilos personalizados */
-</style>

--- a/resources/js/Pages/Employees/Index.vue
+++ b/resources/js/Pages/Employees/Index.vue
@@ -1,74 +1,205 @@
-<template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Empleados</h2>
-                        <p class="text-blue-300 text-2xl">{{ totalEmployees }}</p>
-                    </div>
-                </div>
-            </div>
+<script setup>
+import { computed, reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import MenuRRHHIcon from '@/Components/Icons/MenuRRHHIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
 
-            <!-- Tabla de Empleados -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('employees.create')" class="bg-blue-500 hover:text-gray-50 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Agregar nuevo Empleado
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-3"/>
-                </NavLink>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Puesto</th>
-                        <th class="px-4 py-2 text-left">Fecha de Ingreso</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="employee in filteredEmployees" :key="employee.id" class="border-t">
-                        <td class="px-4 py-2">{{ employee.name }}</td>
-                        <td class="px-4 py-2">{{ employee.job_title }}</td>
-                        <td class="px-4 py-2">{{ employee.hire_date }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('employees.show', employee.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <NavLink :href="route('employees.edit', employee.id)" class="text-yellow-500">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteEmployee(employee.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
+const props = defineProps({
+    employees: {
+        type: Array,
+        default: () => [],
+    },
+    departments: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const filters = reactive({
+    search: '',
+    department_id: '',
+    status: '',
+});
+
+const filteredEmployees = computed(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    return props.employees.filter((employee) => {
+        const matchesSearch =
+            !searchTerm ||
+            employee.name?.toLowerCase().includes(searchTerm) ||
+            employee.job_title?.toLowerCase().includes(searchTerm);
+        const matchesDepartment = !filters.department_id || Number(filters.department_id) === Number(employee.department_id);
+        const matchesStatus = !filters.status || employee.status === filters.status;
+
+        return matchesSearch && matchesDepartment && matchesStatus;
+    });
+});
+
+const totalEmployees = computed(() => filteredEmployees.value.length);
+const activeEmployees = computed(() => filteredEmployees.value.filter((employee) => employee.status === 'activo').length);
+const inactiveEmployees = computed(() => filteredEmployees.value.filter((employee) => employee.status === 'inactivo').length);
+
+const clearFilters = () => {
+    filters.search = '';
+    filters.department_id = '';
+    filters.status = '';
+};
+
+const deleteEmployee = (employeeId) => {
+    if (confirm('Segur que vols eliminar aquest empleat?')) {
+        Inertia.delete(route('employees.destroy', employeeId));
+    }
+};
+
+const departmentName = (departmentId) =>
+    props.departments.find((department) => Number(department.id) === Number(departmentId))?.name ?? '—';
+</script>
+
+<template>
+    <AppLayout title="Equip humà">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Gestió d'empleats"
+                    description="Filtra i administra el talent de l'organització amb una vista clara i coherent."
+                    :icon="MenuRRHHIcon"
+                >
+                    <template #actions>
+                        <Link
+                            :href="route('employees.create')"
+                            class="inline-flex items-center gap-2 rounded-full bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200 transition hover:bg-sky-500"
+                        >
+                            <AddIcon class="h-5 w-5" />
+                            Nou empleat
+                        </Link>
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Total plantilla"
+                        :value="totalEmployees"
+                        :icon="MenuRRHHIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Actius"
+                        :value="activeEmployees"
+                        :icon="AddIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    />
+                    <CrudStatCard
+                        label="Inactius"
+                        :value="inactiveEmployees"
+                        :icon="InfoIcon"
+                        icon-background="bg-amber-500/10 text-amber-600"
+                    />
+                </div>
+
+                <CrudFilterBar>
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="employee-search" value="Cerca" />
+                        <TextInput
+                            id="employee-search"
+                            v-model="filters.search"
+                            type="search"
+                            class="block w-full"
+                            placeholder="Nom o càrrec"
+                        />
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="employee-department" value="Departament" />
+                        <SelectInput id="employee-department" v-model="filters.department_id" class="block w-full">
+                            <option value="">Tots</option>
+                            <option v-for="department in departments" :key="department.id" :value="department.id">
+                                {{ department.name }}
+                            </option>
+                        </SelectInput>
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="employee-status" value="Estat" />
+                        <SelectInput id="employee-status" v-model="filters.status" class="block w-full">
+                            <option value="">Tots</option>
+                            <option value="activo">Actiu</option>
+                            <option value="inactivo">Inactiu</option>
+                        </SelectInput>
+                    </div>
+
+                    <template #actions>
+                        <SecondaryButton type="button" @click="clearFilters">
+                            Netejar filtres
+                        </SecondaryButton>
+                    </template>
+                </CrudFilterBar>
+
+                <CrudTable>
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Nom</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Càrrec</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Departament</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Estat</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Accions</th>
+                        </tr>
+                    </template>
+
+                    <tr v-for="employee in filteredEmployees" :key="employee.id" class="hover:bg-slate-50/60">
+                        <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ employee.name }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ employee.job_title }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ departmentName(employee.department_id) }}</td>
+                        <td class="px-6 py-4 text-sm font-semibold" :class="employee.status === 'activo' ? 'text-emerald-600' : 'text-amber-600'">
+                            {{ employee.status === 'activo' ? 'Actiu' : 'Inactiu' }}
+                        </td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-2">
+                                <Link
+                                    :href="route('employees.show', employee.id)"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-sky-500/10 text-sky-600 transition hover:bg-sky-500/20"
+                                >
+                                    <InfoIcon class="h-5 w-5" />
+                                </Link>
+                                <Link
+                                    :href="route('employees.edit', employee.id)"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                >
+                                    <EditIcon class="h-5 w-5" />
+                                </Link>
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    @click="deleteEmployee(employee.id)"
+                                >
+                                    <DeleteIcon class="h-5 w-5" />
+                                </button>
+                            </div>
                         </td>
                     </tr>
-                    </tbody>
-                </table>
+
+                    <template v-if="!filteredEmployees.length">
+                        <tr>
+                            <td colspan="5" class="px-6 py-10 text-center text-sm text-slate-500">
+                                Cap empleat compleix els filtres actuals.
+                            </td>
+                        </tr>
+                    </template>
+                </CrudTable>
             </div>
         </div>
     </AppLayout>
 </template>
-
-<script setup>
-import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
-import { computed, reactive } from 'vue';
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-
-const props = defineProps({
-    employees: Array,
-});
-
-const filteredEmployees = reactive(props.employees);
-const totalEmployees = computed(() => filteredEmployees.length);
-
-const deleteEmployee = (employeeId) => {
-    if (confirm("¿Estás seguro de que deseas eliminar este empleado?")) {
-        Inertia.delete(route('employees.destroy', employeeId));
-    }
-};
-</script>

--- a/resources/js/Pages/Products/Create.vue
+++ b/resources/js/Pages/Products/Create.vue
@@ -1,98 +1,213 @@
 <script setup>
-import { reactive } from 'vue';
+import { computed } from 'vue';
+import { useForm } from '@inertiajs/inertia-vue3';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
+import AddProductIcon from '@/Components/Icons/AddProductIcon.vue';
 
 const props = defineProps({
-    categories: Array,
-    suppliers: Array,
-    // Lista de proveedores
-});
-
-const data = reactive({
-    form: {
-        name: '',
-        category_id: '',
-        description: '',
-        price: '',
-        cost_price: '', // Nuevo campo
-        stock: '',
-        supplier_id: '', // Nuevo campo
-        is_stackable: false, // Nuevo campo
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+    suppliers: {
+        type: Array,
+        default: () => [],
     },
 });
 
-const submitForm = () => {
-    Inertia.post(route('products.store'), data.form, {
+const form = useForm({
+    name: '',
+    category_id: '',
+    supplier_id: '',
+    description: '',
+    price: '',
+    cost_price: '',
+    stock: '',
+    is_stackable: false,
+});
+
+const submit = () => {
+    form.post(route('products.store'), {
         onSuccess: () => {
+            form.reset();
             Inertia.visit(route('dashboard.products'));
         },
     });
 };
+
+const isInventoryManaged = computed(() => Boolean(form.is_stackable));
 </script>
 
 <template>
-    <AppLayout>
-        <div class="p-5 bg-gray-50 min-h-screen mx-auto">
-            <h1 class="text-3xl text-blue-700 font-bold mb-8">Create Product</h1>
-            <form @submit.prevent="submitForm">
-                <!-- Campos del formulario -->
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="name">Product Name</label>
-                    <input v-model="data.form.name" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="name" type="text" placeholder="Enter product name">
-                </div>
+    <AppLayout title="Nou producte">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Nou producte"
+                    description="Defineix els atributs comercials i logístics perquè el producte estigui disponible a tots els canals."
+                    :icon="MenuProductIcon"
+                />
 
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="description">Description</label>
-                    <textarea v-model="data.form.description" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="description" placeholder="Enter product description"></textarea>
-                </div>
-
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="category">Category</label>
-                    <select v-model="data.form.category_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="category">
-                        <option value="">Select a category</option>
-                        <template v-for="category in categories">
-                            <option :value="category.id">{{ category.name }}</option>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Categories disponibles"
+                        :value="categories.length"
+                        :icon="MenuProductIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Proveïdors actius"
+                        :value="suppliers.length"
+                        :icon="AddProductIcon"
+                        icon-background="bg-sky-500/10 text-sky-600"
+                    >
+                        <template #description>
+                            <p class="text-xs text-slate-500">Selecciona un proveïdor per agilitzar les comandes.</p>
                         </template>
-                    </select>
-                </div>
-
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="supplier">Supplier</label>
-                    <select v-model="data.form.supplier_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="supplier">
-                        <option value="">Select a supplier</option>
-                        <template v-for="supplier in suppliers">
-                            <option :value="supplier.id">{{ supplier.name }}</option>
+                    </CrudStatCard>
+                    <CrudStatCard
+                        label="Gestió d'estoc"
+                        :value="isInventoryManaged ? 'Activada' : 'Opcional'"
+                        :icon="MenuProductIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    >
+                        <template #description>
+                            <p class="text-xs text-slate-500">Marca l'opció «Controlar estoc» si cal fer seguiment.</p>
                         </template>
-                    </select>
+                    </CrudStatCard>
                 </div>
 
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="price">Price</label>
-                    <input v-model="data.form.price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="price" type="number" step="0.01" placeholder="Enter price">
-                </div>
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Fitxa del producte
+                    </template>
+                    <template #description>
+                        Completa la informació comercial i d'inventari per sincronitzar el catàleg.
+                    </template>
 
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="cost_price">Base Price</label>
-                    <input v-model="data.form.cost_price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="cost_price" type="number" step="0.01" placeholder="Enter base price">
-                </div>
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="cost_price">Es stockable?</label>
-                    <input type="checkbox" v-model="data.form.is_stackable" class="shadow appearance-none border rounded  py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="is_stackable" step="0.01" placeholder="Enter if is stackable">
-                </div>
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Informació general</h3>
+                                <p class="mt-1 text-sm text-slate-500">Nom, categorització i descripció visibles a tots els portals.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" autocomplete="off" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
 
-                <div class="mb-4" v-if="data.form.is_stackable">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="stock">Stock</label>
-                    <input v-model="data.form.stock" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="stock" type="number" placeholder="Enter stock quantity">
-                </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="category" value="Categoria" />
+                                    <SelectInput id="category" v-model="form.category_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona una categoria</option>
+                                        <option v-for="category in categories" :key="category.id" :value="category.id">
+                                            {{ category.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.category_id" class="mt-2" />
+                                </div>
 
-                <div class="flex items-center justify-between">
-                    <button type="submit" class="bg-blue-900 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                        <SaveIcon class="w-5 h-5 fill-gray-50" />
-                    </button>
-                </div>
-            </form>
+                                <div class="col-span-6">
+                                    <InputLabel for="description" value="Descripció" />
+                                    <TextareaInput
+                                        id="description"
+                                        v-model="form.description"
+                                        rows="4"
+                                        class="mt-2 block w-full"
+                                        placeholder="Explica els beneficis i el posicionament del producte"
+                                    />
+                                    <InputError :message="form.errors.description" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="supplier" value="Proveïdor" />
+                                    <SelectInput id="supplier" v-model="form.supplier_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona un proveïdor</option>
+                                        <option v-for="supplier in suppliers" :key="supplier.id" :value="supplier.id">
+                                            {{ supplier.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.supplier_id" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div class="flex items-start justify-between gap-6">
+                                <div>
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Preus i inventari</h3>
+                                    <p class="mt-1 text-sm text-slate-500">Controla marges i disponibilitat al magatzem.</p>
+                                </div>
+                                <label class="flex items-center gap-3 text-sm font-medium text-slate-600">
+                                    <Checkbox v-model:checked="form.is_stackable" />
+                                    <span>Controlar estoc manualment</span>
+                                </label>
+                            </div>
+
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="cost_price" value="Cost" />
+                                    <TextInput
+                                        id="cost_price"
+                                        v-model="form.cost_price"
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        class="mt-2 block w-full"
+                                    />
+                                    <InputError :message="form.errors.cost_price" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="price" value="Preu de venda" />
+                                    <TextInput
+                                        id="price"
+                                        v-model="form.price"
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        class="mt-2 block w-full"
+                                    />
+                                    <InputError :message="form.errors.price" class="mt-2" />
+                                </div>
+
+                                <div v-if="isInventoryManaged" class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="stock" value="Unitats disponibles" />
+                                    <TextInput
+                                        id="stock"
+                                        v-model="form.stock"
+                                        type="number"
+                                        min="0"
+                                        step="1"
+                                        class="mt-2 block w-full"
+                                    />
+                                    <InputError :message="form.errors.stock" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Desar producte
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
+            </div>
         </div>
     </AppLayout>
 </template>

--- a/resources/js/Pages/Products/Edit.vue
+++ b/resources/js/Pages/Products/Edit.vue
@@ -1,92 +1,184 @@
-<template>
-    <AppLayout>
-        <div class="p-5 w-3/4 bg-white min-h-screen mx-auto">
-            <h1 class="text-3xl font-bold mb-8">Edit Product</h1>
-            <form @submit.prevent="submitForm">
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="name">Product Name</label>
-                    <input v-model="form.name" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="name" type="text" placeholder="Enter product name">
-                </div>
-
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="description">Description</label>
-                    <textarea v-model="form.description" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="description" placeholder="Enter product description"></textarea>
-                </div>
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="supplier">Supplier</label>
-                    <select v-model="form.supplier_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="supplier">
-                        <option value="">Select a supplier</option>
-                        <option v-for="supplier in suppliers" :key="supplier.id" :value="supplier.id">{{ supplier.name }}</option>
-                    </select>
-                </div>
-
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="category">Category</label>
-                    <select v-model="form.category_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="category">
-                        <option value="">Select a category</option>
-                        <option v-for="category in categories" :key="category.id" :value="category.id">{{ category.name }}</option>
-                    </select>
-                </div>
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="cost_price">Cost Price</label>
-                    <input v-model="form.cost_price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="cost_price" type="number" step="0.01" placeholder="Enter cost price">
-                </div>
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="price">Price</label>
-                    <input v-model="form.price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="price" type="number" step="0.01" placeholder="Enter price">
-                </div>
-                <div class="mb-4">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="cost_price">Es Stockable?</label>
-                    <input v-model="form.is_stackable" class="shadow appearance-none border rounded  py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="cost_price" type="checkbox" step="0.01" placeholder="Enter if is stackable">
-                </div>
-
-                <div class="mb-4" v-if="form.is_stackable">
-                    <label class="block text-gray-700 text-sm font-bold mb-2" for="stock">Stock</label>
-                    <input v-model="form.stock" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="stock" type="number" placeholder="Enter stock quantity">
-                </div>
-
-                <div class="flex items-center justify-between">
-                    <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                        Update Product
-                    </button>
-                </div>
-            </form>
-        </div>
-    </AppLayout>
-</template>
-
 <script setup>
-import { ref } from 'vue';
+import { computed } from 'vue';
 import { useForm } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Inertia } from '@inertiajs/inertia';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
+import AddProductIcon from '@/Components/Icons/AddProductIcon.vue';
 
 const props = defineProps({
-    categories: Array,
     product: {
         type: Object,
         required: true,
     },
-    suppliers: Array,
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+    suppliers: {
+        type: Array,
+        default: () => [],
+    },
 });
 
 const form = useForm({
-    company_id: props.product.company_id,
-    name: props.product.name,
-    category_id: props.product.category_id,
-    description: props.product.description,
-    cost_price: props.product.cost_price,
-    supplier_id: props.product.supplier_id,
-    price: props.product.price,
-    stock: props.product.stock,
-    is_stackable: props.product.is_stackable,
+    name: props.product.name ?? '',
+    category_id: props.product.category_id ?? '',
+    supplier_id: props.product.supplier_id ?? '',
+    description: props.product.description ?? '',
+    price: props.product.price ?? '',
+    cost_price: props.product.cost_price ?? '',
+    stock: props.product.stock ?? '',
+    is_stackable: Boolean(props.product.is_stackable),
 });
 
-const submitForm = () => {
-    Inertia.put(route('products.update', props.product.id), form);
+const submit = () => {
+    form.put(route('products.update', props.product.id));
 };
+
+const isInventoryManaged = computed(() => Boolean(form.is_stackable));
+const formattedPrice = computed(() => (form.price ? Number(form.price).toFixed(2) : '—'));
+const formattedStock = computed(() => (isInventoryManaged.value ? form.stock || 0 : 'No controlat'));
 </script>
 
-<style scoped>
-/* Tailwind CSS is used, no additional styles needed */
-</style>
+<template>
+    <AppLayout title="Edita producte">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Actualitza el producte"
+                    description="Revisa els detalls comercials, ajusta marges i sincronitza l'inventari amb tota la companyia."
+                    :icon="MenuProductIcon"
+                >
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" @click="submit">
+                            Actualitzar
+                        </PrimaryButton>
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Categoria assignada"
+                        :value="categories.find((category) => category.id === form.category_id)?.name ?? 'Sense categoria'"
+                        :icon="MenuProductIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Preu actual"
+                        :value="formattedPrice"
+                        :icon="AddProductIcon"
+                        icon-background="bg-amber-500/10 text-amber-600"
+                    />
+                    <CrudStatCard
+                        label="Unitats disponibles"
+                        :value="formattedStock"
+                        :icon="MenuProductIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    />
+                </div>
+
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Dades del producte
+                    </template>
+                    <template #description>
+                        Mantén actualitzada la informació essencial perquè tots els equips treballin amb la mateixa versió.
+                    </template>
+
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div>
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Informació comercial</h3>
+                                <p class="mt-1 text-sm text-slate-500">Nom, categoria, proveïdor i descripció pública.</p>
+                            </div>
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="category" value="Categoria" />
+                                    <SelectInput id="category" v-model="form.category_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona una categoria</option>
+                                        <option v-for="category in categories" :key="category.id" :value="category.id">
+                                            {{ category.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.category_id" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6">
+                                    <InputLabel for="description" value="Descripció" />
+                                    <TextareaInput id="description" v-model="form.description" rows="4" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.description" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="supplier" value="Proveïdor" />
+                                    <SelectInput id="supplier" v-model="form.supplier_id" class="mt-2 block w-full">
+                                        <option value="">Selecciona un proveïdor</option>
+                                        <option v-for="supplier in suppliers" :key="supplier.id" :value="supplier.id">
+                                            {{ supplier.name }}
+                                        </option>
+                                    </SelectInput>
+                                    <InputError :message="form.errors.supplier_id" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div class="flex items-start justify-between gap-6">
+                                <div>
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Preus i inventari</h3>
+                                    <p class="mt-1 text-sm text-slate-500">Actualitza el marge i la disponibilitat d'estoc.</p>
+                                </div>
+                                <label class="flex items-center gap-3 text-sm font-medium text-slate-600">
+                                    <Checkbox v-model:checked="form.is_stackable" />
+                                    <span>Controlar estoc manualment</span>
+                                </label>
+                            </div>
+
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="cost_price" value="Cost" />
+                                    <TextInput id="cost_price" v-model="form.cost_price" type="number" min="0" step="0.01" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.cost_price" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="price" value="Preu de venda" />
+                                    <TextInput id="price" v-model="form.price" type="number" min="0" step="0.01" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.price" class="mt-2" />
+                                </div>
+
+                                <div v-if="isInventoryManaged" class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="stock" value="Unitats disponibles" />
+                                    <TextInput id="stock" v-model="form.stock" type="number" min="0" step="1" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.stock" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Guardar canvis
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Suppliers/Create.vue
+++ b/resources/js/Pages/Suppliers/Create.vue
@@ -1,54 +1,99 @@
-<template>
-    <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Create Supplier</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" class="w-full border px-4 py-2" type="text" placeholder="Supplier Name" />
-                <p v-if="errors.name" class="text-red-500 text-sm">{{ errors.name }}</p>
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-700">Email</label>
-                <input v-model="form.email" class="w-full border px-4 py-2" type="email" placeholder="Email" />
-                <p v-if="errors.email" class="text-red-500 text-sm">{{ errors.email }}</p>
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-700">Phone</label>
-                <input v-model="form.phone" class="w-full border px-4 py-2" type="text" placeholder="Phone" />
-                <p v-if="errors.phone" class="text-red-500 text-sm">{{ errors.phone }}</p>
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-700">Address</label>
-                <input v-model="form.address" class="w-full border px-4 py-2" type="text" placeholder="Address" />
-                <p v-if="errors.address" class="text-red-500 text-sm">{{ errors.address }}</p>
-            </div>
-
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Create</button>
-        </form>
-    </div>
-    </AppLayout>
-</template>
-
 <script setup>
-import { reactive } from 'vue';
-import { useForm } from '@inertiajs/vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import {Inertia} from "@inertiajs/inertia";
+import { useForm } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import MenuBillingIcon from '@/Components/Icons/MenuBillingIcon.vue';
+import MenuInventoryIcon from '@/Components/Icons/MenuInventoryIcon.vue';
 
-const form = reactive({
+const form = useForm({
     name: '',
     email: '',
     phone: '',
     address: '',
 });
 
-const { errors } = useForm(form);
-
-function submit() {
-    Inertia.post(route('suppliers.store'), form);
-}
+const submit = () => {
+    form.post(route('suppliers.store'));
+};
 </script>
+
+<template>
+    <AppLayout title="Nou proveïdor">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Afegeix un nou proveïdor"
+                    description="Centralitza la informació de contacte i facturació per garantir una relació fluïda amb la cadena de subministrament."
+                    :icon="MenuBillingIcon"
+                />
+
+                <div class="grid gap-6 md:grid-cols-2">
+                    <CrudStatCard
+                        label="Canals de contacte"
+                        :value="form.email || form.phone ? 'Configurats' : 'Pendents'"
+                        :icon="MenuInventoryIcon"
+                        icon-background="bg-sky-500/10 text-sky-600"
+                    />
+                    <CrudStatCard
+                        label="Ubicació"
+                        :value="form.address || 'Sense adreça'"
+                        :icon="MenuBillingIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                </div>
+
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Fitxa del proveïdor
+                    </template>
+                    <template #description>
+                        Defineix les dades principals per sincronitzar compres, inventari i facturació.
+                    </template>
+
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom comercial" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="email" value="Correu electrònic" />
+                                    <TextInput id="email" v-model="form.email" type="email" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.email" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="phone" value="Telèfon" />
+                                    <TextInput id="phone" v-model="form.phone" type="tel" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.phone" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="address" value="Adreça fiscal" />
+                                    <TextInput id="address" v-model="form.address" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.address" class="mt-2" />
+                                </div>
+
+                            </div>
+                        </div>
+                    </template>
+
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Crear proveïdor
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Suppliers/Edit.vue
+++ b/resources/js/Pages/Suppliers/Edit.vue
@@ -1,59 +1,111 @@
+<script setup>
+import { useForm } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import MenuBillingIcon from '@/Components/Icons/MenuBillingIcon.vue';
+import MenuInventoryIcon from '@/Components/Icons/MenuInventoryIcon.vue';
+
+const props = defineProps({
+    supplier: {
+        type: Object,
+        required: true,
+    },
+});
+
+const form = useForm({
+    name: props.supplier.name ?? '',
+    email: props.supplier.email ?? '',
+    phone: props.supplier.phone ?? '',
+    address: props.supplier.address ?? '',
+});
+
+const submit = () => {
+    form.put(route('suppliers.update', props.supplier.id));
+};
+</script>
+
 <template>
-    <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Edit Supplier</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" class="w-full border px-4 py-2" type="text" />
-                <p v-if="errors.name" class="text-red-500 text-sm">{{ errors.name }}</p>
-            </div>
+    <AppLayout title="Edita proveïdor">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Actualitza el proveïdor"
+                    description="Mantén al dia la informació de contacte per assegurar un flux de subministrament estable."
+                    :icon="MenuBillingIcon"
+                >
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing" @click="submit">
+                            Guardar canvis
+                        </PrimaryButton>
+                    </template>
+                </CrudPageHeader>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Email</label>
-                <input v-model="form.email" class="w-full border px-4 py-2" type="email" />
-                <p v-if="errors.email" class="text-red-500 text-sm">{{ errors.email }}</p>
-            </div>
+                <div class="grid gap-6 md:grid-cols-2">
+                    <CrudStatCard
+                        label="Correu"
+                        :value="form.email || '—'"
+                        :icon="MenuInventoryIcon"
+                        icon-background="bg-sky-500/10 text-sky-600"
+                    />
+                    <CrudStatCard
+                        label="Telèfon"
+                        :value="form.phone || '—'"
+                        :icon="MenuBillingIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                </div>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Phone</label>
-                <input v-model="form.phone" class="w-full border px-4 py-2" type="text" />
-                <p v-if="errors.phone" class="text-red-500 text-sm">{{ errors.phone }}</p>
-            </div>
+                <FormSection @submitted="submit">
+                    <template #title>
+                        Fitxa del proveïdor
+                    </template>
+                    <template #description>
+                        Revisa les dades perquè compres, finances i operacions treballin amb informació fiable.
+                    </template>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Address</label>
-                <input v-model="form.address" class="w-full border px-4 py-2" type="text" />
-                <p v-if="errors.address" class="text-red-500 text-sm">{{ errors.address }}</p>
-            </div>
+                    <template #form>
+                        <div class="col-span-6 space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
+                            <div class="grid grid-cols-6 gap-6">
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="name" value="Nom comercial" />
+                                    <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.name" class="mt-2" />
+                                </div>
 
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Update</button>
-        </form>
-    </div>
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="email" value="Correu electrònic" />
+                                    <TextInput id="email" v-model="form.email" type="email" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.email" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="phone" value="Telèfon" />
+                                    <TextInput id="phone" v-model="form.phone" type="tel" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.phone" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="address" value="Adreça fiscal" />
+                                    <TextInput id="address" v-model="form.address" type="text" class="mt-2 block w-full" />
+                                    <InputError :message="form.errors.address" class="mt-2" />
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template #actions>
+                        <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                            Guardar canvis
+                        </PrimaryButton>
+                    </template>
+                </FormSection>
+            </div>
+        </div>
     </AppLayout>
 </template>
-
-<script setup>
-import { reactive } from 'vue';
-import { useForm } from '@inertiajs/vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import {Inertia} from "@inertiajs/inertia";
-import {route} from "ziggy-js";
-const props = defineProps({
-    supplier: Object,
-});
-
-const form = reactive({
-    id: props.supplier.id,
-    name: props.supplier.name,
-    email: props.supplier.email,
-    phone: props.supplier.phone,
-    address: props.supplier.address,
-});
-
-const { errors } = useForm(form);
-
-function submit() {
-    Inertia.put(route('suppliers.update',props.supplier.id), form);
-}
-</script>

--- a/resources/js/Pages/Suppliers/Index.vue
+++ b/resources/js/Pages/Suppliers/Index.vue
@@ -1,87 +1,185 @@
-<template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Proveedores</h2>
-                        <p class="text-blue-300 text-2xl">{{ totalSuppliers }}</p>
-                    </div>
-                </div>
-            </div>
+<script setup>
+import { computed, reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/inertia-vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import MenuBillingIcon from '@/Components/Icons/MenuBillingIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
 
-            <!-- Tabla de proveedores -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <!-- Botón para crear un nuevo proveedor -->
-                <NavLink :href="route('suppliers.create')" class="bg-blue-500 hover:text-gray-50 text-white font-bold py-2 px-4 rounded mb-4 inline-flex items-center">
-                    Agregar nuevo Proveedor
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-3"/>
-                </NavLink>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Email</th>
-                        <th class="px-4 py-2 text-left">Teléfono</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="supplier in suppliers" :key="supplier.id" class="border-t">
-                        <td class="px-4 py-2">{{ supplier.name }}</td>
-                        <td class="px-4 py-2">{{ supplier.email || 'N/A' }}</td>
-                        <td class="px-4 py-2">{{ supplier.phone || 'N/A' }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('suppliers.show', supplier.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <NavLink :href="route('suppliers.edit', supplier.id)" class="text-yellow-500">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteSupplier(supplier.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
+const props = defineProps({
+    suppliers: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const filters = reactive({
+    search: '',
+    contact: '',
+});
+
+const filteredSuppliers = computed(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    return props.suppliers.filter((supplier) => {
+        const matchesSearch =
+            !searchTerm ||
+            supplier.name?.toLowerCase().includes(searchTerm) ||
+            supplier.email?.toLowerCase().includes(searchTerm);
+
+        const matchesContact =
+            !filters.contact ||
+            (filters.contact === 'with_email' && Boolean(supplier.email)) ||
+            (filters.contact === 'without_email' && !supplier.email);
+
+        return matchesSearch && matchesContact;
+    });
+});
+
+const totalSuppliers = computed(() => filteredSuppliers.value.length);
+const suppliersWithEmail = computed(() => filteredSuppliers.value.filter((supplier) => Boolean(supplier.email)).length);
+const suppliersWithoutPhone = computed(() => filteredSuppliers.value.filter((supplier) => !supplier.phone).length);
+
+const clearFilters = () => {
+    filters.search = '';
+    filters.contact = '';
+};
+
+const deleteSupplier = (supplierId) => {
+    if (confirm('Segur que vols eliminar aquest proveïdor?')) {
+        Inertia.delete(route('suppliers.delete', supplierId));
+    }
+};
+</script>
+
+<template>
+    <AppLayout title="Proveïdors">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Xarxa de proveïdors"
+                    description="Mantén la relació comercial alineada amb la resta de departaments i detecta ràpidament punts de millora."
+                    :icon="MenuBillingIcon"
+                >
+                    <template #actions>
+                        <Link
+                            :href="route('suppliers.create')"
+                            class="inline-flex items-center gap-2 rounded-full bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200 transition hover:bg-sky-500"
+                        >
+                            <AddIcon class="h-5 w-5" />
+                            Nou proveïdor
+                        </Link>
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard
+                        label="Total proveïdors"
+                        :value="totalSuppliers"
+                        :icon="MenuBillingIcon"
+                        icon-background="bg-indigo-500/10 text-indigo-600"
+                    />
+                    <CrudStatCard
+                        label="Amb correu"
+                        :value="suppliersWithEmail"
+                        :icon="AddIcon"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    />
+                    <CrudStatCard
+                        label="Sense telèfon"
+                        :value="suppliersWithoutPhone"
+                        :icon="InfoIcon"
+                        icon-background="bg-amber-500/10 text-amber-600"
+                    />
+                </div>
+
+                <CrudFilterBar>
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="supplier-search" value="Cerca" />
+                        <TextInput
+                            id="supplier-search"
+                            v-model="filters.search"
+                            type="search"
+                            class="block w-full"
+                            placeholder="Nom o correu"
+                        />
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="supplier-contact" value="Disponibilitat de contacte" />
+                        <SelectInput id="supplier-contact" v-model="filters.contact" class="block w-full">
+                            <option value="">Tots</option>
+                            <option value="with_email">Amb correu</option>
+                            <option value="without_email">Sense correu</option>
+                        </SelectInput>
+                    </div>
+
+                    <template #actions>
+                        <SecondaryButton type="button" @click="clearFilters">
+                            Netejar filtres
+                        </SecondaryButton>
+                    </template>
+                </CrudFilterBar>
+
+                <CrudTable>
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Nom</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Correu</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Telèfon</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Accions</th>
+                        </tr>
+                    </template>
+
+                    <tr v-for="supplier in filteredSuppliers" :key="supplier.id" class="hover:bg-slate-50/60">
+                        <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ supplier.name }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.email || '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.phone || '—' }}</td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-2">
+                                <Link
+                                    :href="route('suppliers.show', supplier.id)"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-sky-500/10 text-sky-600 transition hover:bg-sky-500/20"
+                                >
+                                    <InfoIcon class="h-5 w-5" />
+                                </Link>
+                                <Link
+                                    :href="route('suppliers.edit', supplier.id)"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                >
+                                    <EditIcon class="h-5 w-5" />
+                                </Link>
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    @click="deleteSupplier(supplier.id)"
+                                >
+                                    <DeleteIcon class="h-5 w-5" />
+                                </button>
+                            </div>
                         </td>
                     </tr>
-                    </tbody>
-                </table>
+
+                    <template v-if="!filteredSuppliers.length">
+                        <tr>
+                            <td colspan="4" class="px-6 py-10 text-center text-sm text-slate-500">
+                                Cap proveïdor compleix els filtres actuals.
+                            </td>
+                        </tr>
+                    </template>
+                </CrudTable>
             </div>
         </div>
     </AppLayout>
 </template>
-
-<script setup>
-import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
-import { computed, reactive } from 'vue';
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-
-const props = defineProps({
-    auth: Object,
-    suppliers: Array,
-});
-
-// Datos reactivos
-const totalSuppliers = computed(() => props.suppliers.length);
-
-// Filtrar proveedores por compañía
-
-
-// Método para eliminar un proveedor
-const deleteSupplier = (supplierId) => {
-    if (confirm("¿Estás seguro de que deseas eliminar este proveedor?")) {
-        Inertia.delete(route('suppliers.delete', supplierId));
-    }
-};
-
-// Al crear el componente
-</script>
-
-<style scoped>
-/* Estilos personalizados aquí */
-</style>


### PR DESCRIPTION
## Summary
- add shared CRUD layout components for consistent dashboard-inspired CRUD pages
- refactor product, employee, and supplier create/edit forms to use shared form components and improved grouping
- align index listings with reusable filter/table components and refreshed action styling

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de567386848323ace9ea36a1a3a04d