### PR TITLE
Refactor inventory dashboards and listings with shared theme

### DIFF
--- a/resources/js/Components/Inventory/InventoryChartCard.vue
+++ b/resources/js/Components/Inventory/InventoryChartCard.vue
@@ -1,0 +1,29 @@
+<template>
+    <section class="bg-white rounded-3xl shadow-xl p-6 h-full flex flex-col">
+        <header class="space-y-1">
+            <p v-if="kicker" class="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500/80">{{ kicker }}</p>
+            <h2 class="text-xl font-semibold text-slate-800">{{ title }}</h2>
+            <p v-if="subtitle" class="text-sm text-slate-500">{{ subtitle }}</p>
+        </header>
+        <div class="mt-6 flex-1">
+            <slot />
+        </div>
+    </section>
+</template>
+
+<script setup>
+defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    subtitle: {
+        type: String,
+        default: '',
+    },
+    kicker: {
+        type: String,
+        default: '',
+    },
+});
+</script>

--- a/resources/js/Components/Inventory/InventoryFilterBar.vue
+++ b/resources/js/Components/Inventory/InventoryFilterBar.vue
@@ -1,0 +1,37 @@
+<template>
+    <section class="rounded-3xl border border-slate-200/60 bg-white/80 backdrop-blur px-6 py-5 shadow-sm">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-end">
+            <div class="grid flex-1 gap-4" :class="gridClass">
+                <slot />
+            </div>
+            <div class="flex items-center gap-3">
+                <slot name="actions" />
+            </div>
+        </div>
+    </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    columns: {
+        type: Number,
+        default: 3,
+    },
+});
+
+const gridClass = computed(() => {
+    const column = Math.min(Math.max(props.columns, 1), 4);
+    switch (column) {
+    case 1:
+        return 'sm:grid-cols-1';
+    case 2:
+        return 'sm:grid-cols-2';
+    case 4:
+        return 'sm:grid-cols-2 lg:grid-cols-4';
+    default:
+        return 'sm:grid-cols-2 lg:grid-cols-3';
+    }
+});
+</script>

--- a/resources/js/Components/Inventory/InventoryKpiCard.vue
+++ b/resources/js/Components/Inventory/InventoryKpiCard.vue
@@ -1,0 +1,32 @@
+<template>
+    <div class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg shadow-amber-900/10 transition duration-200 hover:-translate-y-1 hover:shadow-2xl">
+        <p class="text-xs uppercase tracking-[0.3em] text-amber-200">{{ label }}</p>
+        <p class="text-3xl font-semibold mt-2 text-white">{{ value }}</p>
+        <p v-if="subtitle || hasSubtitleSlot" class="text-sm text-amber-200 mt-3">
+            <slot name="subtitle">{{ subtitle }}</slot>
+        </p>
+        <slot />
+    </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+defineProps({
+    label: {
+        type: String,
+        required: true,
+    },
+    value: {
+        type: [String, Number],
+        required: true,
+    },
+    subtitle: {
+        type: String,
+        default: '',
+    },
+});
+
+const slots = useSlots();
+const hasSubtitleSlot = computed(() => Boolean(slots.subtitle));
+</script>

