### PR TITLE
Align finance module pages with dashboard design

### DIFF
--- a/resources/js/Components/Finance/FinancePageHeader.vue
+++ b/resources/js/Components/Finance/FinancePageHeader.vue
@@ -1,0 +1,64 @@
+<template>
+    <div class="bg-gradient-to-r from-slate-900 via-emerald-700 to-blue-900 pb-24 print:bg-white print:pb-10">
+        <div class="max-w-7xl mx-auto px-6 pt-10">
+            <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                <div class="space-y-2 text-white print:text-slate-900">
+                    <p v-if="eyebrow" class="text-emerald-200 text-xs uppercase tracking-[0.35em] print:text-emerald-700">
+                        {{ eyebrow }}
+                    </p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold">
+                        {{ title }}
+                    </h1>
+                    <p v-if="description" class="text-sm text-emerald-200 max-w-2xl print:text-slate-600">
+                        {{ description }}
+                    </p>
+                </div>
+                <div v-if="$slots.actions" class="flex flex-wrap gap-3 print:hidden">
+                    <slot name="actions" />
+                </div>
+            </div>
+
+            <div v-if="$slots.metrics" class="mt-10">
+                <div :class="metricsGridClass">
+                    <slot name="metrics" />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    eyebrow: {
+        type: String,
+        default: '',
+    },
+    metricsColumns: {
+        type: Number,
+        default: 4,
+    },
+});
+
+const metricsGridClass = computed(() => {
+    const base = 'grid grid-cols-1 gap-5';
+    const variants = {
+        1: `${base}`,
+        2: `${base} sm:grid-cols-2`,
+        3: `${base} sm:grid-cols-2 xl:grid-cols-3`,
+        4: `${base} sm:grid-cols-2 xl:grid-cols-4`,
+        5: `${base} sm:grid-cols-2 xl:grid-cols-5`,
+    };
+
+    return variants[props.metricsColumns] ?? variants[4];
+});
+</script>

--- a/resources/js/Components/Finance/FinanceSummaryCard.vue
+++ b/resources/js/Components/Finance/FinanceSummaryCard.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="rounded-2xl border border-white/15 bg-white/10 backdrop-blur p-6 text-white shadow-lg transition hover:border-emerald-200/50 print:border-slate-200 print:bg-white print:text-slate-900 print:shadow-none">
+        <p v-if="label" class="text-xs uppercase tracking-[0.35em] text-emerald-200 print:text-emerald-600">
+            {{ label }}
+        </p>
+        <div class="mt-3">
+            <slot name="value">
+                <p class="text-3xl font-semibold">
+                    {{ value }}
+                </p>
+            </slot>
+        </div>
+        <p v-if="helper" class="text-sm text-emerald-200 mt-3 print:text-slate-500">
+            {{ helper }}
+        </p>
+        <slot />
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    label: {
+        type: String,
+        default: '',
+    },
+    value: {
+        type: [String, Number],
+        default: '',
+    },
+    helper: {
+        type: String,
+        default: '',
+    },
+});
+</script>

--- a/resources/js/Pages/ExpenseCategories/Index.vue
+++ b/resources/js/Pages/ExpenseCategories/Index.vue
@@ -1,71 +1,202 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Categorías de Gasto</h2>
-                        <p class="text-blue-300 text-2xl">{{ categories.length }}</p>
-                    </div>
-                </div>
-            </div>
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Estructura de gasto"
+                title="Categorías contables"
+                description="Organiza y actualiza la jerarquía de categorías con métricas visuales y un estilo coherente con el dashboard principal."
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('expenseCategories.create')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        <AddIcon class="h-4 w-4" />
+                        <span>Nueva categoría</span>
+                    </NavLink>
+                    <button
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Imprimir resumen
+                    </button>
+                </template>
 
