### PR TITLE
Redesign client management surfaces

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -14,7 +14,7 @@ class ClientController extends Controller
 {
     public function index()
     {
-        $clients = Client::where('company_id',Auth::user()->company_id);
+        $clients = Client::where('company_id', Auth::user()->company_id)->get();
         return Inertia::render('Clients/Index', [
             'clients' => $clients
         ]);

--- a/resources/js/Components/Clients/ClientForm.vue
+++ b/resources/js/Components/Clients/ClientForm.vue
@@ -1,0 +1,119 @@
+<template>
+    <form @submit.prevent="$emit('submit')" class="space-y-8">
+        <div v-if="form.hasErrors" class="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700" role="alert">
+            <p class="font-semibold">Revisa los campos con errores.</p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div v-if="companies.length" class="md:col-span-2">
+                <label for="company_id" class="block text-sm font-semibold text-slate-700">Empresa</label>
+                <select
+                    id="company_id"
+                    v-model="form.company_id"
+                    class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                    :aria-invalid="hasError('company_id')"
+                    :aria-describedby="hasError('company_id') ? 'company_id-error' : undefined"
+                >
+                    <option value="" disabled>Selecciona una empresa</option>
+                    <option v-for="company in companies" :key="company.id" :value="company.id">{{ company.name }}</option>
+                </select>
+                <p v-if="hasError('company_id')" :id="'company_id-error'" class="mt-2 text-sm text-rose-500">{{ form.errors.company_id }}</p>
+            </div>
+            <div v-else class="md:col-span-2">
+                <label class="block text-sm font-semibold text-slate-700">Empresa</label>
+                <div class="mt-2 flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
+                    <span>{{ companyName }}</span>
+                    <span class="text-xs uppercase tracking-widest text-slate-400">Asignada</span>
+                </div>
+                <input type="hidden" v-model="form.company_id" />
+            </div>
+
+            <div v-for="field in fields" :key="field.key" :class="field.full ? 'md:col-span-2' : ''">
+                <label :for="field.key" class="block text-sm font-semibold text-slate-700">{{ field.label }}</label>
+                <component
+                    :is="field.component"
+                    :id="field.key"
+                    v-model="form[field.key]"
+                    v-bind="field.props"
+                    class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                    :aria-invalid="hasError(field.key)"
+                    :aria-describedby="hasError(field.key) ? `${field.key}-error` : undefined"
+                />
+                <p v-if="hasError(field.key)" :id="`${field.key}-error`" class="mt-2 text-sm text-rose-500">{{ form.errors[field.key] }}</p>
+            </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div class="flex items-center gap-3 text-xs text-slate-400 uppercase tracking-widest">
+                <span>Atajos</span>
+                <span aria-hidden="true">•</span>
+                <span>Ctrl + Enter para guardar</span>
+            </div>
+            <div class="flex flex-wrap gap-3">
+                <button
+                    v-if="cancelHref"
+                    type="button"
+                    class="inline-flex items-center justify-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition"
+                    @click="$emit('cancel', cancelHref)"
+                >
+                    Cancelar
+                </button>
+                <button
+                    type="submit"
+                    class="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-6 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-200 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-70"
+                    :disabled="processing"
+                >
+                    <span v-if="processing" class="flex items-center gap-2">
+                        <span class="h-4 w-4 animate-spin rounded-full border-2 border-white/60 border-t-white"></span>
+                        Guardando
+                    </span>
+                    <span v-else>{{ submitLabel }}</span>
+                </button>
+            </div>
+        </div>
+    </form>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    form: {
+        type: Object,
+        required: true,
+    },
+    processing: {
+        type: Boolean,
+        default: false,
+    },
+    submitLabel: {
+        type: String,
+        default: 'Guardar cambios',
+    },
+    companies: {
+        type: Array,
+        default: () => [],
+    },
+    companyName: {
+        type: String,
+        default: '',
+    },
+    cancelHref: {
+        type: String,
+        default: null,
+    },
+});
+
+const fields = computed(() => [
+    { key: 'name', label: 'Nombre del cliente', component: 'input', props: { type: 'text', required: true } },
+    { key: 'nif', label: 'NIF', component: 'input', props: { type: 'text', required: true } },
+    { key: 'bank', label: 'Banco', component: 'input', props: { type: 'text', required: true } },
+    { key: 'phone', label: 'Teléfono', component: 'input', props: { type: 'tel', required: true } },
+    { key: 'email', label: 'Correo electrónico', component: 'input', props: { type: 'email', required: true } },
+    { key: 'address', label: 'Dirección', component: 'textarea', props: { rows: 3, required: true }, full: true },
+]);
+
+function hasError(key) {
+    return Boolean(props.form.errors?.[key]);
+}
+</script>

--- a/resources/js/Components/Icons/DashboardIcon.vue
+++ b/resources/js/Components/Icons/DashboardIcon.vue
@@ -1,0 +1,6 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.5A6.5 6.5 0 0 1 9.5 7H21v10.5A2.5 2.5 0 0 1 18.5 20H5.5A2.5 2.5 0 0 1 3 17.5v-4z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 7V3h3.5A2.5 2.5 0 0 1 15 5.5V7" />
+    </svg>
+</template>

--- a/resources/js/Components/UI/DataTable.vue
+++ b/resources/js/Components/UI/DataTable.vue
@@ -1,0 +1,64 @@
+<template>
+    <div class="overflow-x-auto pt-6">
+        <table class="w-full text-left" :aria-describedby="descriptionId">
+            <caption v-if="caption" :id="descriptionId" class="sr-only">{{ caption }}</caption>
+            <thead>
+                <tr class="text-xs uppercase tracking-widest text-slate-400">
+                    <th v-for="column in columns" :key="column.key" class="pb-3" :class="column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : ''">
+                        {{ column.label }}
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
+                <template v-if="items.length">
+                    <tr v-for="item in items" :key="resolveKey(item)" class="hover:bg-slate-50/80 transition" tabindex="0">
+                        <slot name="row" :item="item" />
+                    </tr>
+                </template>
+                <tr v-else>
+                    <td :colspan="columns.length" class="py-6 text-center text-slate-400">
+                        <slot name="empty">
+                            {{ emptyMessage }}
+                        </slot>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    columns: {
+        type: Array,
+        default: () => [],
+    },
+    items: {
+        type: Array,
+        default: () => [],
+    },
+    emptyMessage: {
+        type: String,
+        default: 'No hay datos disponibles.',
+    },
+    rowKey: {
+        type: [String, Function],
+        default: 'id',
+    },
+    caption: {
+        type: String,
+        default: '',
+    },
+});
+
+const descriptionId = computed(() => (props.caption ? `${props.caption.replace(/\s+/g, '-').toLowerCase()}-caption` : undefined));
+
+function resolveKey(item) {
+    if (typeof props.rowKey === 'function') {
+        return props.rowKey(item);
+    }
+    return item?.[props.rowKey];
+}
+</script>