--- a/resources/js/Components/Inventory/InventoryResponsiveTable.vue
+++ b/resources/js/Components/Inventory/InventoryResponsiveTable.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="rounded-3xl bg-white shadow-xl ring-1 ring-slate-900/5">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-slate-100">
+                <thead class="bg-slate-50/80">
+                    <slot name="head" />
+                </thead>
+                <tbody class="divide-y divide-slate-100 bg-white">
+                    <slot />
+                </tbody>
+            </table>
+        </div>
+        <footer v-if="hasFooter" class="border-t border-slate-100 bg-slate-50/60 px-6 py-4">
+            <slot name="footer" />
+        </footer>
+        <div v-if="showEmptyState" class="px-6 py-10 text-center text-sm text-slate-500">
+            <slot name="empty">No hi ha registres disponibles.</slot>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+const props = defineProps({
+    isEmpty: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const slots = useSlots();
+
+const hasFooter = computed(() => Boolean(slots.footer));
+const showEmptyState = computed(() => props.isEmpty);
+</script>

--- a/resources/js/Components/Inventory/InventoryStatusBadge.vue
+++ b/resources/js/Components/Inventory/InventoryStatusBadge.vue
@@ -1,0 +1,30 @@
+<template>
+    <span :class="['inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset', statusClasses]">
+        <span v-if="showDot" class="h-2 w-2 rounded-full bg-current"></span>
+        <slot>{{ statusLabel }}</slot>
+    </span>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { resolveInventoryStatus } from './inventoryTheme';
+
+const props = defineProps({
+    status: {
+        type: [String, Number],
+        default: '',
+    },
+    fallback: {
+        type: String,
+        default: '—',
+    },
+    showDot: {
+        type: Boolean,
+        default: true,
+    },
+});
+
+const meta = computed(() => resolveInventoryStatus(props.status, props.fallback));
+const statusLabel = computed(() => meta.value.label);
+const statusClasses = computed(() => meta.value.classes);
+</script>

--- a/resources/js/Components/Inventory/InventorySummaryCard.vue
+++ b/resources/js/Components/Inventory/InventorySummaryCard.vue
@@ -1,0 +1,38 @@
+<template>
+    <article class="rounded-3xl border border-slate-200/60 bg-white px-6 py-5 shadow-sm transition duration-200 hover:-translate-y-1 hover:shadow-xl">
+        <div class="flex items-start justify-between gap-6">
+            <div class="space-y-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{{ label }}</p>
+                <p class="text-3xl font-semibold text-slate-800">{{ value }}</p>
+                <p v-if="description || hasDescription" class="text-xs text-slate-500">
+                    <slot name="description">{{ description }}</slot>
+                </p>
+            </div>
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-100 to-rose-100 text-amber-600">
+                <slot name="icon" />
+            </div>
+        </div>
+    </article>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+defineProps({
+    label: {
+        type: String,
+        required: true,
+    },
+    value: {
+        type: [String, Number],
+        required: true,
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+});
+
+const slots = useSlots();
+const hasDescription = computed(() => Boolean(slots.description));
+</script>

--- a/resources/js/Components/Inventory/inventoryTheme.js
+++ b/resources/js/Components/Inventory/inventoryTheme.js
@@ -1,0 +1,80 @@
+export const inventoryPalette = {
+    background: 'bg-slate-950',
+    gradient: 'from-amber-600 via-rose-600 to-purple-700',
+    surface: 'bg-white',
+    surfaceMuted: 'bg-white/80 backdrop-blur',
+    border: 'border-white/20',
+    shadow: 'shadow-xl shadow-amber-900/10',
+    text: {
+        overGradient: 'text-amber-200',
+        hero: 'text-white',
+        heading: 'text-slate-800',
+        body: 'text-slate-500',
+        subtle: 'text-slate-400',
+    },
+    accents: {
+        amber: 'bg-amber-500/10 text-amber-500',
+        emerald: 'bg-emerald-500/10 text-emerald-600',
+        sky: 'bg-sky-500/10 text-sky-600',
+        rose: 'bg-rose-500/10 text-rose-600',
+        indigo: 'bg-indigo-500/10 text-indigo-600',
+        violet: 'bg-violet-500/10 text-violet-600',
+    },
+};
+
+export const inventoryTypography = {
+    heroKicker: 'text-sm uppercase tracking-[0.3em] text-amber-200',
+    heroTitle: 'text-3xl sm:text-4xl font-semibold text-white',
+    heroSubtitle: 'text-sm text-amber-200',
+    sectionTitle: 'text-xl font-semibold text-slate-800',
+    sectionSubtitle: 'text-sm text-slate-500',
+    overline: 'text-xs uppercase tracking-[0.3em] text-amber-200',
+    statValue: 'text-3xl font-semibold text-white',
+};
+
+export const inventoryLayout = {
+    heroWrapper: 'bg-gradient-to-r pb-24 rounded-b-[2.5rem] md:rounded-b-[3rem]',
+    heroContainer: 'max-w-7xl mx-auto px-6 pt-10',
+    kpiGrid: 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10',
+    bodyWrapper: 'max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10',
+    sectionGrid: 'grid grid-cols-1 xl:grid-cols-3 gap-8',
+};
+
+export const inventoryStatusMap = {
+    completed: {
+        label: 'Completat',
+        classes: 'bg-emerald-50 text-emerald-600 ring-emerald-500/20',
+    },
+    pending: {
+        label: 'Pendent',
+        classes: 'bg-amber-50 text-amber-600 ring-amber-500/20',
+    },
+    cancelled: {
+        label: 'Cancel·lat',
+        classes: 'bg-rose-50 text-rose-600 ring-rose-500/20',
+    },
+    active: {
+        label: 'Actiu',
+        classes: 'bg-emerald-50 text-emerald-600 ring-emerald-500/20',
+    },
+    inactive: {
+        label: 'Inactiu',
+        classes: 'bg-slate-100 text-slate-500 ring-slate-400/20',
+    },
+    in_stock: {
+        label: 'En estoc',
+        classes: 'bg-emerald-50 text-emerald-600 ring-emerald-500/20',
+    },
+    out_of_stock: {
+        label: 'Sense estoc',
+        classes: 'bg-rose-50 text-rose-600 ring-rose-500/20',
+    },
+};
+
+export const resolveInventoryStatus = (status, fallback = 'default') => {
+    const normalized = status?.toString().toLowerCase();
+    return inventoryStatusMap[normalized] ?? {
+        label: fallback,
+        classes: 'bg-slate-100 text-slate-500 ring-slate-400/20',
+    };
+};

--- a/resources/js/Pages/Categories/Index.vue
+++ b/resources/js/Pages/Categories/Index.vue
@@ -1,76 +1,169 @@
-<template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Categorías</h2>
-                        <p class="text-blue-300 text-2xl">{{ totalCategories }}</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Tabla de categorías -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <!-- Botón para crear una nueva categoría -->
-                <div class="mb-6 w-1/6">
-                    <NavLink :href="route('categories.create')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded flex items-center space-x-2">
-                        <AddIcon class="w-5 h-5" />
-                        <span>Crear Nueva Categoría</span>
-                    </NavLink>
-                </div>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="category in categories" :key="category.id" class="border-t">
-                        <td class="px-4 py-2">{{ category.name }}</td>
-                        <td class="px-4 py-2">{{ category.description }}</td>
-                        <td class="px-4 py-2 flex space-x-2">
-                            <NavLink :href="route('categories.edit', category.id)" class="text-yellow-500">
-                                <EditIcon class="w-5 h-5" />
-                            </NavLink>
-                            <button @click="deleteCategory(category.id)" class="text-red-500">
-                                <DeleteIcon class="w-5 h-5" />
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </AppLayout>
-</template>
-
 <script setup>
+import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import { computed } from 'vue';
+import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
+import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
+import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
+import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
+import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import AddIcon from '@/Components/Icons/AddIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
-import NavLink from "@/Components/NavLink.vue";
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     categories: Array,
 });
 
-const totalCategories = computed(() => props.categories.length);
+const filters = reactive({
+    search: '',
+});
+
+const filteredCategories = computed(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    return props.categories.filter((category) =>
+        !searchTerm ||
+        category.name?.toLowerCase().includes(searchTerm) ||
+        category.description?.toLowerCase().includes(searchTerm),
+    );
+});
+
+const totalCategories = computed(() => filteredCategories.value.length);
+const withDescription = computed(() => filteredCategories.value.filter((category) => Boolean(category.description)).length);
+const withoutDescription = computed(() => totalCategories.value - withDescription.value);
+
+const clearFilters = () => {
+    filters.search = '';
+};
 
 const deleteCategory = (id) => {
-    if (confirm("¿Estás seguro de que deseas eliminar esta categoría?")) {
+    if (confirm('¿Estàs segur que vols eliminar aquesta categoria?')) {
         Inertia.delete(route('categories.destroy', id));
     }
 };
+
+const palette = inventoryPalette;
+const typography = inventoryTypography;
 </script>
 
-<style scoped>
-/* Estilos personalizados aquí */
-</style>
+<template>
+    <AppLayout>
+        <div :class="['min-h-screen pb-16', palette.background]">
+            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
+                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
+                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
+                        <div class="flex items-center gap-4">
+                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
+                                <MenuProductIcon class="h-8 w-8 text-white" />
+                            </div>
+                            <div class="space-y-2">
+                                <p :class="typography.heroKicker">Gestió de categories</p>
+                                <h1 :class="typography.heroTitle">Classifica el catàleg amb coherència</h1>
+                                <p :class="typography.heroSubtitle">
+                                    Organitza les línies de producte per facilitar la cerca i l'anàlisi de vendes.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex justify-end">
+                            <Link
+                                :href="route('categories.create')"
+                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
+                            >
+                                <AddIcon class="h-5 w-5" />
+                                Nova categoria
+                            </Link>
+                        </div>
+                    </div>
+
+                    <div class="grid gap-6 md:grid-cols-3">
+                        <InventorySummaryCard label="Total categories" :value="totalCategories">
+                            <template #icon>
+                                <MenuProductIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Amb descripció" :value="withDescription">
+                            <template #icon>
+                                <InfoIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Sense descripció" :value="withoutDescription" description="Completa la fitxa per millorar el catàleg">
+                            <template #icon>
+                                <DeleteIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
+                <InventoryFilterBar :columns="1">
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="category-search" value="Cerca" />
+                        <TextInput
+                            id="category-search"
+                            v-model="filters.search"
+                            type="search"
+                            class="block w-full"
+                            placeholder="Nom o descripció"
+                        />
+                    </div>
+
+                    <template #actions>
+                        <SecondaryButton type="button" @click="clearFilters">
+                            Netejar filtres
+                        </SecondaryButton>
+                    </template>
+                </InventoryFilterBar>
+
+                <InventoryResponsiveTable :is-empty="!filteredCategories.length">
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Descripció</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Completat</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Accions</th>
+                        </tr>
+                    </template>
+
+                    <tr v-for="category in filteredCategories" :key="category.id" class="hover:bg-slate-50/60">
+                        <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ category.name }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ category.description || '—' }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            <InventoryStatusBadge :status="category.description ? 'active' : 'inactive'">
+                                {{ category.description ? 'Informació completa' : 'Pendents detalls' }}
+                            </InventoryStatusBadge>
+                        </td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-2">
+                                <Link
+                                    :href="route('categories.edit', category.id)"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                >
+                                    <EditIcon class="h-5 w-5" />
+                                </Link>
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    @click="deleteCategory(category.id)"
+                                >
+                                    <DeleteIcon class="h-5 w-5" />
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <template #empty>
+                        Cap categoria coincideix amb la cerca actual.
+                    </template>
+                </InventoryResponsiveTable>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/DashboardProductos.vue
+++ b/resources/js/Pages/DashboardProductos.vue
@@ -1,78 +1,68 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-amber-600 via-rose-600 to-purple-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-amber-200 text-sm uppercase tracking-widest">Inventario estratégico</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Visión global del catálogo de productos</h1>
-                        <p class="text-sm text-amber-200">Controla categorías, stock y rendimiento para anticiparte a la demanda.</p>
+        <div :class="['min-h-screen', palette.background]">
+            <div :class="['bg-gradient-to-r', palette.gradient, layout.heroWrapper]">
+                <div :class="layout.heroContainer">
+                    <div class="space-y-2 text-white">
+                        <p :class="typography.heroKicker">Inventari estratègic</p>
+                        <h1 :class="typography.heroTitle">Visió global del catàleg de productes</h1>
+                        <p :class="typography.heroSubtitle">Controla categories, estoc i rendiment per anticipar la demanda.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Categorías</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalCategories }}</p>
-                            <p class="text-sm text-amber-200 mt-3">{{ averageProductsPerCategory }} productos promedio</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Productos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalProducts }}</p>
-                            <p class="text-sm text-amber-200 mt-3">{{ activeProducts }} activos</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Stock disponible</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalStock }}</p>
-                            <p class="text-sm text-amber-200 mt-3">{{ lowStockProducts.length }} productos en alerta</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Precio medio</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ averagePrice }}</p>
-                            <p class="text-sm text-amber-200 mt-3">Top ventas {{ topSellingProduct }}</p>
-                        </div>
+                    <div :class="layout.kpiGrid">
+                        <InventoryKpiCard label="Categories" :value="totalCategories">
+                            <template #subtitle>
+                                {{ averageProductsPerCategory }} productes per categoria
+                            </template>
+                        </InventoryKpiCard>
+                        <InventoryKpiCard label="Productes" :value="totalProducts">
+                            <template #subtitle>
+                                {{ activeProducts }} actius
+                            </template>
+                        </InventoryKpiCard>
+                        <InventoryKpiCard label="Estoc disponible" :value="totalStock">
+                            <template #subtitle>
+                                {{ lowStockProducts.length }} productes en alerta
+                            </template>
+                        </InventoryKpiCard>
+                        <InventoryKpiCard label="Preu mitjà" :value="`€${averagePrice}`">
+                            <template #subtitle>
+                                Top vendes {{ topSellingProduct }}
+                            </template>
+                        </InventoryKpiCard>
                     </div>
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
-                        <h2 class="text-xl font-semibold text-slate-800">Cantidad de productos por categoría</h2>
-                        <p class="text-sm text-slate-500">Visualiza cómo se distribuye tu catálogo.</p>
-                        <div class="mt-6">
-                            <BarChart :data="productsByCategoryData" />
-                        </div>
-                    </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
-                        <h2 class="text-xl font-semibold text-slate-800">Distribución del catálogo</h2>
-                        <p class="text-sm text-slate-500">Proporción de productos por línea de negocio.</p>
-                        <div class="mt-6">
-                            <PieChart :data="productsCategoryDistributionData" />
-                        </div>
-                    </div>
+            <div :class="layout.bodyWrapper">
+                <div :class="layout.sectionGrid">
+                    <InventoryChartCard title="Quantitat per categoria" subtitle="Visualitza com es distribueix el catàleg.">
+                        <BarChart :data="productsByCategoryData" />
+                    </InventoryChartCard>
+                    <InventoryChartCard title="Distribució del catàleg" subtitle="Proporció de productes per línia de negoci.">
+                        <PieChart :data="productsCategoryDistributionData" />
+                    </InventoryChartCard>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
-                        <h2 class="text-xl font-semibold text-slate-800">Rendimiento por categoría</h2>
-                        <p class="text-sm text-slate-500">Ventas estimadas según la demanda registrada.</p>
-                        <div class="mt-6">
-                            <RadarChart :data="categorySalesRadar" />
-                        </div>
-                    </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
-                        <h2 class="text-xl font-semibold text-slate-800">Alertas de stock crítico</h2>
-                        <p class="text-sm text-slate-500">Prioriza reposiciones con mayor impacto comercial.</p>
+                <div :class="layout.sectionGrid">
+                    <InventoryChartCard title="Rendiment per categoria" subtitle="Vendes estimades segons la demanda registrada.">
+                        <RadarChart :data="categorySalesRadar" />
+                    </InventoryChartCard>
+                    <InventoryChartCard title="Alertes d'estoc crític" subtitle="Prioritza reposicions amb major impacte comercial." kicker="Prioritat">
                         <ul class="mt-6 space-y-3 max-h-80 overflow-y-auto pr-2 text-sm text-slate-600">
                             <li v-for="product in lowStockProducts" :key="product.id" class="flex items-center justify-between rounded-2xl border border-slate-200/70 p-4">
                                 <div>
                                     <p class="font-semibold text-slate-700">{{ product.name }}</p>