-            <!-- Tabla de categorías de gastos -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('expenseCategories.create')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Nueva Categoría
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-5"/>
-                </NavLink>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Identificador</th>
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="category in categories" :key="category.id" class="border-t">
-                        <td class="px-4 py-2">{{ category.id }}</td>
-                        <td class="px-4 py-2">{{ category.name }}</td>
-                        <td class="px-4 py-2">{{ category.description }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('expenseCategories.show', category.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <NavLink :href="route('expenseCategories.edit', category.id)" class="text-yellow-500 ml-2">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteCategory(category.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
+                <template #metrics>
+                    <FinanceSummaryCard label="Total categorías" :value="categories.length" :helper="`Actualizado: ${new Date().toLocaleDateString('es-ES')}`" />
+                    <FinanceSummaryCard label="Con descripción" :value="categoriesWithDescription" :helper="`${descriptionCoverage}% cobertura`" />
+                    <FinanceSummaryCard label="Promedio de longitud" :value="`${averageDescriptionLength} car.`" :helper="`Más extensa: ${longestCategoryName}`" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Cobertura de documentación</h2>
+                        <p class="text-sm text-slate-500">Identifica el nivel de detalle de cada categoría para garantizar trazabilidad en auditorías.</p>
+                    </header>
+                    <div class="mt-6">
+                        <DoughnutChart :data="descriptionDistributionData" />
+                    </div>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-0">
+                    <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Listado de categorías</h2>
+                            <p class="text-sm text-slate-500">Formato preparado para lectura ágil y exportación en papel.</p>
+                        </div>
+                        <div class="text-right text-sm text-slate-500">
+                            Total: {{ categories.length }}
+                        </div>
+                    </header>
+                    <div class="mt-6 overflow-x-auto print:overflow-visible">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Identificador</th>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Descripción</th>
+                                    <th scope="col" class="px-4 py-3 text-center print:hidden">Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr
+                                    v-for="category in categories"
+                                    :key="category.id"
+                                    class="bg-white/60 transition hover:bg-emerald-50/60"
+                                >
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ category.id }}</td>
+                                    <td class="px-4 py-3">{{ category.name }}</td>
+                                    <td class="px-4 py-3 max-w-xl">
+                                        <p v-if="category.description" class="whitespace-pre-line">{{ category.description }}</p>
+                                        <span v-else class="text-slate-400">Sin descripción</span>
+                                    </td>
+                                    <td class="px-4 py-3 text-center print:hidden">
+                                        <div class="flex justify-center gap-3">
+                                            <NavLink :href="route('expenseCategories.show', category.id)" class="text-slate-500 hover:text-slate-700" title="Ver detalle">
+                                                <InfoIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <NavLink :href="route('expenseCategories.edit', category.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
+                                                <EditIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <button
+                                                type="button"
+                                                @click="deleteCategory(category.id)"
+                                                class="text-rose-500 hover:text-rose-700"
+                                                title="Eliminar"
+                                            >
+                                                <DeleteIcon class="w-5 h-5" />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import DoughnutChart from '@/Components/DoughnutChart.vue';
+import NavLink from '@/Components/NavLink.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
 
 const props = defineProps({
-    categories: Array,
+    categories: {
+        type: Array,
+        default: () => [],
+    },
 });
 
+const categories = computed(() => props.categories ?? []);
+
+const categoriesWithDescription = computed(() => categories.value.filter(category => Boolean(category?.description)).length);
+
+const descriptionCoverage = computed(() => {
+    if (!categories.value.length) {
+        return 0;
+    }
+    return Math.round((categoriesWithDescription.value / categories.value.length) * 100);
+});
+
+const averageDescriptionLength = computed(() => {
+    if (!categoriesWithDescription.value) {
+        return 0;
+    }
+    const totalCharacters = categories.value.reduce((acc, category) => {
+        if (!category?.description) {
+            return acc;
+        }
+        return acc + category.description.length;
+    }, 0);
+
+    return Math.round(totalCharacters / categoriesWithDescription.value);
+});
+
+const longestCategoryName = computed(() => {
+    if (!categories.value.length) {
+        return 'Sin datos';
+    }
+    const longest = categories.value.reduce((acc, category) => {
+        const length = category?.description?.length ?? 0;
+        if (!acc || length > acc.length) {
+            return { length, name: category.name };
+        }
+        return acc;
+    }, null);
+
+    return longest ? longest.name : 'Sin datos';
+});
+
+const descriptionDistributionData = computed(() => {
+    if (!categories.value.length) {
+        return {
+            labels: ['Sin datos'],
+            datasets: [
+                {
+                    data: [1],
+                    backgroundColor: ['rgba(148, 163, 184, 0.45)'],
+                    borderColor: ['rgba(148, 163, 184, 1)'],
+                },
+            ],
+        };
+    }
+
+    const withDescription = categoriesWithDescription.value;
+    const withoutDescription = categories.value.length - withDescription;
+
+    return {
+        labels: ['Con descripción', 'Sin descripción'],
+        datasets: [
+            {
+                data: [withDescription, withoutDescription],
+                backgroundColor: ['rgba(16, 185, 129, 0.45)', 'rgba(148, 163, 184, 0.45)'],
+                borderColor: ['rgba(16, 185, 129, 1)', 'rgba(148, 163, 184, 1)'],
+            },
+        ],
+    };
+});
+
+const printPage = () => {
+    window.print();
+};
+
 const deleteCategory = (id) => {
-    if (confirm("¿Estás seguro de que deseas eliminar esta categoría?")) {
+    if (confirm('¿Estás seguro de que deseas eliminar esta categoría?')) {
         Inertia.delete(route('expenseCategories.destroy', id));
     }
 };

--- a/resources/js/Pages/Expenses/Index.vue
+++ b/resources/js/Pages/Expenses/Index.vue
@@ -1,138 +1,457 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Gastos</h2>
-                        <p class="text-blue-300 text-2xl">{{ filteredExpenses.length }}</p>
-                    </div>
-                </div>
-            </div>
-            <!-- Filtros -->
-            <div class="bg-white p-4 rounded-lg shadow-md mb-6">
-                <h2 class="text-lg text-blue-700 font-semibold mb-4">Filtrar Gastos</h2>
-                <div class="flex space-x-10">
-
-                    <select v-model="selectedPaymentMethod" class="border rounded p-2">
-                        <option value="">Método de Pago</option>
-                        <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">{{ paymentMethod.name }}</option>
-
-                    </select>
-
-                    <input
-                        type="date"
-                        v-model="startDate"
-                        class="border rounded p-2"
-                    />
-                    <input
-                        type="date"
-                        v-model="endDate"
-                        class="border rounded p-2"
-                    />
-                    <select v-model="selectedCategory" class="border rounded p-2">
-                        <option value="">Categoría de Gasto</option>
-                        <option v-for="category in categories" :key="category.id" :value="category.id">{{ category.name }}</option>
-                    </select>
-                    <button @click="deleteFilters" class="bg-red-600 flex font-semibold  text-white rounded p-2">
-                        Limpiar filtros
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Control financiero"
+                title="Gastos operativos"
+                description="Visualiza los gastos con filtros dinámicos, gráficas comparables y tarjetas en línea con el panel contable."
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('expenses.create')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        <AddIcon class="h-4 w-4" />
+                        <span>Registrar gasto</span>
+                    </NavLink>
+                    <button
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Imprimir informe
                     </button>
-                </div>
-            </div>
+                </template>
 
-            <!-- Tabla de gastos -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('expenses.create')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Nuevo Gasto
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-5"/>
-                </NavLink>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Identificador</th>
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Monto</th>
-                        <th class="px-4 py-2 text-left">Fecha</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="expense in filteredExpenses" :key="expense.id" class="border-t">
-                        <td class="px-4 py-2">{{ expense.id }}</td>
-                        <td class="px-4 py-2">{{ expense.name }}</td>
-                        <td class="px-4 py-2">{{ expense.description }}</td>
-                        <td class="px-4 py-2">{{ expense.amount }}</td>
-                        <td class="px-4 py-2">{{ expense.date }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('expenses.show', expense.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <NavLink :href="route('expenses.edit', expense.id)" class="text-yellow-500 ml-2">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteExpense(expense.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
+                <template #metrics>
+                    <FinanceSummaryCard label="Gasto total" :value="formatCurrency(totalGrossAmount)" :helper="`${visibleExpenses.length} registros visibles`" />
+                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(totalNetAmount)" :helper="`IVA acumulado ${formatCurrency(totalTaxAmount)}`" />
+                    <FinanceSummaryCard label="Ticket medio" :value="formatCurrency(averageGrossAmount)" :helper="`Rango ${formatCurrency(lowestExpenseGross)} – ${formatCurrency(highestExpenseGross)}`" />
+                    <FinanceSummaryCard label="Mayor gasto" :value="formatCurrency(highestExpenseGross)" :helper="highestExpenseDescriptor" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="flex flex-col gap-2 border-b border-slate-100 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Filtrar gastos</h2>
+                            <p class="text-sm text-slate-500">Combina filtros para focalizar tus análisis. Las gráficas y totales se recalculan al instante.</p>
+                        </div>
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-xl bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-200"
+                            @click="resetFilters"
+                        >
+                            Limpiar filtros
+                        </button>
+                    </header>
+                    <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        <label class="flex flex-col text-sm font-medium text-slate-600">
+                            Método de pago
+                            <select
+                                v-model="selectedPaymentMethod"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            >
+                                <option value="">Todos</option>
+                                <option
+                                    v-for="paymentMethod in paymentMethods"
+                                    :key="paymentMethod.id"
+                                    :value="String(paymentMethod.id)"
+                                >
+                                    {{ paymentMethod.name }}
+                                </option>
+                            </select>
+                        </label>
+
+                        <label class="flex flex-col text-sm font-medium text-slate-600">
+                            Desde
+                            <input
+                                type="date"
+                                v-model="startDate"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            />
+                        </label>
+
+                        <label class="flex flex-col text-sm font-medium text-slate-600">
+                            Hasta
+                            <input
+                                type="date"
+                                v-model="endDate"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            />
+                        </label>
+
+                        <label class="flex flex-col text-sm font-medium text-slate-600">
+                            Categoría
+                            <select
+                                v-model="selectedCategory"
+                                class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                            >
+                                <option value="">Todas</option>
+                                <option
+                                    v-for="category in categories"
+                                    :key="category.id"
+                                    :value="String(category.id)"
+                                >
+                                    {{ category.name }}
+                                </option>
+                            </select>
+                        </label>
+                    </div>
+                </section>
+
+                <section class="grid grid-cols-1 gap-8 xl:grid-cols-2">
+                    <article class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                        <header class="flex flex-col gap-2 border-b border-slate-100 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                            <div>
+                                <h2 class="text-xl font-semibold text-slate-800">Gasto mensual</h2>
+                                <p class="text-sm text-slate-500">Controla la evolución temporal de los desembolsos seleccionados.</p>
+                            </div>
+                            <div class="flex items-center gap-3 text-sm text-slate-500">
+                                <span class="inline-flex h-2.5 w-2.5 rounded-full bg-rose-500"></span>
+                                Total mensual
+                            </div>
+                        </header>
+                        <div class="mt-6">
+                            <BarChart :data="monthlyExpensesData" />
+                        </div>
+                    </article>
+
+                    <article class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                        <header class="border-b border-slate-100 pb-4">
+                            <h2 class="text-xl font-semibold text-slate-800">Distribución por categoría</h2>
+                            <p class="text-sm text-slate-500">Comprende qué líneas de gasto concentran más recursos.</p>
+                        </header>
+                        <div class="mt-6">
+                            <DoughnutChart :data="categoryDistributionData" />
+                        </div>
+                    </article>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-0">
+                    <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Relación detallada de gastos</h2>
+                            <p class="text-sm text-slate-500">Información preparada para manejar grandes volúmenes y exportar en papel.</p>
+                        </div>
+                        <div class="text-right text-sm text-slate-500">
+                            {{ filteredCountMessage }}
+                        </div>
+                    </header>
+                    <div class="mt-6 overflow-x-auto print:overflow-visible">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Identificador</th>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Descripción</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Base imponible</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Total</th>
+                                    <th scope="col" class="px-4 py-3">Fecha</th>
+                                    <th scope="col" class="px-4 py-3">Método</th>
+                                    <th scope="col" class="px-4 py-3">Categoría</th>
+                                    <th scope="col" class="px-4 py-3 text-center print:hidden">Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr
+                                    v-for="expense in visibleExpenses"
+                                    :key="expense.id"
+                                    class="bg-white/60 transition hover:bg-rose-50/60"
+                                >
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ expense.id }}</td>
+                                    <td class="px-4 py-3">{{ expense.name }}</td>
+                                    <td class="px-4 py-3 max-w-xs truncate" :title="expense.description">{{ expense.description || '—' }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount ?? 0) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(taxAmount(expense)) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(grossAmount(expense)) }}</td>
+                                    <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
+                                    <td class="px-4 py-3">{{ paymentMethodName(expense.payment_method_id) }}</td>
+                                    <td class="px-4 py-3">{{ categoryName(expense.expense_category_id) }}</td>
+                                    <td class="px-4 py-3 text-center print:hidden">
+                                        <div class="flex justify-center gap-3">
+                                            <NavLink :href="route('expenses.show', expense.id)" class="text-slate-500 hover:text-slate-700" title="Ver detalle">
+                                                <InfoIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <NavLink :href="route('expenses.edit', expense.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
+                                                <EditIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <button
+                                                type="button"
+                                                @click="deleteExpense(expense.id)"
+                                                class="text-rose-500 hover:text-rose-700"
+                                                title="Eliminar"
+                                            >
+                                                <DeleteIcon class="w-5 h-5" />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                            <tfoot class="bg-slate-50/80 text-xs uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <td class="px-4 py-3" colspan="3">Totales</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalNetAmount) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalTaxAmount) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalGrossAmount) }}</td>
+                                    <td class="px-4 py-3" colspan="4"></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed, ref } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from "@/Components/NavLink.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import { ref, computed } from 'vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import BarChart from '@/Components/BarChart.vue';
+import DoughnutChart from '@/Components/DoughnutChart.vue';
+import NavLink from '@/Components/NavLink.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
 
 const props = defineProps({
-    expenses: Array,
-    categories: Array,
-    paymentMethods: Array,// Asegúrate de que las categorías estén pasadas como props
-    user: Object
+    expenses: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+    paymentMethods: {
+        type: Array,
+        default: () => [],
+    },
 });
 