--- a/resources/js/Components/UI/Panel.vue
+++ b/resources/js/Components/UI/Panel.vue
@@ -1,0 +1,37 @@
+<template>
+    <section :aria-labelledby="headingId" class="bg-white rounded-3xl shadow-xl p-6" role="region">
+        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4" :class="headerBorder ? 'border-b border-slate-100 pb-5' : ''">
+            <div>
+                <h2 v-if="title" :id="headingId" class="text-xl font-semibold text-slate-800">{{ title }}</h2>
+                <p v-if="description" class="text-sm text-slate-500 mt-1">{{ description }}</p>
+            </div>
+            <div>
+                <slot name="actions" />
+            </div>
+        </div>
+        <div :class="headerBorder ? 'pt-6' : ''">
+            <slot />
+        </div>
+    </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    title: {
+        type: String,
+        default: '',
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    headerBorder: {
+        type: Boolean,
+        default: true,
+    },
+});
+
+const headingId = computed(() => (props.title ? `${props.title.replace(/\s+/g, '-').toLowerCase()}-panel` : undefined));
+</script>

--- a/resources/js/Components/UI/SummaryCard.vue
+++ b/resources/js/Components/UI/SummaryCard.vue
@@ -1,0 +1,53 @@
+<template>
+    <div :class="wrapperClass">
+        <p v-if="eyebrow" class="text-xs uppercase tracking-[0.3em]" :class="eyebrowClass">{{ eyebrow }}</p>
+        <p class="text-3xl font-semibold mt-2">
+            <slot name="value">{{ value }}</slot>
+        </p>
+        <p v-if="description || hasDescriptionSlot" class="text-sm mt-3" :class="descriptionClass">
+            <slot name="description">{{ description }}</slot>
+        </p>
+    </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+const props = defineProps({
+    value: {
+        type: [String, Number],
+        default: '',
+    },
+    eyebrow: {
+        type: String,
+        default: '',
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    variant: {
+        type: String,
+        default: 'glass',
+    },
+});
+
+const variantStyles = {
+    glass: {
+        wrapper: 'rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg',
+        eyebrow: 'text-emerald-200',
+        description: 'text-emerald-200',
+    },
+    light: {
+        wrapper: 'rounded-2xl border border-slate-200 bg-white p-6 text-slate-800 shadow-lg',
+        eyebrow: 'text-emerald-500',
+        description: 'text-slate-500',
+    },
+};
+
+const wrapperClass = computed(() => variantStyles[props.variant]?.wrapper || variantStyles.glass.wrapper);
+const eyebrowClass = computed(() => variantStyles[props.variant]?.eyebrow || variantStyles.glass.eyebrow);
+const descriptionClass = computed(() => variantStyles[props.variant]?.description || variantStyles.glass.description);
+
+const hasDescriptionSlot = computed(() => !!useSlots().description);
+</script>

--- a/resources/js/Pages/Clients/Create.vue
+++ b/resources/js/Pages/Clients/Create.vue
@@ -1,52 +1,55 @@
 <template>
     <AppLayout>
-        <div class="container bg-gray-50 w-full min-h-screen mx-auto p-6">
-            <h1 class="text-2xl font-bold mb-6">Crear Nuevo Cliente</h1>
-            <form @submit.prevent="createClient">
+        <div class="min-h-screen bg-slate-950">
+            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-5xl mx-auto px-6 pt-10">
+                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                        <div>
+                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Nuevo cliente</p>
+                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear cliente</h1>
+                            <p class="text-sm text-emerald-200 mt-2">Completa los datos para sumar un nuevo cliente a tu cartera.</p>
+                        </div>
+                        <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            Volver al listado
+                        </NavLink>
+                    </div>
+                </div>
+            </div>
 
-                <div class="mb-4">
-                    <label for="name" class="block text-gray-700">Nombre del Cliente</label>
-                    <input v-model="form.name" id="name" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="nif" class="block text-gray-700">NIF</label>
-                    <input v-model="form.nif" id="nif" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="bank" class="block text-gray-700">Banco</label>
-                    <input v-model="form.bank" id="bank" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="phone" class="block text-gray-700">Teléfono</label>
-                    <input v-model="form.phone" id="phone" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="email" class="block text-gray-700">Email</label>
-                    <input v-model="form.email" id="email" type="email" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="address" class="block text-gray-700">Dirección</label>
-                    <input v-model="form.address" id="address" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <button type="submit" class="bg-blue-900  hover:bg-blue-500 text-white font-bold py-2 px-4 rounded">
-                    <SaveIcon class="w-5 h-5 stroke-gray-300 "/>
-                </button>
-            </form>
+            <div class="max-w-5xl mx-auto px-6 -mt-16 pb-16">
+                <Panel title="Datos del cliente" description="Los campos marcados como obligatorios garantizan una facturación sin incidencias.">
+                    <ClientForm
+                        :form="form"
+                        :processing="form.processing"
+                        submit-label="Crear cliente"
+                        :company-name="props.company?.name ?? 'Empresa asignada'"
+                        @submit="submit"
+                        @cancel="goBack"
+                        :cancel-href="route('clients.index')"
+                    />
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import { reactive } from 'vue';
-import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import Panel from '@/Components/UI/Panel.vue';
+import ClientForm from '@/Components/Clients/ClientForm.vue';
+import NavLink from '@/Components/NavLink.vue';
+import { useForm } from '@inertiajs/vue3';
+import { Inertia } from '@inertiajs/inertia';
 
 const props = defineProps({
-    company: Object,
+    company: {
+        type: Object,
+        default: () => ({}),
+    },
 });
-const form = reactive({
-    company_id:props.company.id,
+
+const form = useForm({
+    company_id: props.company.id || '',
     name: '',
     nif: '',
     bank: '',
@@ -55,16 +58,18 @@ const form = reactive({
     address: '',
 });
 
-const createClient = async () => {
-    try {
-        await Inertia.post(route('clients.store'), form);
-        Inertia.visit(route('clients')); // Redirige a la lista de clientes después de crear
-    } catch (error) {
-        console.error('Error al crear el cliente:', error);
-    }
-};
-</script>
+function submit() {
+    form.post(route('clients.store'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset('name', 'nif', 'bank', 'phone', 'email', 'address'),
+    });
+}
 
-<style scoped>
-/* Estilos adicionales si es necesario */
-</style>
+function goBack(href) {
+    if (href) {
+        Inertia.visit(href);
+        return;
+    }
+    window.history.back();
+}
+</script>

--- a/resources/js/Pages/Clients/Edit.vue
+++ b/resources/js/Pages/Clients/Edit.vue
@@ -1,51 +1,58 @@
 <template>
     <AppLayout>
-        <div class="container mx-auto p-6">
-            <h1 class="text-2xl font-bold mb-6">Editar Cliente</h1>
-            <form @submit.prevent="updateClient">
+        <div class="min-h-screen bg-slate-950">
+            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-5xl mx-auto px-6 pt-10">
+                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                        <div>
+                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Editar cliente</p>
+                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Actualiza la información</h1>
+                            <p class="text-sm text-emerald-200 mt-2">Mantén los datos al día para garantizar una comunicación fluida.</p>
+                        </div>
+                        <NavLink :href="route('clients.show', props.client.id)" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            Ver ficha
+                        </NavLink>
+                    </div>
+                </div>
+            </div>
 
-                <div class="mb-4">
-                    <label for="name" class="block text-gray-700">Nombre del Cliente</label>
-                    <input v-model="form.name" id="name" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="nif" class="block text-gray-700">NIF</label>
-                    <input v-model="form.nif" id="nif" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="bank" class="block text-gray-700">Banco</label>
-                    <input v-model="form.bank" id="bank" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="phone" class="block text-gray-700">Teléfono</label>
-                    <input v-model="form.phone" id="phone" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="email" class="block text-gray-700">Email</label>
-                    <input v-model="form.email" id="email" type="email" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <div class="mb-4">
-                    <label for="address" class="block text-gray-700">Dirección</label>
-                    <input v-model="form.address" id="address" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
-                </div>
-                <button type="submit" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
-                    Actualizar Cliente
-                </button>
-            </form>
+            <div class="max-w-5xl mx-auto px-6 -mt-16 pb-16">
+                <Panel title="Datos del cliente" description="Revisa y confirma que toda la información sea correcta.">
+                    <ClientForm
+                        :form="form"
+                        :processing="form.processing"
+                        submit-label="Guardar cambios"
+                        :companies="props.companies"
+                        @submit="submit"
+                        @cancel="goBack"
+                        :cancel-href="route('clients.show', props.client.id)"
+                    />
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import { reactive, onMounted } from 'vue';
-import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import Panel from '@/Components/UI/Panel.vue';
+import ClientForm from '@/Components/Clients/ClientForm.vue';
+import NavLink from '@/Components/NavLink.vue';
+import { useForm } from '@inertiajs/vue3';
+import { Inertia } from '@inertiajs/inertia';
 
 const props = defineProps({
-    client: Object,
+    client: {
+        type: Object,
+        required: true,
+    },
+    companies: {
+        type: Array,
+        default: () => [],
+    },
 });
 
-const form = reactive({
+const form = useForm({
     company_id: props.client.company_id || '',
     name: props.client.name || '',
     nif: props.client.nif || '',
@@ -55,23 +62,17 @@ const form = reactive({
     address: props.client.address || '',
 });
 
-onMounted(() => {
-    if (!props.client) {
-        // Manejar el caso en el que el cliente no se pasa como prop (por ejemplo, cuando no se ha cargado)
-        console.error('Cliente no proporcionado.');
-    }
-});
+function submit() {
+    form.put(route('clients.update', props.client.id), {
+        preserveScroll: true,
+    });
+}
 
-const updateClient = async () => {
-    try {
-        await Inertia.put(route('clients.update', props.client.id), form);
-        Inertia.visit(route('clients')); // Redirige a la lista de clientes después de actualizar
-    } catch (error) {
-        console.error('Error al actualizar el cliente:', error);
+function goBack(href) {
+    if (href) {
+        Inertia.visit(href);
+        return;
     }
-};
+    window.history.back();
+}
 </script>
-
-<style scoped>
-/* Estilos adicionales si es necesario */
-</style>

--- a/resources/js/Pages/Clients/Index.vue
+++ b/resources/js/Pages/Clients/Index.vue
@@ -1,0 +1,222 @@
+<template>
+    <AppLayout>
+        <div class="min-h-screen bg-slate-950">
+            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                        <div>
+                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Gestión de clientes</p>
+                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Clientes de la compañía</h1>
+                            <p class="text-sm text-emerald-200 mt-2">Consulta, filtra y administra tu cartera de clientes desde un único lugar.</p>
+                        </div>
+                        <div class="flex flex-wrap gap-3">
+                            <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                                <AddIcon class="w-4 h-4" /> Nuevo cliente
+                            </NavLink>
+                            <NavLink :href="route('dashboard.clients')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                                <DashboardIcon class="w-4 h-4" /> Ver dashboard
+                            </NavLink>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <SummaryCard v-for="card in summaryCards" :key="card.eyebrow" :eyebrow="card.eyebrow" :value="card.value" :description="card.description" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <Panel title="Filtros" description="Refina la lista aplicando varios criterios.">
+                    <template #actions>
+                        <button @click="resetFilters" class="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
+                            Reiniciar filtros
+                        </button>
+                    </template>
+                    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+                        <div v-for="field in filterFields" :key="field.id">
+                            <label :for="field.id" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">{{ field.label }}</label>
+                            <component
+                                :is="field.component"
+                                :id="field.id"
+                                v-model="field.model.value"
+                                v-bind="field.props"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            >
+                                <option v-for="option in field.options" :key="option.value" :value="option.value">
+                                    {{ option.label }}
+                                </option>
+                            </component>
+                        </div>
+                    </div>
+                </Panel>
+
+                <Panel title="Listado de clientes" description="Accede rápidamente al detalle, edición y eliminación." :header-border="true">
+                    <DataTable
+                        :columns="tableColumns"
+                        :items="filteredClients"
+                        empty-message="No hay clientes que coincidan con los criterios actuales."
+                        caption="Tabla de clientes"
+                    >
+                        <template #row="{ item: client }">
+                            <td class="py-4 font-semibold text-slate-700">#{{ client.id }}</td>
+                            <td class="py-4">
+                                <p class="font-medium text-slate-700">{{ client.name }}</p>
+                                <p class="text-xs text-slate-400 mt-1">{{ statusCopy(client.status) }}</p>
+                            </td>
+                            <td class="py-4">{{ client.email || '—' }}</td>
+                            <td class="py-4">{{ client.phone || '—' }}</td>
+                            <td class="py-4">{{ client.nif || '—' }}</td>
+                            <td class="py-4">
+                                <div class="flex items-center justify-end gap-3 text-slate-500">
+                                    <NavLink :href="route('clients.show', client.id)" class="hover:text-blue-500 transition" aria-label="Ver cliente">
+                                        <InfoIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <NavLink :href="route('clients.edit', client.id)" class="hover:text-amber-500 transition" aria-label="Editar cliente">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button type="button" @click="deleteClient(client.id)" class="hover:text-rose-500 transition" aria-label="Eliminar cliente">
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </template>
+                    </DataTable>
+                </Panel>
+            </div>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import SummaryCard from '@/Components/UI/SummaryCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
+import DataTable from '@/Components/UI/DataTable.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import DashboardIcon from '@/Components/Icons/DashboardIcon.vue';
+
+const props = defineProps({
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const nameFilter = ref('');
+const phoneFilter = ref('');
+const nifFilter = ref('');
+const statusFilter = ref('');
+
+const filterFields = [
+    {
+        id: 'nameFilter',
+        label: 'Nombre',
+        model: nameFilter,
+        component: 'input',
+        props: { type: 'text', placeholder: 'Introduce un nombre' },
+    },
+    {
+        id: 'phoneFilter',
+        label: 'Teléfono',
+        model: phoneFilter,
+        component: 'input',
+        props: { type: 'text', placeholder: 'Introduce un teléfono' },
+    },
+    {
+        id: 'nifFilter',
+        label: 'NIF',
+        model: nifFilter,
+        component: 'input',
+        props: { type: 'text', placeholder: 'Introduce un NIF' },
+    },
+    {
+        id: 'statusFilter',
+        label: 'Estado',
+        model: statusFilter,
+        component: 'select',
+        props: {},
+        options: [
+            { value: '', label: 'Todos' },
+            { value: 'active', label: 'Activo' },
+            { value: 'inactive', label: 'Inactivo' },
+            { value: 'unknown', label: 'Sin estado' },
+        ],
+    },
+];
+
+const filteredClients = computed(() => {
+    return props.clients.filter(client => {
+        const nameMatches = !nameFilter.value || (client.name ?? '').toLowerCase().includes(nameFilter.value.toLowerCase());
+        const phoneMatches = !phoneFilter.value || (client.phone ?? '').includes(phoneFilter.value);
+        const nifMatches = !nifFilter.value || (client.nif ?? '').toLowerCase().includes(nifFilter.value.toLowerCase());
+        const statusValue = client.status ?? 'unknown';
+        const statusMatches = !statusFilter.value || statusFilter.value === statusValue;
+        return nameMatches && phoneMatches && nifMatches && statusMatches;
+    });
+});
+
+const activeClients = computed(() => props.clients.filter(client => client.status === 'active').length);
+const inactiveClients = computed(() => props.clients.filter(client => client.status === 'inactive').length);
+
+const summaryCards = computed(() => [
+    {
+        eyebrow: 'Clientes totales',
+        value: props.clients.length,
+        description: `${activeClients.value} activos`,
+    },
+    {
+        eyebrow: 'Clientes inactivos',
+        value: inactiveClients.value,
+        description: `${Math.round(props.clients.length ? (inactiveClients.value / props.clients.length) * 100 : 0)}% tasa de baja`,
+    },
+    {
+        eyebrow: 'Datos de contacto',
+        value: filteredClients.value.filter(client => client.email || client.phone).length,
+        description: 'Clientes con correo o teléfono registrado',
+    },
+    {
+        eyebrow: 'Clientes sin estado',
+        value: props.clients.filter(client => !client.status).length,
+        description: 'Pendientes de clasificar',
+    },
+]);
+
+const tableColumns = [
+    { key: 'id', label: 'ID' },
+    { key: 'name', label: 'Nombre' },
+    { key: 'email', label: 'Correo' },
+    { key: 'phone', label: 'Teléfono' },
+    { key: 'nif', label: 'NIF' },
+    { key: 'actions', label: 'Acciones', align: 'right' },
+];
+
+function resetFilters() {
+    nameFilter.value = '';
+    phoneFilter.value = '';
+    nifFilter.value = '';
+    statusFilter.value = '';
+}
+
+function deleteClient(id) {
+    if (confirm('¿Deseas eliminar este cliente?')) {
+        Inertia.delete(route('clients.destroy', id));
+    }
+}
+
+function statusCopy(status) {
+    switch (status) {
+        case 'active':
+            return 'Activo';
+        case 'inactive':
+            return 'Inactivo';
+        default:
+            return 'Sin estado';
+    }
+}
+</script>

--- a/resources/js/Pages/Clients/Show.vue
+++ b/resources/js/Pages/Clients/Show.vue
@@ -1,153 +1,127 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Presupuestos</h2>
-                        <p class="text-blue-300 text-2xl">{{ filteredBudgets.length }}</p>
+        <div class="min-h-screen bg-slate-950">
+            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-6xl mx-auto px-6 pt-10">
+                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                        <div>
+                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Ficha de cliente</p>
+                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">{{ client.name }}</h1>
+                            <p class="text-sm text-emerald-200 mt-2">Visualiza la información clave y el historial de presupuestos y facturas.</p>
+                        </div>
+                        <div class="flex flex-wrap gap-3">
+                            <NavLink :href="route('clients.edit', client.id)" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                                Editar cliente
+                            </NavLink>
+                            <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                                Volver al listado
+                            </NavLink>
+                        </div>
                     </div>
-                </div>
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Facturas</h2>
-                        <p class="text-blue-300 text-2xl">{{ filteredInvoices.length }}</p>
-                    </div>
-                </div>
-<!--                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">-->
-<!--                    <div>-->
-<!--                        <h2 class="text-lg text-blue-500 font-semibold">Total Clientes</h2>-->
-<!--                        <p class="text-blue-300 text-2xl">{{ clients.length }}</p>-->
-<!--                    </div>-->
-<!--                </div>-->
-            </div>
 
-            <!-- Información del cliente -->
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h2 class="text-2xl text-blue-500 font-bold">Detalles del Cliente</h2>
-                <div class="grid grid-cols-2 gap-4 mt-4">
-                    <p><strong>Nombre:</strong> {{ client.name }}</p>
-                    <p><strong>NIF:</strong> {{ client.nif }}</p>
-                    <p><strong>Email:</strong> {{ client.email }}</p>
-                    <p><strong>Teléfono:</strong> {{ client.phone }}</p>
-                    <p><strong>Numero de cuenta:</strong> {{ client.bank }}</p>
-                    <p><strong>Dirección:</strong> {{ client.address }}</p>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 mt-10">
+                        <SummaryCard eyebrow="Presupuestos" :value="filteredBudgets.length" :description="`Importe total €${totalBudgetAmount}`" />
+                        <SummaryCard eyebrow="Facturas" :value="filteredInvoices.length" :description="`Importe total €${totalInvoiceAmount}`" />
+                        <SummaryCard eyebrow="Estado del cliente" :value="statusCopy(client.status)" description="Situación actual" />
+                        <SummaryCard eyebrow="Última actividad" :value="lastActivity" description="Último documento registrado" />
+                    </div>
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <!-- Sección de presupuestos -->
-                <div>
-                    <h3 class="text-xl font-semibold mb-4">Presupuestos</h3>
-                    <div class="bg-white p-4 rounded-lg shadow-md mb-6">
-                        <div class="flex flex-wrap gap-4 mb-4">
-                            <!-- Filtro por estado -->
+            <div class="max-w-6xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <Panel title="Datos generales" description="Información de contacto y datos fiscales del cliente.">
+                    <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-6">
+                        <div v-for="detail in clientDetails" :key="detail.label" class="rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
+                            <dt class="text-xs uppercase tracking-[0.25em] text-slate-400">{{ detail.label }}</dt>
+                            <dd class="mt-2 text-base font-medium text-slate-700">{{ detail.value || '—' }}</dd>
+                        </div>
+                    </dl>
+                </Panel>
+
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                    <Panel title="Presupuestos" description="Filtra los presupuestos por estado o rango de fechas.">
+                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                             <div>
-                                <label for="budgetStatusFilter" class="block text-sm text-blue-500 font-semibold">Estado</label>
-                                <select v-model="selectedBudgetStatus" id="budgetStatusFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm">
+                                <label for="budgetStatusFilter" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Estado</label>
+                                <select id="budgetStatusFilter" v-model="selectedBudgetStatus" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200">
                                     <option value="">Todos</option>
                                     <option value="pending">Pendiente</option>
                                     <option value="approved">Aprobado</option>
                                     <option value="rejected">Rechazado</option>
                                 </select>
                             </div>
-
-                            <!-- Filtro por rango de fechas -->
                             <div>
-                                <label for="budgetStartDate" class="block text-sm text-blue-500 font-semibold">Fecha de Inicio</label>
-                                <input type="date" v-model="budgetStartDate" id="budgetStartDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
+                                <label for="budgetStartDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha inicio</label>
+                                <input id="budgetStartDate" type="date" v-model="budgetStartDate" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" />
                             </div>
-
                             <div>
-                                <label for="budgetEndDate" class="block text-sm text-blue-500 font-semibold">Fecha de Finalización</label>
-                                <input type="date" v-model="budgetEndDate" id="budgetEndDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
+                                <label for="budgetEndDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha fin</label>
+                                <input id="budgetEndDate" type="date" v-model="budgetEndDate" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" />
                             </div>
                         </div>
-
-                        <!-- Tabla de presupuestos -->
-                        <table class="w-full table-auto">
-                            <thead class="bg-gray-100">
-                            <tr>
-                                <th class="px-4 py-2 text-left">Identificador</th>
-                                <th class="px-4 py-2 text-left">Fecha</th>
-                                <th class="px-4 py-2 text-left">Estado</th>
-                                <th class="px-4 py-2 text-left">Total</th>
-                                <th class="px-4 py-2 text-left">Acciones</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr v-for="budget in filteredBudgets" :key="budget.id" class="border-t">
-                                <td class="px-4 py-2">{{ budget.name }}</td>
-                                <td class="px-4 py-2">{{ budget.date }}</td>
-                                <td class="px-4 py-2">{{ budget.state }}</td>
-                                <td class="px-4 py-2">{{ budget.total }}</td>
-                                <td class="px-4 py-2">
-                                    <NavLink :href="route('budgets.show', budget.id)" class="text-blue-500">
+                        <DataTable
+                            :columns="budgetColumns"
+                            :items="filteredBudgets"
+                            empty-message="No hay presupuestos que coincidan con el filtro seleccionado."
+                            caption="Tabla de presupuestos"
+                        >
+                            <template #row="{ item: budget }">
+                                <td class="py-4 font-semibold text-slate-700">{{ budget.name }}</td>
+                                <td class="py-4">{{ formatDate(budget.date) }}</td>
+                                <td class="py-4">
+                                    <span :class="statusPillClass(budget.state)">{{ statusCopy(budget.state) }}</span>
+                                </td>
+                                <td class="py-4">€{{ Number(budget.total ?? 0).toFixed(2) }}</td>
+                                <td class="py-4">
+                                    <NavLink :href="route('budgets.show', budget.id)" class="flex justify-end text-blue-500 hover:text-blue-600 transition" aria-label="Ver presupuesto">
                                         <InfoIcon class="w-5 h-5" />
                                     </NavLink>
                                 </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                            </template>
+                        </DataTable>
+                    </Panel>
 
-                <!-- Sección de facturas -->
-                <div>
-                    <h3 class="text-xl font-semibold mb-4">Facturas</h3>
-                    <div class="bg-white p-4 rounded-lg shadow-md">
-                        <div class="flex flex-wrap gap-4 mb-4">
-                            <!-- Filtro por estado -->
+                    <Panel title="Facturas" description="Controla las facturas emitidas y su estado de cobro.">
+                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                             <div>
-                                <label for="invoiceStatusFilter" class="block text-sm text-blue-500 font-semibold">Estado</label>
-                                <select v-model="selectedInvoiceStatus" id="invoiceStatusFilter" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm">
+                                <label for="invoiceStatusFilter" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Estado</label>
+                                <select id="invoiceStatusFilter" v-model="selectedInvoiceStatus" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200">
                                     <option value="">Todos</option>
-                                    <option value="paid">Pagado</option>
+                                    <option value="paid">Pagada</option>
                                     <option value="pending">Pendiente</option>
-                                    <option value="cancelled">Cancelado</option>
+                                    <option value="cancelled">Cancelada</option>
                                 </select>
                             </div>
-
-                            <!-- Filtro por rango de fechas -->
                             <div>
-                                <label for="invoiceStartDate" class="block text-sm text-blue-500 font-semibold">Fecha de Inicio</label>
-                                <input type="date" v-model="invoiceStartDate" id="invoiceStartDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
+                                <label for="invoiceStartDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha inicio</label>
+                                <input id="invoiceStartDate" type="date" v-model="invoiceStartDate" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" />
                             </div>
-
                             <div>
-                                <label for="invoiceEndDate" class="block text-sm text-blue-500 font-semibold">Fecha de Finalización</label>
-                                <input type="date" v-model="invoiceEndDate" id="invoiceEndDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
+                                <label for="invoiceEndDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha fin</label>
+                                <input id="invoiceEndDate" type="date" v-model="invoiceEndDate" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" />
                             </div>
                         </div>
-
-                        <!-- Tabla de facturas -->
-                        <table class="w-full table-auto">
-                            <thead class="bg-gray-100">
-                            <tr>
-                                <th class="px-4 py-2 text-left">Identificador</th>
-                                <th class="px-4 py-2 text-left">Fecha</th>
-                                <th class="px-4 py-2 text-left">Estado</th>
-                                <th class="px-4 py-2 text-left">Total</th>
-                                <th class="px-4 py-2 text-left">Acciones</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr v-for="invoice in filteredInvoices" :key="invoice.id" class="border-t">
-                                <td class="px-4 py-2">{{ invoice.name }}</td>
-                                <td class="px-4 py-2">{{ invoice.date }}</td>
-                                <td class="px-4 py-2">{{ invoice.state }}</td>
-                                <td class="px-4 py-2">{{ invoice.total }}</td>
-                                <td class="px-4 py-2">
-                                    <NavLink :href="route('invoices.show', invoice.id)" class="text-blue-500">
+                        <DataTable
+                            :columns="invoiceColumns"
+                            :items="filteredInvoices"
+                            empty-message="No hay facturas que coincidan con el filtro seleccionado."
+                            caption="Tabla de facturas"
+                        >
+                            <template #row="{ item: invoice }">
+                                <td class="py-4 font-semibold text-slate-700">{{ invoice.name }}</td>
+                                <td class="py-4">{{ formatDate(invoice.date) }}</td>
+                                <td class="py-4">
+                                    <span :class="statusPillClass(invoice.state)">{{ statusCopy(invoice.state) }}</span>
+                                </td>
+                                <td class="py-4">€{{ Number(invoice.total ?? 0).toFixed(2) }}</td>
+                                <td class="py-4">
+                                    <NavLink :href="route('invoices.show', invoice.id)" class="flex justify-end text-blue-500 hover:text-blue-600 transition" aria-label="Ver factura">
                                         <InfoIcon class="w-5 h-5" />
                                     </NavLink>
                                 </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                            </template>
+                        </DataTable>
+                    </Panel>
                 </div>
             </div>
         </div>
@@ -155,17 +129,30 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import { computed, ref } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from "@/Components/NavLink.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
+import NavLink from '@/Components/NavLink.vue';
+import SummaryCard from '@/Components/UI/SummaryCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
+import DataTable from '@/Components/UI/DataTable.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
 
 const props = defineProps({
-    client: Object,
-    budgets: Array,
-    invoices: Array,
-    clients: Array,
+    client: {
+        type: Object,
+        required: true,
+    },
+    budgets: {
+        type: Array,
+        default: () => [],
+    },
+    invoices: {
+        type: Array,
+        default: () => [],
+    },
 });
+
+const client = computed(() => props.client);
 
 const selectedBudgetStatus = ref('');
 const budgetStartDate = ref('');
@@ -174,7 +161,6 @@ const selectedInvoiceStatus = ref('');
 const invoiceStartDate = ref('');
 const invoiceEndDate = ref('');
 
-// Filtrar presupuestos
 const filteredBudgets = computed(() => {
     return props.budgets.filter(budget => {
         const statusMatches = !selectedBudgetStatus.value || budget.state === selectedBudgetStatus.value;
@@ -184,7 +170,6 @@ const filteredBudgets = computed(() => {
     });
 });
 
-// Filtrar facturas
 const filteredInvoices = computed(() => {
     return props.invoices.filter(invoice => {
         const statusMatches = !selectedInvoiceStatus.value || invoice.state === selectedInvoiceStatus.value;
@@ -193,4 +178,90 @@ const filteredInvoices = computed(() => {
         return statusMatches && startDateMatches && endDateMatches;
     });
 });
+
+const totalBudgetAmount = computed(() => filteredBudgets.value.reduce((acc, budget) => acc + Number(budget.total ?? 0), 0).toFixed(2));
+const totalInvoiceAmount = computed(() => filteredInvoices.value.reduce((acc, invoice) => acc + Number(invoice.total ?? 0), 0).toFixed(2));
+
+const lastActivity = computed(() => {
+    const combined = [...props.budgets, ...props.invoices]
+        .filter(item => item.date)
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
+    if (!combined.length) {
+        return 'Sin actividad';
+    }
+    const latest = combined[0];
+    const amount = latest.total ? ` · €${Number(latest.total).toFixed(2)}` : '';
+    return `${formatDate(latest.date)}${amount}`;
+});
+
+const clientDetails = computed(() => [
+    { label: 'Nombre', value: client.value.name },
+    { label: 'NIF', value: client.value.nif },
+    { label: 'Email', value: client.value.email },
+    { label: 'Teléfono', value: client.value.phone },
+    { label: 'Banco', value: client.value.bank },
+    { label: 'Dirección', value: client.value.address },
+]);
+
+const budgetColumns = [
+    { key: 'name', label: 'Identificador' },
+    { key: 'date', label: 'Fecha' },
+    { key: 'state', label: 'Estado' },
+    { key: 'total', label: 'Total' },
+    { key: 'actions', label: 'Acciones', align: 'right' },
+];
+
+const invoiceColumns = [
+    { key: 'name', label: 'Identificador' },
+    { key: 'date', label: 'Fecha' },
+    { key: 'state', label: 'Estado' },
+    { key: 'total', label: 'Total' },
+    { key: 'actions', label: 'Acciones', align: 'right' },
+];
+
+function formatDate(value) {
+    if (!value) {
+        return '—';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return date.toLocaleDateString();
+}
+
+function statusCopy(status) {
+    switch (status) {
+        case 'active':
+            return 'Activo';
+        case 'inactive':
+            return 'Inactivo';
+        case 'pending':
+            return 'Pendiente';
+        case 'approved':
+            return 'Aprobado';
+        case 'rejected':
+            return 'Rechazado';
+        case 'paid':
+            return 'Pagada';
+        case 'cancelled':
+            return 'Cancelada';
+        default:
+            return 'Sin estado';
+    }
+}
+
+function statusPillClass(status) {
+    const base = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold capitalize';
+    const mapping = {
+        active: 'bg-emerald-100 text-emerald-700',
+        approved: 'bg-emerald-100 text-emerald-700',
+        paid: 'bg-emerald-100 text-emerald-700',
+        pending: 'bg-amber-100 text-amber-700',
+        inactive: 'bg-slate-200 text-slate-600',
+        rejected: 'bg-rose-100 text-rose-700',
+        cancelled: 'bg-rose-100 text-rose-700',
+    };
+    return `${base} ${mapping[status] || 'bg-slate-200 text-slate-600'}`;
+}
 </script>

--- a/resources/js/Pages/DashboardClientes.vue
+++ b/resources/js/Pages/DashboardClientes.vue
@@ -15,119 +15,100 @@
                     </div>
 
                     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Clientes totales</p>
-                            <p class="text-3xl font-semibold mt-2">{{ filteredClients.length }}</p>
-                            <p class="text-sm text-emerald-200 mt-3">{{ activeClients }} activos</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Clientes inactivos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ inactiveClients }}</p>
-                            <p class="text-sm text-emerald-200 mt-3">{{ churnRate }}% tasa de baja</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Ingresos acumulados</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ totalBilled }}</p>
-                            <p class="text-sm text-emerald-200 mt-3">Ticket medio €{{ averageInvoice }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Facturas cobradas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ paidInvoicesPercentage }}%</p>
-                            <p class="text-sm text-emerald-200 mt-3">{{ paidInvoices }} de {{ props.invoices.length }}</p>
-                        </div>
+                        <SummaryCard
+                            v-for="card in summaryCards"
+                            :key="card.eyebrow"
+                            :eyebrow="card.eyebrow"
+                            :value="card.value"
+                            :description="card.description"
+                        />
                     </div>
                 </div>
             </div>
 
             <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="bg-white rounded-3xl shadow-xl p-6">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Filtrado inteligente</h2>
-                            <p class="text-sm text-slate-500 mt-1">Encuentra el cliente ideal combinando filtros avanzados.</p>
-                        </div>
+                <Panel title="Filtrado inteligente" description="Encuentra el cliente ideal combinando filtros avanzados.">
+                    <template #actions>
                         <button @click="clearFilters" class="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
                             Limpiar filtros
                         </button>
-                    </div>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 pt-6">
-                        <div>
-                            <label for="nameFilter" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Nombre</label>
-                            <input id="nameFilter" v-model="nameFilter" type="text" class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" placeholder="Buscar por nombre" />
-                        </div>
-                        <div>
-                            <label for="phoneFilter" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Teléfono</label>
-                            <input id="phoneFilter" v-model="phoneFilter" type="text" class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" placeholder="Buscar por teléfono" />
-                        </div>
-                        <div>
-                            <label for="nifFilter" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">NIF</label>
-                            <input id="nifFilter" v-model="nifFilter" type="text" class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200" placeholder="Buscar por NIF" />
+                    </template>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div v-for="field in filterFields" :key="field.id">
+                            <label :for="field.id" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">{{ field.label }}</label>
+                            <input
+                                :id="field.id"
+                                v-model="field.model.value"
+                                :type="field.type"
+                                :placeholder="field.placeholder"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            />
                         </div>
                     </div>
-                </div>
+                </Panel>
 
                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="xl:col-span-2 bg-white rounded-3xl shadow-xl p-6">
-                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
-                            <div>
-                                <h2 class="text-xl font-semibold text-slate-800">Clientes</h2>
-                                <p class="text-sm text-slate-500 mt-1">Listado actualizado con accesos rápidos a cada ficha.</p>
-                            </div>
-                        </div>
-                        <div class="overflow-x-auto pt-6">
-                            <table class="w-full text-left">
-                                <thead>
-                                    <tr class="text-xs uppercase tracking-widest text-slate-400">
-                                        <th class="pb-3">ID</th>
-                                        <th class="pb-3">Nombre</th>
-                                        <th class="pb-3">Correo</th>
-                                        <th class="pb-3">Teléfono</th>
-                                        <th class="pb-3 text-right">Acciones</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
-                                    <tr v-for="client in filteredClients" :key="client.id" class="hover:bg-slate-50/80 transition">
-                                        <td class="py-4 font-semibold text-slate-700">#{{ client.id }}</td>
-                                        <td class="py-4">
-                                            <p class="font-medium text-slate-700">{{ client.name }}</p>
-                                            <p class="text-xs text-slate-400 mt-1">{{ statusCopy(client.status) }}</p>
-                                        </td>
-                                        <td class="py-4">{{ client.email }}</td>
-                                        <td class="py-4">{{ client.phone }}</td>
-                                        <td class="py-4">
-                                            <div class="flex items-center justify-end gap-3 text-slate-500">
-                                                <NavLink :href="route('clients.show', client.id)" class="hover:text-blue-500 transition"><InfoIcon class="w-5 h-5" /></NavLink>
-                                                <NavLink :href="route('clients.edit', client.id)" class="hover:text-amber-500 transition"><EditIcon class="w-5 h-5" /></NavLink>
-                                                <button @click="deleteClient(client.id)" class="hover:text-rose-500 transition">
-                                                    <DeleteIcon class="w-5 h-5" />
-                                                </button>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr v-if="filteredClients.length === 0">
-                                        <td colspan="5" class="py-6 text-center text-slate-400">No se han encontrado clientes con los filtros actuales.</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                    <Panel
+                        class="xl:col-span-2"
+                        title="Clientes"
+                        description="Listado actualizado con accesos rápidos a cada ficha."
+                    >
+                        <DataTable
+                            :columns="clientTableColumns"
+                            :items="filteredClients"
+                            empty-message="No se han encontrado clientes con los filtros actuales."
+                            caption="Listado de clientes"
+                        >
+                            <template #row="{ item: client }">
+                                <td class="py-4 font-semibold text-slate-700">#{{ client.id }}</td>
+                                <td class="py-4">
+                                    <p class="font-medium text-slate-700">{{ client.name }}</p>
+                                    <p class="text-xs text-slate-400 mt-1">{{ statusCopy(client.status) }}</p>
+                                </td>
+                                <td class="py-4">{{ client.email }}</td>
+                                <td class="py-4">{{ client.phone }}</td>
+                                <td class="py-4">
+                                    <div class="flex items-center justify-end gap-3 text-slate-500">
+                                        <NavLink
+                                            :href="route('clients.show', client.id)"
+                                            class="hover:text-blue-500 transition"
+                                            aria-label="Ver detalles del cliente"
+                                        >
+                                            <InfoIcon class="w-5 h-5" />
+                                        </NavLink>
+                                        <NavLink
+                                            :href="route('clients.edit', client.id)"
+                                            class="hover:text-amber-500 transition"
+                                            aria-label="Editar cliente"
+                                        >
+                                            <EditIcon class="w-5 h-5" />
+                                        </NavLink>
+                                        <button
+                                            type="button"
+                                            @click="deleteClient(client.id)"
+                                            class="hover:text-rose-500 transition"
+                                            aria-label="Eliminar cliente"
+                                        >
+                                            <DeleteIcon class="w-5 h-5" />
+                                        </button>
+                                    </div>
+                                </td>
+                            </template>
+                        </DataTable>
+                    </Panel>
 
                     <div class="space-y-8">
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <h2 class="text-xl font-semibold text-slate-800">Estado de la cartera</h2>
-                            <p class="text-sm text-slate-500">Visualiza la salud actual de tus relaciones comerciales.</p>
+                        <Panel title="Estado de la cartera" description="Visualiza la salud actual de tus relaciones comerciales." :header-border="false">
                             <div class="mt-5">
                                 <DoughnutChart :data="clientStatusChart" />
                             </div>
-                        </div>
+                        </Panel>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <h2 class="text-xl font-semibold text-slate-800">Ingresos por cliente</h2>
-                            <p class="text-sm text-slate-500">Identifica los clientes con mayor contribución económica.</p>
+                        <Panel title="Ingresos por cliente" description="Identifica los clientes con mayor contribución económica." :header-border="false">
                             <div class="mt-5">
                                 <BarChart :data="revenueByClientChart" />
                             </div>
-                        </div>
+                        </Panel>
                     </div>
                 </div>
             </div>
@@ -146,6 +127,9 @@ import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
 import DoughnutChart from '@/Components/DoughnutChart.vue';
 import BarChart from '@/Components/BarChart.vue';
+import SummaryCard from '@/Components/UI/SummaryCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
+import DataTable from '@/Components/UI/DataTable.vue';
 
 const props = defineProps({
     clients: {
@@ -170,6 +154,61 @@ const filteredClients = computed(() => {
         return nameMatch && phoneMatch && nifMatch;
     });
 });
+
+const summaryCards = computed(() => [
+    {
+        eyebrow: 'Clientes totales',
+        value: filteredClients.value.length,
+        description: `${activeClients.value} activos`,
+    },
+    {
+        eyebrow: 'Clientes inactivos',
+        value: inactiveClients.value,
+        description: `${churnRate.value}% tasa de baja`,
+    },
+    {
+        eyebrow: 'Ingresos acumulados',
+        value: `€${totalBilled.value}`,
+        description: `Ticket medio €${averageInvoice.value}`,
+    },
+    {
+        eyebrow: 'Facturas cobradas',
+        value: `${paidInvoicesPercentage.value}%`,
+        description: `${paidInvoices.value} de ${props.invoices.length}`,
+    },
+]);
+
+const filterFields = [
+    {
+        id: 'nameFilter',
+        label: 'Nombre',
+        placeholder: 'Buscar por nombre',
+        type: 'text',
+        model: nameFilter,
+    },
+    {
+        id: 'phoneFilter',
+        label: 'Teléfono',
+        placeholder: 'Buscar por teléfono',
+        type: 'text',
+        model: phoneFilter,
+    },
+    {
+        id: 'nifFilter',
+        label: 'NIF',
+        placeholder: 'Buscar por NIF',
+        type: 'text',
+        model: nifFilter,
+    },
+];
+
+const clientTableColumns = [
+    { key: 'id', label: 'ID' },
+    { key: 'name', label: 'Nombre' },
+    { key: 'email', label: 'Correo' },
+    { key: 'phone', label: 'Teléfono' },
+    { key: 'actions', label: 'Acciones', align: 'right' },
+];
 
 const activeClients = computed(() => props.clients.filter(client => client.status === 'active').length);
 const inactiveClients = computed(() => props.clients.filter(client => client.status === 'inactive').length);


### PR DESCRIPTION
## Summary
- refactor the customer dashboard to catalogue summary cards, filters and data table using shared UI components
- add a modernised clients index plus refreshed create, edit and show pages with consistent styling and empty/error states
- introduce reusable summary card, panel and data table components to align table, list and detail presentations

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de5df439bc8323be4c97ed1dfffc29