-                                    <p class="text-xs text-slate-400">Stock actual: {{ product.stock ?? product.quantity ?? 0 }}</p>
+                                    <p class="text-xs text-slate-400">Estoc actual: {{ product.stock ?? product.quantity ?? 0 }}</p>
                                 </div>
-                                <span class="inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600">{{ product.category?.name ?? 'Sin categoría' }}</span>
+                                <InventoryStatusBadge :status="product.category?.name ?? 'Sense categoria'" :show-dot="false">
+                                    {{ product.category?.name ?? 'Sense categoria' }}
+                                </InventoryStatusBadge>
                             </li>
-                            <li v-if="lowStockProducts.length === 0" class="text-sm text-slate-400">No hay productos con stock crítico.</li>
+                            <li v-if="lowStockProducts.length === 0" class="rounded-2xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-400">
+                                No hi ha productes amb estoc crític.
+                            </li>
                         </ul>
-                    </div>
+                    </InventoryChartCard>
                 </div>
             </div>
         </div>
@@ -85,18 +75,26 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import BarChart from '@/Components/BarChart.vue';
 import PieChart from '@/Components/PieChart.vue';
 import RadarChart from '@/Components/RadarChart.vue';
+import InventoryKpiCard from '@/Components/Inventory/InventoryKpiCard.vue';
+import InventoryChartCard from '@/Components/Inventory/InventoryChartCard.vue';
+import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
+import { inventoryLayout, inventoryTypography, inventoryPalette } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     categories: Array,
     products: Array,
 });
 