-// Estados para los filtros
+const expenses = computed(() => props.expenses ?? []);
+const categories = computed(() => props.categories ?? []);
+const paymentMethods = computed(() => props.paymentMethods ?? []);
+
 const selectedPaymentMethod = ref('');
 const startDate = ref('');
 const endDate = ref('');
 const selectedCategory = ref('');
 
-// Computed para filtrar gastos
-const filteredExpenses = computed(() => {
-    return props.expenses.filter(expense => {
-        const matchesPaymentMethod = selectedPaymentMethod.value ? expense.payment_method_id === selectedPaymentMethod.value: true;
-        const matchesCategory = selectedCategory.value ? expense.expense_category_id === selectedCategory.value : true;
-        const matchesStartDate = startDate.value ? new Date(expense.date) >= new Date(startDate.value) : true;
-        const matchesEndDate = endDate.value ? new Date(expense.date) <= new Date(endDate.value) : true;
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
+};
 
-        return matchesPaymentMethod && matchesCategory && matchesStartDate && matchesEndDate;
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const taxAmount = (expense) => {
+    const amount = Number(expense?.amount ?? 0);
+    const rate = Number(expense?.iva ?? 0);
+    return amount * rate / 100;
+};
+
+const grossAmount = (expense) => {
+    const amount = Number(expense?.amount ?? 0);
+    return amount + taxAmount(expense);
+};
+
+const matchesDate = (expense) => {
+    const date = new Date(expense.date);
+    if (Number.isNaN(date.getTime())) {
+        return true;
+    }
+    const from = startDate.value ? new Date(startDate.value) : null;
+    const to = endDate.value ? new Date(endDate.value) : null;
+
+    if (from && date < from) {
+        return false;
+    }
+
+    if (to && date > to) {
+        return false;
+    }
+
+    return true;
+};
+
+const visibleExpenses = computed(() => {
+    return expenses.value.filter(expense => {
+        const matchesPaymentMethod = selectedPaymentMethod.value
+            ? String(expense.payment_method_id) === selectedPaymentMethod.value
+            : true;
+
+        const matchesCategory = selectedCategory.value
+            ? String(expense.expense_category_id) === selectedCategory.value
+            : true;
+
+        return matchesPaymentMethod && matchesCategory && matchesDate(expense);
     });
 });
 
-// Función para aplicar los filtros
-const deleteFilters = () => {
+const filteredCountMessage = computed(() => {
+    if (visibleExpenses.value.length === expenses.value.length) {
+        return `${expenses.value.length} registros`; 
+    }
+    return `${visibleExpenses.value.length} de ${expenses.value.length} registros`;
+});
+
+const totalNetAmount = computed(() => visibleExpenses.value.reduce((acc, expense) => acc + Number(expense?.amount ?? 0), 0));
+const totalTaxAmount = computed(() => visibleExpenses.value.reduce((acc, expense) => acc + taxAmount(expense), 0));
+const totalGrossAmount = computed(() => totalNetAmount.value + totalTaxAmount.value);
+
+const averageGrossAmount = computed(() => {
+    if (!visibleExpenses.value.length) {
+        return 0;
+    }
+    return totalGrossAmount.value / visibleExpenses.value.length;
+});
+
+const highestExpenseGross = computed(() => {
+    if (!visibleExpenses.value.length) {
+        return 0;
+    }
+    return Math.max(...visibleExpenses.value.map(expense => grossAmount(expense)));
+});
+
+const lowestExpenseGross = computed(() => {
+    if (!visibleExpenses.value.length) {
+        return 0;
+    }
+    return Math.min(...visibleExpenses.value.map(expense => grossAmount(expense)));
+});
+
+const highestExpenseDescriptor = computed(() => {
+    if (!visibleExpenses.value.length) {
+        return 'Sin registros';
+    }
+    const richest = visibleExpenses.value.reduce((acc, expense) => {
+        const amount = grossAmount(expense);
+        if (!acc || amount > acc.amount) {
+            return {
+                amount,
+                categoryId: expense.expense_category_id,
+                methodId: expense.payment_method_id,
+            };
+        }
+        return acc;
+    }, null);
+
+    const category = categories.value.find(cat => cat.id === richest?.categoryId);
+    const method = paymentMethods.value.find(method => method.id === richest?.methodId);
+    const categoryNameValue = category?.name || 'Sin categoría';
+    const methodNameValue = method?.name || 'Sin método';
+
+    return `${categoryNameValue} · ${methodNameValue}`;
+});
+
+const monthlyExpensesData = computed(() => {
+    const totals = Array(12).fill(0);
+    visibleExpenses.value.forEach(expense => {
+        const date = new Date(expense.date);
+        if (!Number.isNaN(date.getTime())) {
+            totals[date.getMonth()] += grossAmount(expense);
+        }
+    });
+
+    return {
+        labels: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
+        datasets: [
+            {
+                label: 'Total mensual',
+                backgroundColor: 'rgba(244, 63, 94, 0.45)',
+                borderColor: 'rgba(244, 63, 94, 1)',
+                borderWidth: 1,
+                data: totals,
+            },
+        ],
+    };
+});
+
+const palette = ['#0EA5E9', '#10B981', '#6366F1', '#F97316', '#F43F5E', '#8B5CF6', '#14B8A6', '#F59E0B', '#0F172A', '#84CC16', '#A855F7', '#0EA5E9'];
+
+const categoryDistributionData = computed(() => {
+    if (!visibleExpenses.value.length) {
+        return {
+            labels: ['Sin datos'],
+            datasets: [
+                {
+                    data: [1],
+                    backgroundColor: ['rgba(148, 163, 184, 0.45)'],
+                    borderColor: ['rgba(148, 163, 184, 1)'],
+                },
+            ],
+        };
+    }
+
+    const totals = visibleExpenses.value.reduce((acc, expense) => {
+        const category = categoryName(expense.expense_category_id);
+        acc[category] = (acc[category] || 0) + grossAmount(expense);
+        return acc;
+    }, {});
+
+    const labels = Object.keys(totals);
+    const data = Object.values(totals);
+
+    return {
+        labels,
+        datasets: [
+            {
+                data,
+                backgroundColor: labels.map((_, index) => palette[index % palette.length] + '73'),
+                borderColor: labels.map((_, index) => palette[index % palette.length]),
+            },
+        ],
+    };
+});
+
+const paymentMethodName = (id) => {
+    const method = paymentMethods.value.find(item => item.id === id);
+    return method?.name || 'Sin método';
+};
+
+const categoryName = (id) => {
+    const category = categories.value.find(item => item.id === id);
+    return category?.name || 'Sin categoría';
+};
+
+const resetFilters = () => {
     selectedPaymentMethod.value = '';
     startDate.value = '';
     endDate.value = '';
     selectedCategory.value = '';
 };
 
-// Función para eliminar un gasto
+const printPage = () => {
+    window.print();
+};
+
 const deleteExpense = (id) => {
-    if (confirm("¿Estás seguro de que deseas eliminar este gasto?")) {
+    if (confirm('¿Estás seguro de que deseas eliminar este gasto?')) {
         Inertia.delete(route('expenses.destroy', id));
     }
 };
 </script>
-

--- a/resources/js/Pages/Expenses/Show.vue
+++ b/resources/js/Pages/Expenses/Show.vue
@@ -1,74 +1,182 @@
 <template>
     <AppLayout>
-        <div class="items-center justify-start bg-white min-h-screen w-full flex flex-col">
-            <div class="container mt-10 p-6 bg-white rounded-lg ">
-                <h1 class="text-2xl text-blue-500 font-bold mb-6">Detalles del Gasto</h1>
-
-                <!-- Información del gasto -->
-                <div class="grid grid-cols-2 gap-4">
-                    <div>
-                        <p><strong>Nombre:</strong> {{ expense.name }}</p>
-                        <p><strong>Descripción:</strong> {{ expense.description }}</p>
-                        <p><strong>Fecha:</strong> {{ expense.date }}</p>
-                        <template v-for="paymentMethod in paymentMethods" :key="paymentMethod.id">
-                            <p v-if="paymentMethod.id === expense.payment_method_id"><strong>Método de Pago:</strong> {{ paymentMethod.name }}</p>
-                        </template>
-                        <template v-for="category in categories" :key="category.id">
-                            <p v-if="category.id === expense.expense_category_id"><strong>Categoría:</strong> {{ category.name }}</p>
-                        </template>
-
-                    </div>
-                    <div>
-                        <p><strong>Total:</strong> {{ expense.amount }}</p>
-                        <p><strong>IVA (%):</strong> {{ expense.iva }}</p>
-                        <p><strong>Monto IVA:</strong> {{ (expense.amount * (expense.iva / 100)).toFixed(2) }}</p>
-                    </div>
-                </div>
-
-                <!-- Archivo adjunto -->
-                <div class="mt-6">
-                    <p v-if="expense.file"><strong>Archivo Adjunto:</strong> <a :href="'/storage/'+expense.file" target="_blank" class="text-blue-600 hover:underline">Ver Archivo</a></p>
-                    <p v-else><strong>No hay archivo adjunto.</strong></p>
-                </div>
-
-                <!-- Botones de acciones con íconos -->
-                <div class="mt-6 flex justify-start space-x-4">
-                    <NavLink :href="route('expenses.edit', expense.id)" title="Editar Gasto">
-                        <EditIcon class="w-6 h-6 text-gray-600" />
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Detalle de gasto"
+                :title="expense.name || 'Gasto'"
+                :description="`Consulta la trazabilidad completa del gasto y su impacto en los indicadores del panel contable.`"
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('expenses.edit', expense.id)"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        <EditIcon class="h-4 w-4" />
+                        <span>Editar</span>
                     </NavLink>
-                    <button @click="confirmDelete" title="Eliminar Gasto">
-                        <DeleteIcon class="w-6 h-6 text-gray-600" />
+                    <button
+                        type="button"
+                        @click="confirmDelete"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Eliminar
                     </button>
-                </div>
+                    <button
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Imprimir ficha
+                    </button>
+                </template>
 
-            </div>
+                <template #metrics>
+                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(netAmount)" :helper="formatDate(expense.date)" />
+                    <FinanceSummaryCard label="IVA" :value="formatCurrency(taxAmount)" :helper="`${expense.iva ?? 0}% aplicado`" />
+                    <FinanceSummaryCard label="Total" :value="formatCurrency(grossAmount)" :helper="`${paymentMethodName} · ${categoryName}`" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Información principal</h2>
+                        <p class="text-sm text-slate-500">Datos esenciales del gasto armonizados con la tipografía y estilo del dashboard.</p>
+                    </header>
+                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Descripción</dt>
+                            <dd class="mt-2 whitespace-pre-line">{{ expense.description || 'Sin descripción' }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</dt>
+                            <dd class="mt-2">{{ formatDate(expense.date) }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Método de pago</dt>
+                            <dd class="mt-2">{{ paymentMethodName }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Categoría</dt>
+                            <dd class="mt-2">{{ categoryName }}</dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Desglose económico</h2>
+                        <p class="text-sm text-slate-500">Visualiza la proporción entre base imponible e impuestos.</p>
+                    </header>
+                    <div class="mt-6">
+                        <DoughnutChart :data="breakdownChart" />
+                    </div>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Documentación</h2>
+                        <p class="text-sm text-slate-500">Archivos listos para auditoría o consulta por terceros.</p>
+                    </header>
+                    <div class="mt-6 text-sm text-slate-600">
+                        <template v-if="expense.file">
+                            <a :href="`/storage/${expense.file}`" target="_blank" class="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 font-semibold text-emerald-700 transition hover:bg-emerald-100">
+                                Ver archivo adjunto
+                            </a>
+                        </template>
+                        <p v-else class="text-slate-400">No hay archivo adjunto.</p>
+                    </div>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import DoughnutChart from '@/Components/DoughnutChart.vue';
+import NavLink from '@/Components/NavLink.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
 
 const props = defineProps({
-    expense: Object,
-    paymentMethods: Array,
-    categories: Array,
+    expense: {
+        type: Object,
+        required: true,
+    },
+    paymentMethods: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
 });
 
+const expense = computed(() => props.expense ?? {});
+const paymentMethods = computed(() => props.paymentMethods ?? []);
+const categories = computed(() => props.categories ?? []);
 
-// Confirmación y eliminación del gasto
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const netAmount = computed(() => Number(expense.value.amount ?? 0));
+const taxAmount = computed(() => netAmount.value * Number(expense.value.iva ?? 0) / 100);
+const grossAmount = computed(() => netAmount.value + taxAmount.value);
+
+const paymentMethodName = computed(() => {
+    const method = paymentMethods.value.find(item => item.id === expense.value.payment_method_id);
+    return method?.name || 'Sin método';
+});
+
+const categoryName = computed(() => {
+    const category = categories.value.find(item => item.id === expense.value.expense_category_id);
+    return category?.name || 'Sin categoría';
+});
+
+const breakdownChart = computed(() => ({
+    labels: ['Base imponible', 'IVA'],
+    datasets: [
+        {
+            data: [netAmount.value, taxAmount.value],
+            backgroundColor: ['rgba(16, 185, 129, 0.45)', 'rgba(244, 63, 94, 0.45)'],
+            borderColor: ['rgba(16, 185, 129, 1)', 'rgba(244, 63, 94, 1)'],
+        },
+    ],
+}));
+
+const printPage = () => {
+    window.print();
+};
+
 const confirmDelete = () => {
-    if (confirm("¿Estás seguro de que quieres eliminar este gasto?")) {
-        Inertia.delete(route('expenses.destroy', props.expense.id));
+    if (confirm('¿Estás seguro de que quieres eliminar este gasto?')) {
+        Inertia.delete(route('expenses.destroy', expense.value.id));
     }
 };
 </script>
-
-<style scoped>
-/* Estilos adicionales pueden ser añadidos aquí */
-</style>
-

--- a/resources/js/Pages/Incomes/Index.vue
+++ b/resources/js/Pages/Incomes/Index.vue
@@ -1,78 +1,369 @@
 <template>
     <AppLayout>
-    <div class="max-w-6xl mx-auto p-6">
-        <h1 class="text-2xl font-bold mb-6">Listado de Ingresos</h1>
-
-        <div class="mb-4 flex justify-between items-center">
-            <a
-                :href="route('incomes.create')"
-                class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Control financiero"
+                title="Ingresos registrados"
+                description="Explora la evolución de tus ingresos, analiza su origen y mantén un registro claro con herramientas preparadas para impresión."
             >
-                Crear Ingreso
-            </a>
-        </div>
-
-        <table class="table-auto w-full bg-white rounded shadow">
-            <thead class="bg-gray-100">
-            <tr>
-                <th class="px-4 py-2 text-left">Nombre</th>
-                <th class="px-4 py-2 text-left">Origen</th>
-                <th class="px-4 py-2 text-right">Base Imponible</th>
-                <th class="px-4 py-2 text-right">IVA (%)</th>
-                <th class="px-4 py-2 text-right">Monto IVA</th>
-                <th class="px-4 py-2 text-right">Total</th>
-                <th class="px-4 py-2 text-left">Fecha</th>
-                <th class="px-4 py-2 text-center">Acciones</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr
-                v-for="income in incomes"
-                :key="income.id"
-                class="border-b hover:bg-gray-50"
-            >
-                <td class="px-4 py-2">{{ income.name }}</td>
-                <td class="px-4 py-2">{{ income.source }}</td>
-                <td class="px-4 py-2 text-right">{{ income.tax_base.toFixed(2) }}</td>
-                <td class="px-4 py-2 text-right">{{ income.tax_rate }}%</td>
-                <td class="px-4 py-2 text-right">
-                    {{ (income.tax_base * income.tax_rate / 100).toFixed(2) }}
-                </td>
-                <td class="px-4 py-2 text-right">
-                    {{ (income.tax_base + income.tax_base * income.tax_rate / 100).toFixed(2) }}
-                </td>
-                <td class="px-4 py-2">{{ income.date }}</td>
-                <td class="px-4 py-2 text-center flex justify-center space-x-2">
-                    <a
-                        :href="route('incomes.edit', income.id)"
-                        class="text-blue-500 hover:text-blue-700"
-                        title="Editar"
+                <template #actions>
+                    <NavLink
+                        :href="route('incomes.create')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                     >
-                        <EditIcon class="stroke-gray-600 w-5" />
-                    </a>
+                        <span>Registrar ingreso</span>
+                    </NavLink>
                     <button
-                        @click="deleteIncome(income.id)"
-                        class="text-red-500 hover:text-red-700"
-                        title="Eliminar"
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                     >
-                        <DeleteIcon class="stroke-gray-600 w-5"/>
+                        Imprimir informe
                     </button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
+                </template>
+
+                <template #metrics>
+                    <FinanceSummaryCard label="Total ingresos" :value="formatCurrency(totalGross)" :helper="`Impuestos incluidos: ${formatCurrency(totalTax)}`" />
+                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(totalBase)" :helper="`IVA medio ${averageTaxRate}%`" />
+                    <FinanceSummaryCard label="Ticket medio" :value="formatCurrency(averageTicket)" :helper="`${incomes.length} registros`" />
+                    <FinanceSummaryCard label="Máximo registrado" :value="formatCurrency(highestIncome)" :helper="highestIncomeSource" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="flex flex-col gap-2 border-b border-slate-100 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Resumen mensual</h2>
+                            <p class="text-sm text-slate-500">Suma las entradas por mes para detectar patrones de estacionalidad.</p>
+                        </div>
+                        <div class="flex items-center gap-3 text-sm text-slate-500">
+                            <span class="inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500"></span>
+                            Ingresos brutos
+                        </div>
+                    </header>
+                    <div class="mt-6">
+                        <BarChart :data="monthlyIncomeData" />
+                    </div>
+                </section>
+
+                <section class="grid grid-cols-1 gap-8 xl:grid-cols-2">
+                    <article class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                        <header class="border-b border-slate-100 pb-4">
+                            <h2 class="text-xl font-semibold text-slate-800">Distribución por origen</h2>
+                            <p class="text-sm text-slate-500">Comprueba qué fuentes aportan un mayor volumen de ingresos.</p>
+                        </header>
+                        <div class="mt-6">
+                            <DoughnutChart :data="sourceDistributionData" />
+                        </div>
+                    </article>
+
+                    <article class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                        <header class="border-b border-slate-100 pb-4">
+                            <h2 class="text-xl font-semibold text-slate-800">Detalle registrado</h2>
+                            <p class="text-sm text-slate-500">Consulta rápidamente las cifras clave de cada ingreso.</p>
+                        </header>
+                        <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Desviación media</dt>
+                                <dd class="mt-2 text-xl font-semibold">{{ formatCurrency(averageDeviation) }}</dd>
+                                <p class="mt-2 text-xs text-slate-500">Indicador de dispersión frente al ticket medio.</p>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Último registro</dt>
+                                <dd class="mt-2 text-xl font-semibold">{{ lastIncomeFormatted.amount }}</dd>
+                                <p class="mt-2 text-xs text-slate-500">{{ lastIncomeFormatted.date }} · {{ lastIncomeFormatted.source }}</p>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Primer registro</dt>
+                                <dd class="mt-2 text-xl font-semibold">{{ firstIncomeFormatted.amount }}</dd>
+                                <p class="mt-2 text-xs text-slate-500">{{ firstIncomeFormatted.date }} · {{ firstIncomeFormatted.source }}</p>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Fuentes activas</dt>
+                                <dd class="mt-2 text-xl font-semibold">{{ uniqueSources }}</dd>
+                                <p class="mt-2 text-xs text-slate-500">Referencias distintas en el periodo.</p>
+                            </div>
+                        </dl>
+                    </article>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-0">
+                    <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Detalle de ingresos</h2>
+                            <p class="text-sm text-slate-500">Tabla optimizada para manejar grandes volúmenes con totales calculados.</p>
+                        </div>
+                        <div class="text-right text-sm text-slate-500">
+                            Total registros: {{ incomes.length }}
+                        </div>
+                    </header>
+                    <div class="mt-6 overflow-x-auto print:overflow-visible">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Origen</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Base imponible</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA (%)</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Total</th>
+                                    <th scope="col" class="px-4 py-3">Fecha</th>
+                                    <th scope="col" class="px-4 py-3 text-center print:hidden">Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr
+                                    v-for="income in incomes"
+                                    :key="income.id"
+                                    class="bg-white/60 transition hover:bg-emerald-50/60"
+                                >
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ income.name }}</td>
+                                    <td class="px-4 py-3">{{ income.source || 'Sin especificar' }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(income.tax_base ?? 0) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ income.tax_rate ?? 0 }}%</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(taxAmount(income)) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalAmount(income)) }}</td>
+                                    <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(income.date) }}</td>
+                                    <td class="px-4 py-3 text-center print:hidden">
+                                        <div class="flex justify-center gap-3">
+                                            <NavLink :href="route('incomes.edit', income.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
+                                                <EditIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <button
+                                                type="button"
+                                                @click="deleteIncome(income.id)"
+                                                class="text-rose-500 hover:text-rose-700"
+                                                title="Eliminar"
+                                            >
+                                                <DeleteIcon class="w-5 h-5" />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                            <tfoot class="bg-slate-50/80 text-xs uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <td class="px-4 py-3" colspan="2">Totales</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalBase) }}</td>
+                                    <td class="px-4 py-3 text-right">—</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalTax) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalGross) }}</td>
+                                    <td class="px-4 py-3" colspan="2"></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </section>
+            </main>
+        </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { router } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import BarChart from '@/Components/BarChart.vue';
+import DoughnutChart from '@/Components/DoughnutChart.vue';
+import NavLink from '@/Components/NavLink.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
-import AppLayout from '@/Layouts/AppLayout.vue';
+
 const props = defineProps({
-    incomes: Array, // Lista de ingresos enviada desde el controlador
+    incomes: {
+        type: Array,
+        default: () => [],
+    },
 });
+
+const incomes = computed(() => props.incomes ?? []);
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const taxAmount = (income) => {
+    const base = Number(income?.tax_base ?? 0);
+    const rate = Number(income?.tax_rate ?? 0);
+    return base * rate / 100;
+};
+
+const totalAmount = (income) => {
+    const base = Number(income?.tax_base ?? 0);
+    return base + taxAmount(income);
+};
+
+const totalBase = computed(() => incomes.value.reduce((acc, income) => acc + Number(income?.tax_base ?? 0), 0));
+const totalTax = computed(() => incomes.value.reduce((acc, income) => acc + taxAmount(income), 0));
+const totalGross = computed(() => totalBase.value + totalTax.value);
+
+const averageTicket = computed(() => {
+    if (!incomes.value.length) {
+        return 0;
+    }
+    return totalGross.value / incomes.value.length;
+});
+
+const averageTaxRate = computed(() => {
+    if (!incomes.value.length) {
+        return 0;
+    }
+    const totalRate = incomes.value.reduce((acc, income) => acc + Number(income?.tax_rate ?? 0), 0);
+    return (totalRate / incomes.value.length).toFixed(1);
+});
+
+const highestIncome = computed(() => {
+    if (!incomes.value.length) {
+        return 0;
+    }
+    return Math.max(...incomes.value.map(income => totalAmount(income)));
+});
+
+const highestIncomeSource = computed(() => {
+    if (!incomes.value.length) {
+        return 'Sin registros';
+    }
+    const richest = incomes.value.reduce((acc, income) => {
+        const amount = totalAmount(income);
+        if (!acc || amount > acc.amount) {
+            return { amount, source: income.source || 'Sin origen' };
+        }
+        return acc;
+    }, null);
+
+    return richest ? `Origen ${richest.source}` : 'Sin registros';
+});
+
+const uniqueSources = computed(() => {
+    const sources = new Set(incomes.value.map(income => income.source || 'Sin origen'));
+    return sources.size;
+});
+
+const sortedIncomes = computed(() => {
+    return [...incomes.value].sort((a, b) => new Date(a.date) - new Date(b.date));
+});
+
+const lastIncomeFormatted = computed(() => {
+    if (!sortedIncomes.value.length) {
+        return { amount: formatCurrency(0), date: 'Sin fecha', source: 'Sin origen' };
+    }
+    const income = sortedIncomes.value[sortedIncomes.value.length - 1];
+    return {
+        amount: formatCurrency(totalAmount(income)),
+        date: formatDate(income.date),
+        source: income.source || 'Sin origen',
+    };
+});
+
+const firstIncomeFormatted = computed(() => {
+    if (!sortedIncomes.value.length) {
+        return { amount: formatCurrency(0), date: 'Sin fecha', source: 'Sin origen' };
+    }
+    const income = sortedIncomes.value[0];
+    return {
+        amount: formatCurrency(totalAmount(income)),
+        date: formatDate(income.date),
+        source: income.source || 'Sin origen',
+    };
+});
+
+const averageDeviation = computed(() => {
+    if (incomes.value.length <= 1) {
+        return 0;
+    }
+    const avg = averageTicket.value;
+    const variance = incomes.value.reduce((acc, income) => {
+        const diff = totalAmount(income) - avg;
+        return acc + diff * diff;
+    }, 0) / (incomes.value.length - 1);
+    return Math.sqrt(variance);
+});
+
+const monthlyIncomeData = computed(() => {
+    const monthlyTotals = Array(12).fill(0);
+    incomes.value.forEach(income => {
+        const date = new Date(income.date);
+        if (!Number.isNaN(date.getTime())) {
+            monthlyTotals[date.getMonth()] += totalAmount(income);
+        }
+    });
+
+    return {
+        labels: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
+        datasets: [
+            {
+                label: 'Ingresos brutos',
+                backgroundColor: 'rgba(16, 185, 129, 0.45)',
+                borderColor: 'rgba(16, 185, 129, 1)',
+                borderWidth: 1,
+                data: monthlyTotals,
+            },
+        ],
+    };
+});
+
+const palette = ['#0EA5E9', '#10B981', '#6366F1', '#F97316', '#F43F5E', '#8B5CF6', '#14B8A6', '#F59E0B', '#0F172A', '#84CC16', '#A855F7', '#0EA5E9'];
+
+const sourceDistributionData = computed(() => {
+    if (!incomes.value.length) {
+        return {
+            labels: ['Sin datos'],
+            datasets: [
+                {
+                    data: [1],
+                    backgroundColor: ['rgba(148, 163, 184, 0.45)'],
+                    borderColor: ['rgba(148, 163, 184, 1)'],
+                },
+            ],
+        };
+    }
+
+    const totals = incomes.value.reduce((acc, income) => {
+        const source = income.source || 'Sin origen';
+        acc[source] = (acc[source] || 0) + totalAmount(income);
+        return acc;
+    }, {});
+
+    const labels = Object.keys(totals);
+    const data = Object.values(totals);
+
+    return {
+        labels,
+        datasets: [
+            {
+                data,
+                backgroundColor: labels.map((_, index) => palette[index % palette.length] + '73'),
+                borderColor: labels.map((_, index) => palette[index % palette.length]),
+            },
+        ],
+    };
+});
+
+const printPage = () => {
+    window.print();
+};
 
 const deleteIncome = (id) => {
     if (confirm('¿Estás seguro de eliminar este ingreso?')) {

--- a/resources/js/Pages/PaymentMethods/Index.vue
+++ b/resources/js/Pages/PaymentMethods/Index.vue
@@ -1,70 +1,196 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <!-- Widgets informativos -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Métodos de Pago</h2>
-                        <p class="text-blue-300 text-2xl">{{ paymentMethods.length }}</p>
-                    </div>
-                </div>
-            </div>
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Estructura de cobro"
+                title="Métodos de pago"
+                description="Gestiona los canales de cobro con tarjetas coherentes, gráficas y formato imprimible inspirado en el dashboard contable."
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('paymentMethods.create')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        <AddIcon class="h-4 w-4" />
+                        <span>Nuevo método</span>
+                    </NavLink>
+                    <button
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Imprimir resumen
+                    </button>
+                </template>
 
-            <!-- Tabla de métodos de pago -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('paymentMethods.create')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Nuevo Método
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-5"/>
-                </NavLink>
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Identificador</th>
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="method in paymentMethods" :key="method.id" class="border-t">
-                        <td class="px-4 py-2">{{ method.id }}</td>
-                        <td class="px-4 py-2">{{ method.name }}</td>
-                        <td class="px-4 py-2">{{ method.description }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('paymentMethods.show', method.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <NavLink :href="route('paymentMethods.edit', method.id)" class="text-yellow-500 ml-2">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteMethod(method.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
+                <template #metrics>
+                    <FinanceSummaryCard label="Total métodos" :value="paymentMethods.length" :helper="`Actualizado: ${new Date().toLocaleDateString('es-ES')}`" />
+                    <FinanceSummaryCard label="Con descripción" :value="methodsWithDescription" :helper="`${descriptionCoverage}% cobertura`" />
+                    <FinanceSummaryCard label="Nombre medio" :value="`${averageNameLength} car.`" :helper="`Más extenso: ${longestMethodName}`" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Cobertura descriptiva</h2>
+                        <p class="text-sm text-slate-500">Comprueba qué métodos disponen de documentación útil para equipos comerciales y financieros.</p>
+                    </header>
+                    <div class="mt-6">
+                        <DoughnutChart :data="descriptionDistributionData" />
+                    </div>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-0">
+                    <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Listado de métodos</h2>
+                            <p class="text-sm text-slate-500">Diseño preparado para grandes volúmenes y exportación en papel.</p>
+                        </div>
+                        <div class="text-right text-sm text-slate-500">
+                            Total: {{ paymentMethods.length }}
+                        </div>
+                    </header>
+                    <div class="mt-6 overflow-x-auto print:overflow-visible">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Identificador</th>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Descripción</th>
+                                    <th scope="col" class="px-4 py-3 text-center print:hidden">Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr
+                                    v-for="method in paymentMethods"
+                                    :key="method.id"
+                                    class="bg-white/60 transition hover:bg-emerald-50/60"
+                                >
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ method.id }}</td>
+                                    <td class="px-4 py-3">{{ method.name }}</td>
+                                    <td class="px-4 py-3 max-w-xl">
+                                        <p v-if="method.description" class="whitespace-pre-line">{{ method.description }}</p>
+                                        <span v-else class="text-slate-400">Sin descripción</span>
+                                    </td>
+                                    <td class="px-4 py-3 text-center print:hidden">
+                                        <div class="flex justify-center gap-3">
+                                            <NavLink :href="route('paymentMethods.show', method.id)" class="text-slate-500 hover:text-slate-700" title="Ver detalle">
+                                                <InfoIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <NavLink :href="route('paymentMethods.edit', method.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
+                                                <EditIcon class="w-5 h-5" />
+                                            </NavLink>
+                                            <button
+                                                type="button"
+                                                @click="deleteMethod(method.id)"
+                                                class="text-rose-500 hover:text-rose-700"
+                                                title="Eliminar"
+                                            >
+                                                <DeleteIcon class="w-5 h-5" />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from "@/Components/NavLink.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import DoughnutChart from '@/Components/DoughnutChart.vue';
+import NavLink from '@/Components/NavLink.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
 
 const props = defineProps({
-    paymentMethods: Array,
+    paymentMethods: {
+        type: Array,
+        default: () => [],
+    },
 });
 
+const paymentMethods = computed(() => props.paymentMethods ?? []);
+
+const methodsWithDescription = computed(() => paymentMethods.value.filter(method => Boolean(method?.description)).length);
+
+const descriptionCoverage = computed(() => {
+    if (!paymentMethods.value.length) {
+        return 0;
+    }
+    return Math.round((methodsWithDescription.value / paymentMethods.value.length) * 100);
+});
+
+const averageNameLength = computed(() => {
+    if (!paymentMethods.value.length) {
+        return 0;
+    }
+    const totalCharacters = paymentMethods.value.reduce((acc, method) => acc + (method?.name?.length ?? 0), 0);
+    return Math.round(totalCharacters / paymentMethods.value.length);
+});
+
+const longestMethodName = computed(() => {
+    if (!paymentMethods.value.length) {
+        return 'Sin datos';
+    }
+    const longest = paymentMethods.value.reduce((acc, method) => {
+        const length = method?.name?.length ?? 0;
+        if (!acc || length > acc.length) {
+            return { length, name: method.name };
+        }
+        return acc;
+    }, null);
+
+    return longest ? longest.name : 'Sin datos';
+});
+
+const descriptionDistributionData = computed(() => {
+    if (!paymentMethods.value.length) {
+        return {
+            labels: ['Sin datos'],
+            datasets: [
+                {
+                    data: [1],
+                    backgroundColor: ['rgba(148, 163, 184, 0.45)'],
+                    borderColor: ['rgba(148, 163, 184, 1)'],
+                },
+            ],
+        };
+    }
+
+    const withDescription = methodsWithDescription.value;
+    const withoutDescription = paymentMethods.value.length - withDescription;
+
+    return {
+        labels: ['Con descripción', 'Sin descripción'],
+        datasets: [
+            {
+                data: [withDescription, withoutDescription],
+                backgroundColor: ['rgba(59, 130, 246, 0.45)', 'rgba(148, 163, 184, 0.45)'],
+                borderColor: ['rgba(59, 130, 246, 1)', 'rgba(148, 163, 184, 1)'],
+            },
+        ],
+    };
+});
+
+const printPage = () => {
+    window.print();
+};
+
 const deleteMethod = (id) => {
-    if (confirm("¿Estás seguro de que deseas eliminar este método de pago?")) {
+    if (confirm('¿Estás seguro de que deseas eliminar este método de pago?')) {
         Inertia.delete(route('paymentMethods.destroy', id));
     }
 };


### PR DESCRIPTION
## Summary
- add reusable finance header and summary card components to mirror the dashboard styling across finance views
- restyle incomes, expenses, expense categories, and payment methods indexes with gradient hero, unified cards, charts, and print-friendly tables
- refresh the expense detail page with consistent typography, KPI cards, and a tax breakdown chart

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de5df6e18c83238ca090589334a990