+const layout = inventoryLayout;
+const typography = inventoryTypography;
+const palette = inventoryPalette;
+
 const totalCategories = computed(() => props.categories.length);
 const totalProducts = computed(() => props.products.length);
-const averageProductsPerCategory = computed(() => props.categories.length ? Math.round(totalProducts.value / props.categories.length) : 0);
+const averageProductsPerCategory = computed(() => (props.categories.length ? Math.round(totalProducts.value / props.categories.length) : 0));
 const activeProducts = computed(() => props.products.filter(product => product.status === 'active' || product.active).length);
 const totalStock = computed(() => props.products.reduce((acc, product) => acc + (product.stock ?? product.quantity ?? 0), 0));
-const averagePrice = computed(() => props.products.length ? (props.products.reduce((acc, product) => acc + (product.price ?? 0), 0) / props.products.length).toFixed(2) : '0.00');
+const averagePrice = computed(() => (props.products.length ? (props.products.reduce((acc, product) => acc + (product.price ?? 0), 0) / props.products.length).toFixed(2) : '0.00'));
 
 const lowStockProducts = computed(() => props.products.filter(product => (product.stock ?? product.quantity ?? 0) <= 10));
 
@@ -120,7 +118,7 @@ const productsByCategoryData = computed(() => {
         labels: categoryTotals.map(ct => ct.category),
         datasets: [
             {
-                label: 'Productos por categoría',
+                label: 'Productes per categoria',
                 backgroundColor: 'rgba(251, 191, 36, 0.5)',
                 borderColor: 'rgba(251, 191, 36, 1)',
                 borderWidth: 1,
@@ -143,7 +141,7 @@ const productsCategoryDistributionData = computed(() => {
         labels: categoryTotals.map(ct => ct.category),
         datasets: [
             {
-                label: 'Distribución de productos',
+                label: 'Distribució de productes',
                 backgroundColor: ['#FBBF24', '#F97316', '#FB7185', '#A855F7', '#6366F1'],
                 data: categoryTotals.map(ct => ct.total),
             },
@@ -165,7 +163,7 @@ const categorySalesRadar = computed(() => {
         labels: dataset.map(item => item.category),
         datasets: [
             {
-                label: 'Ventas estimadas',
+                label: 'Vendes estimades',
                 data: dataset.map(item => item.sales),
                 backgroundColor: 'rgba(251, 146, 60, 0.35)',
                 borderColor: 'rgba(249, 115, 22, 1)',

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -3,10 +3,6 @@ import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
-import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
-import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
-import CrudTable from '@/Components/Crud/CrudTable.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import SelectInput from '@/Components/SelectInput.vue';
@@ -16,6 +12,11 @@ import AddProductIcon from '@/Components/Icons/AddProductIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import MenuExpenseIcon from '@/Components/Icons/MenuExpenseIcon.vue';
+import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
+import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
+import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
+import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
+import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     products: {
@@ -75,50 +76,67 @@ const downloadLabel = (labelPath) => {
 
 const categoryName = (categoryId) =>
     props.categories.find((category) => Number(category.id) === Number(categoryId))?.name ?? '—';
+
+const palette = inventoryPalette;
+const typography = inventoryTypography;
+
+const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_of_stock');
 </script>
 
 <template>
     <AppLayout title="Catàleg de productes">
-        <div class="min-h-screen bg-slate-100/80 py-12">
-            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
-                <CrudPageHeader
-                    title="Catàleg de productes"
-                    description="Consulta, filtra i gestiona els productes disponibles per a la venda i el control d'estoc."
-                    :icon="MenuProductIcon"
-                >
-                    <template #actions>
-                        <Link
-                            :href="route('products.create')"
-                            class="inline-flex items-center gap-2 rounded-full bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200 transition hover:bg-sky-500"
-                        >
-                            <AddProductIcon class="h-5 w-5" />
-                            Nou producte
-                        </Link>
-                    </template>
-                </CrudPageHeader>
+        <div :class="['min-h-screen pb-16', palette.background]">
+            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
+                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
+                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
+                        <div class="flex items-center gap-4">
+                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
+                                <MenuProductIcon class="h-8 w-8 text-white" />
+                            </div>
+                            <div class="space-y-2">
+                                <p :class="typography.heroKicker">Catàleg de productes</p>
+                                <h1 :class="typography.heroTitle">Control integral del portfoli</h1>
+                                <p :class="typography.heroSubtitle">
+                                    Consulta, filtra i gestiona els productes disponibles per a la venda i el control d'estoc.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex justify-end">
+                            <Link
+                                :href="route('products.create')"
+                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
+                            >
+                                <AddProductIcon class="h-5 w-5" />
+                                Nou producte
+                            </Link>
+                        </div>
+                    </div>
 
-                <div class="grid gap-6 md:grid-cols-3">
-                    <CrudStatCard
-                        label="Total de productes"
-                        :value="totalProducts"
-                        :icon="MenuProductIcon"
-                        icon-background="bg-indigo-500/10 text-indigo-600"
-                    />
-                    <CrudStatCard
-                        label="En estoc"
-                        :value="inStock"
-                        :icon="AddProductIcon"
-                        icon-background="bg-emerald-500/10 text-emerald-600"
-                    />
-                    <CrudStatCard
-                        label="Sense estoc"
-                        :value="outOfStock"
-                        :icon="MenuProductIcon"
-                        icon-background="bg-rose-500/10 text-rose-600"
-                    />
+                    <div class="grid gap-6 md:grid-cols-3">
+                        <InventorySummaryCard label="Total de productes" :value="totalProducts">
+                            <template #icon>
+                                <MenuProductIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="En estoc" :value="inStock">
+                            <template #icon>
+                                <AddProductIcon class="h-6 w-6" />
+                            </template>
+                            <template #description>
+                                Disponibles immediatament
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Sense estoc" :value="outOfStock" description="Revisa les reposicions pendents">
+                            <template #icon>
+                                <MenuExpenseIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                    </div>
                 </div>
+            </div>
 
-                <CrudFilterBar>
+            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
+                <InventoryFilterBar>
                     <div class="flex flex-1 flex-col gap-2">
                         <InputLabel for="search" value="Cerca" />
                         <TextInput
@@ -154,16 +172,16 @@ const categoryName = (categoryId) =>
                             Netejar filtres
                         </SecondaryButton>
                     </template>
-                </CrudFilterBar>
+                </InventoryFilterBar>
 
-                <CrudTable>
+                <InventoryResponsiveTable :is-empty="!filteredProducts.length">
                     <template #head>
                         <tr>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Nom</th>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Categoria</th>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Preu (€)</th>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Estoc</th>
-                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Accions</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Categoria</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Preu (€)</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Estoc</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Accions</th>
                         </tr>
                     </template>
 
@@ -171,8 +189,10 @@ const categoryName = (categoryId) =>
                         <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ product.name }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ categoryName(product.category_id) }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ Number(product.price).toFixed(2) }}</td>
-                        <td class="px-6 py-4 text-sm font-semibold" :class="Number(product.stock) > 0 ? 'text-emerald-600' : 'text-rose-500'">
-                            {{ product.stock ?? 0 }}
+                        <td class="px-6 py-4 text-sm font-semibold">
+                            <InventoryStatusBadge :status="stockStatus(product)">
+                                {{ Number(product.stock ?? 0) }}
+                            </InventoryStatusBadge>
                         </td>
                         <td class="px-6 py-4">
                             <div class="flex items-center justify-end gap-2">
@@ -201,14 +221,10 @@ const categoryName = (categoryId) =>
                         </td>
                     </tr>
 
-                    <template v-if="!filteredProducts.length">
-                        <tr>
-                            <td colspan="5" class="px-6 py-10 text-center text-sm text-slate-500">
-                                Cap resultat coincideix amb els filtres actuals.
-                            </td>
-                        </tr>
+                    <template #empty>
+                        Cap resultat coincideix amb els filtres actuals.
                     </template>
-                </CrudTable>
+                </InventoryResponsiveTable>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/Pages/StockEntries/Index.vue
+++ b/resources/js/Pages/StockEntries/Index.vue
@@ -1,121 +1,22 @@
-<template>
-    <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Entradas de Stock</h2>
-                        <p class="text-blue-300 text-2xl">{{ stockEntries.length }}</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Filtros -->
-            <div class="mb-6 bg-white p-4 rounded-lg shadow-md">
-                <div class="flex flex-wrap gap-4">
-                    <!-- Filtro por proveedor -->
-                    <div>
-                        <label for="supplierFilter" class="block text-sm text-blue-500 font-semibold">Proveedor</label>
-                        <select v-model="selectedSupplier" id="supplierFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm">
-                            <option value="">Todos</option>
-                            <option v-for="supplier in suppliers" :key="supplier.id" :value="supplier.id">{{ supplier.name }}</option>
-                        </select>
-                    </div>
-
-                    <!-- Filtro por estado -->
-                    <div>
-                        <label for="statusFilter" class="block text-sm text-blue-500 font-semibold">Estado</label>
-                        <select v-model="selectedStatus" id="statusFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm">
-                            <option value="">Todos</option>
-                            <option value="pending">Pendiente</option>
-                            <option value="completed">Completado</option>
-                        </select>
-                    </div>
-
-                    <!-- Filtro por rango de fechas -->
-                    <div>
-                        <label for="startDateFilter" class="block text-sm text-blue-500 font-semibold">Fecha de Inicio</label>
-                        <input type="date" v-model="startDate" id="startDateFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
-                    </div>
-
-                    <div>
-                        <label for="endDateFilter" class="block text-sm text-blue-500 font-semibold">Fecha de Finalización</label>
-                        <input type="date" v-model="endDate" id="endDateFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
-                    </div>
-
-                    <!-- Botón para limpiar filtros -->
-                    <button @click="clearFilters" class="mt-6 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
-                        Limpiar Filtros
-                    </button>
-                </div>
-            </div>
-
-            <!-- Tabla de entradas de stock -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Referencia</th>
-                        <th class="px-4 py-2 text-left">Proveedor</th>
-                        <th class="px-4 py-2 text-left">Fecha de Entrada</th>
-                        <th class="px-4 py-2 text-left">Total</th>
-                        <th class="px-4 py-2 text-left">Estado</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="entry in filteredStockEntries" :key="entry.id" class="border-t">
-                        <td class="px-4 py-2">{{ entry.reference }}</td>
-
-                        <!-- Mostrar nombre del proveedor -->
-                        <td class="px-4 py-2">
-                            <template v-for="supplier in suppliers" :key="supplier.id">
-                                <span v-if="supplier.id === entry.supplier_id">{{ supplier.name }}</span>
-                            </template>
-                        </td>
-
-                        <td class="px-4 py-2">{{ entry.entry_date }}</td>
-                        <td class="px-4 py-2">{{ entry.total }}</td>
-
-                        <!-- Mostrar estado con punto de color -->
-                        <td class="px-4 py-2 flex items-center">
-                            <span
-                                :class="{
-                                    'bg-green-500': entry.status === 'completed',
-                                    'bg-yellow-500': entry.status === 'pending'
-                                }"
-                                class="w-3 h-3 rounded-full inline-block mr-2"
-                            ></span>
-                            {{ entry.status }}
-                        </td>
-
-                        <td class="px-4 py-2  space-x-5">
-                           <button @click="deleteStockEntry(entry.id)" title="Eliminar" class=" p-2 rounded-full">
-                               <DeleteIcon class="w-5 h-5 stroke-red-900 fill-red-300"/>
-                            </button>
-                            <button @click="editStockEntry(entry.id)" title="Editar" class=" p-2 rounded-full">
-                                <EditIcon class="w-5 h-5 stroke-blue-900 fill-blue-300"/>
-                            </button>
-                            <button @click="showStockEntryDetails(entry.id)" title="Detalles" class=" p-2 rounded-full">
-                                <InfoIcon class="w-5 h-5 stroke-gray-900 fill-gray-300"/>
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </AppLayout>
-</template>
-
 <script setup>
-import { defineProps, ref, computed } from 'vue';
+import { computed, ref } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
+import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
+import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
+import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
+import MenuExpenseIcon from '@/Components/Icons/MenuExpenseIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     stockEntries: Array,
@@ -127,20 +28,22 @@ const selectedStatus = ref('');
 const startDate = ref('');
 const endDate = ref('');
 
-// Filtrar las entradas de stock basadas en los filtros seleccionados
-const filteredStockEntries = computed(() => {
-    return props.stockEntries.filter(entry => {
-        const supplierMatch = selectedSupplier.value === '' || entry.supplier_id === selectedSupplier.value;
+const filteredStockEntries = computed(() =>
+    props.stockEntries.filter((entry) => {
+        const supplierMatch = selectedSupplier.value === '' || Number(entry.supplier_id) === Number(selectedSupplier.value);
         const statusMatch = selectedStatus.value === '' || entry.status === selectedStatus.value;
 
-        // Convertir las fechas de las entradas de stock y los filtros a objetos Date para comparar
         const entryDate = new Date(entry.entry_date);
-        const startDateMatch = startDate.value === '' || entryDate >= new Date(startDate.value);
-        const endDateMatch = endDate.value === '' || entryDate <= new Date(endDate.value);
+        const startDateMatch = !startDate.value || entryDate >= new Date(startDate.value);
+        const endDateMatch = !endDate.value || entryDate <= new Date(endDate.value);
 
         return supplierMatch && statusMatch && startDateMatch && endDateMatch;
-    });
-});
+    }),
+);
+
+const totalEntries = computed(() => filteredStockEntries.value.length);
+const pendingEntries = computed(() => filteredStockEntries.value.filter((entry) => entry.status === 'pending').length);
+const completedEntries = computed(() => filteredStockEntries.value.filter((entry) => entry.status === 'completed').length);
 
 const clearFilters = () => {
     selectedSupplier.value = '';
@@ -150,7 +53,7 @@ const clearFilters = () => {
 };
 
 const deleteStockEntry = (id) => {
-    if (confirm("¿Estás seguro de que deseas eliminar esta entrada de stock?")) {
+    if (confirm('¿Estàs segur que vols eliminar aquesta entrada de stock?')) {
         Inertia.delete(route('stockEntries.destroy', id));
     }
 };
@@ -158,11 +61,158 @@ const deleteStockEntry = (id) => {
 const editStockEntry = (id) => {
     Inertia.visit(route('stockEntries.goToEdit', id));
 };
+
 const showStockEntryDetails = (id) => {
     Inertia.visit(route('stockEntries.goToShow', id));
 };
+
+const supplierName = (supplierId) =>
+    props.suppliers.find((supplier) => Number(supplier.id) === Number(supplierId))?.name ?? '—';
+
+const palette = inventoryPalette;
+const typography = inventoryTypography;
 </script>
 
-<style scoped>
-/* Estilos personalizados si es necesario */
-</style>
+<template>
+    <AppLayout>
+        <div :class="['min-h-screen pb-16', palette.background]">
+            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
+                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
+                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
+                        <div class="flex items-center gap-4">
+                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
+                                <MenuExpenseIcon class="h-8 w-8 text-white" />
+                            </div>
+                            <div class="space-y-2">
+                                <p :class="typography.heroKicker">Entrades d'estoc</p>
+                                <h1 :class="typography.heroTitle">Flux de reposicions coordinat</h1>
+                                <p :class="typography.heroSubtitle">
+                                    Supervisa els moviments d'entrada, assigna prioritats i planifica els lliuraments amb informació unificada.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex justify-end gap-3">
+                            <Link
+                                :href="route('stockEntries.create')"
+                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
+                            >
+                                <AddIcon class="h-5 w-5" />
+                                Nova entrada
+                            </Link>
+                        </div>
+                    </div>
+
+                    <div class="grid gap-6 md:grid-cols-3">
+                        <InventorySummaryCard label="Total entrades" :value="totalEntries">
+                            <template #icon>
+                                <MenuExpenseIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Pendents" :value="pendingEntries" description="Esperant recepció">
+                            <template #icon>
+                                <InfoIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Completades" :value="completedEntries" description="Disponible al magatzem">
+                            <template #icon>
+                                <AddIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
+                <InventoryFilterBar :columns="4">
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="supplierFilter" value="Proveïdor" />
+                        <SelectInput id="supplierFilter" v-model="selectedSupplier" class="block w-full">
+                            <option value="">Tots</option>
+                            <option v-for="supplier in suppliers" :key="supplier.id" :value="supplier.id">{{ supplier.name }}</option>
+                        </SelectInput>
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="statusFilter" value="Estat" />
+                        <SelectInput id="statusFilter" v-model="selectedStatus" class="block w-full">
+                            <option value="">Tots</option>
+                            <option value="pending">Pendent</option>
+                            <option value="completed">Completat</option>
+                        </SelectInput>
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="startDateFilter" value="Data d'inici" />
+                        <TextInput id="startDateFilter" v-model="startDate" type="date" class="block w-full" />
+                    </div>
+
+                    <div class="flex flex-1 flex-col gap-2">
+                        <InputLabel for="endDateFilter" value="Data de finalització" />
+                        <TextInput id="endDateFilter" v-model="endDate" type="date" class="block w-full" />
+                    </div>
+
+                    <template #actions>
+                        <SecondaryButton type="button" @click="clearFilters">
+                            Netejar filtres
+                        </SecondaryButton>
+                    </template>
+                </InventoryFilterBar>
+
+                <InventoryResponsiveTable :is-empty="!filteredStockEntries.length">
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Referència</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Proveïdor</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Data d'entrada</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Total</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Estat</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Accions</th>
+                        </tr>
+                    </template>
+
+                    <tr v-for="entry in filteredStockEntries" :key="entry.id" class="hover:bg-slate-50/60">
+                        <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ entry.reference }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ supplierName(entry.supplier_id) }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ entry.entry_date }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-500">{{ entry.total }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            <InventoryStatusBadge :status="entry.status" />
+                        </td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-2">
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    @click="deleteStockEntry(entry.id)"
+                                    title="Eliminar"
+                                >
+                                    <DeleteIcon class="h-5 w-5" />
+                                </button>
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                    @click="editStockEntry(entry.id)"
+                                    title="Editar"
+                                >
+                                    <EditIcon class="h-5 w-5" />
+                                </button>
+                                <button
+                                    type="button"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-sky-500/10 text-sky-600 transition hover:bg-sky-500/20"
+                                    @click="showStockEntryDetails(entry.id)"
+                                    title="Detalls"
+                                >
+                                    <InfoIcon class="h-5 w-5" />
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <template #empty>
+                        No hi ha entrades que coincideixin amb els filtres aplicats.
+                    </template>
+                </InventoryResponsiveTable>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Suppliers/Index.vue
+++ b/resources/js/Pages/Suppliers/Index.vue
@@ -3,10 +3,6 @@ import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
-import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
-import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
-import CrudTable from '@/Components/Crud/CrudTable.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import SelectInput from '@/Components/SelectInput.vue';
@@ -16,6 +12,11 @@ import AddIcon from '@/Components/Icons/AddIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
+import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
+import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
+import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
+import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     suppliers: {
@@ -61,50 +62,62 @@ const deleteSupplier = (supplierId) => {
         Inertia.delete(route('suppliers.delete', supplierId));
     }
 };
+
+const palette = inventoryPalette;
+const typography = inventoryTypography;
 </script>
 
 <template>
     <AppLayout title="Proveïdors">
-        <div class="min-h-screen bg-slate-100/80 py-12">
-            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
-                <CrudPageHeader
-                    title="Xarxa de proveïdors"
-                    description="Mantén la relació comercial alineada amb la resta de departaments i detecta ràpidament punts de millora."
-                    :icon="MenuBillingIcon"
-                >
-                    <template #actions>
-                        <Link
-                            :href="route('suppliers.create')"
-                            class="inline-flex items-center gap-2 rounded-full bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200 transition hover:bg-sky-500"
-                        >
-                            <AddIcon class="h-5 w-5" />
-                            Nou proveïdor
-                        </Link>
-                    </template>
-                </CrudPageHeader>
+        <div :class="['min-h-screen pb-16', palette.background]">
+            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
+                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
+                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
+                        <div class="flex items-center gap-4">
+                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
+                                <MenuBillingIcon class="h-8 w-8 text-white" />
+                            </div>
+                            <div class="space-y-2">
+                                <p :class="typography.heroKicker">Xarxa de proveïdors</p>
+                                <h1 :class="typography.heroTitle">Sincronitza relacions clau</h1>
+                                <p :class="typography.heroSubtitle">
+                                    Mantén la relació comercial alineada amb la resta de departaments i detecta ràpidament punts de millora.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex justify-end">
+                            <Link
+                                :href="route('suppliers.create')"
+                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
+                            >
+                                <AddIcon class="h-5 w-5" />
+                                Nou proveïdor
+                            </Link>
+                        </div>
+                    </div>
 
-                <div class="grid gap-6 md:grid-cols-3">
-                    <CrudStatCard
-                        label="Total proveïdors"
-                        :value="totalSuppliers"
-                        :icon="MenuBillingIcon"
-                        icon-background="bg-indigo-500/10 text-indigo-600"
-                    />
-                    <CrudStatCard
-                        label="Amb correu"
-                        :value="suppliersWithEmail"
-                        :icon="AddIcon"
-                        icon-background="bg-emerald-500/10 text-emerald-600"
-                    />
-                    <CrudStatCard
-                        label="Sense telèfon"
-                        :value="suppliersWithoutPhone"
-                        :icon="InfoIcon"
-                        icon-background="bg-amber-500/10 text-amber-600"
-                    />
+                    <div class="grid gap-6 md:grid-cols-3">
+                        <InventorySummaryCard label="Total proveïdors" :value="totalSuppliers">
+                            <template #icon>
+                                <MenuBillingIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Amb correu" :value="suppliersWithEmail" description="Contacte immediat">
+                            <template #icon>
+                                <AddIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                        <InventorySummaryCard label="Sense telèfon" :value="suppliersWithoutPhone" description="Requereix seguiment">
+                            <template #icon>
+                                <InfoIcon class="h-6 w-6" />
+                            </template>
+                        </InventorySummaryCard>
+                    </div>
                 </div>
+            </div>
 
-                <CrudFilterBar>
+            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
+                <InventoryFilterBar :columns="2">
                     <div class="flex flex-1 flex-col gap-2">
                         <InputLabel for="supplier-search" value="Cerca" />
                         <TextInput
@@ -130,15 +143,16 @@ const deleteSupplier = (supplierId) => {
                             Netejar filtres
                         </SecondaryButton>
                     </template>
-                </CrudFilterBar>
+                </InventoryFilterBar>
 
-                <CrudTable>
+                <InventoryResponsiveTable :is-empty="!filteredSuppliers.length">
                     <template #head>
                         <tr>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Nom</th>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Correu</th>
-                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Telèfon</th>
-                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Accions</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Correu</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Telèfon</th>
+                            <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Contacte</th>
+                            <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Accions</th>
                         </tr>
                     </template>
 
@@ -146,6 +160,11 @@ const deleteSupplier = (supplierId) => {
                         <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ supplier.name }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.email || '—' }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.phone || '—' }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            <InventoryStatusBadge :status="supplier.email ? 'active' : 'inactive'">
+                                {{ supplier.email ? 'Contacte directe' : 'Sense correu' }}
+                            </InventoryStatusBadge>
+                        </td>
                         <td class="px-6 py-4">
                             <div class="flex items-center justify-end gap-2">
                                 <Link
@@ -171,14 +190,10 @@ const deleteSupplier = (supplierId) => {
                         </td>
                     </tr>
 
-                    <template v-if="!filteredSuppliers.length">
-                        <tr>
-                            <td colspan="4" class="px-6 py-10 text-center text-sm text-slate-500">
-                                Cap proveïdor compleix els filtres actuals.
-                            </td>
-                        </tr>
+                    <template #empty>
+                        Cap proveïdor compleix els filtres actuals.
                     </template>
-                </CrudTable>
+                </InventoryResponsiveTable>
             </div>
         </div>
     </AppLayout>


### PR DESCRIPTION
## Summary
- extract inventory theme tokens and reusable dashboard widgets (KPI, charts, tables, filters, status badges)
- refresh dashboard and listing screens in the inventory module to share gradients, typography and responsive summaries
- unify stock, supplier and category management tables with responsive layout, status badges and streamlined filter panels

## Testing
- npm run build *(fails: missing vendor/tightenco/ziggy dependency in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de5df23a648323b8949d40efda6bee