### PR TITLE
Refine CRM workflow surfaces

### DIFF
--- a/resources/js/Components/Crm/EmptyState.vue
+++ b/resources/js/Components/Crm/EmptyState.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="flex flex-col items-center justify-center rounded-3xl border border-dashed border-slate-200 bg-slate-50 py-16 px-8 text-center">
+        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-violet-500/10 text-violet-500">
+            <slot name="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm10.5-4.125a.75.75 0 10-1.5 0v4.5a.75.75 0 001.5 0v-4.5ZM12 16.5a.875.875 0 100-1.75.875.875 0 000 1.75Z" clip-rule="evenodd" />
+                </svg>
+            </slot>
+        </div>
+        <h3 class="mt-4 text-lg font-semibold text-slate-700">{{ title }}</h3>
+        <p v-if="description" class="mt-2 max-w-md text-sm text-slate-500">{{ description }}</p>
+        <div v-if="$slots.action" class="mt-6">
+            <slot name="action" />
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    description: {
+        type: String,
+        default: null,
+    },
+});
+</script>

--- a/resources/js/Components/Crm/FlowStepper.vue
+++ b/resources/js/Components/Crm/FlowStepper.vue
@@ -1,0 +1,47 @@
+<template>
+    <div class="w-full">
+        <div class="flex flex-wrap items-center justify-center gap-6">
+            <div v-for="(step, index) in steps" :key="step.label" class="flex items-center gap-4">
+                <div class="relative">
+                    <div class="h-12 w-12 rounded-full border-2" :class="stepClasses(index)">
+                        <div class="absolute inset-0 flex items-center justify-center text-sm font-semibold" :class="stepTextClasses(index)">
+                            {{ index + 1 }}
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <p class="text-sm font-semibold" :class="labelClasses(index)">{{ step.label }}</p>
+                    <p v-if="step.description" class="text-xs text-slate-400 max-w-[14rem]">{{ step.description }}</p>
+                </div>
+                <div v-if="index < steps.length - 1" class="hidden sm:block w-12 h-px bg-gradient-to-r from-violet-500/40 to-violet-500/80"></div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    steps: {
+        type: Array,
+        default: () => [],
+    },
+    activeIndex: {
+        type: Number,
+        default: 0,
+    },
+});
+
+const stepClasses = index => [
+    'flex items-center justify-center border-violet-300/60',
+    props.activeIndex >= index ? 'bg-violet-500 text-white shadow-lg shadow-violet-500/40' : 'bg-slate-900 text-slate-400',
+];
+
+const stepTextClasses = index => [
+    props.activeIndex >= index ? 'text-white' : 'text-slate-400',
+];
+
+const labelClasses = index => [
+    'uppercase tracking-widest text-xs',
+    props.activeIndex >= index ? 'text-violet-200' : 'text-slate-400',
+];
+</script>

--- a/resources/js/Components/Crm/SectionCard.vue
+++ b/resources/js/Components/Crm/SectionCard.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="bg-white rounded-3xl shadow-xl p-6">
+        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 border-b border-slate-100 pb-5">
+            <div>
+                <h2 class="text-xl font-semibold text-slate-800">{{ title }}</h2>
+                <p v-if="description" class="text-sm text-slate-500 mt-1">{{ description }}</p>
+            </div>
+            <div class="flex items-center gap-2" v-if="$slots.actions">
+                <slot name="actions" />
+            </div>
+        </div>
+        <div class="mt-6">
+            <slot />
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    description: {
+        type: String,
+        default: null,
+    },
+});
+</script>

--- a/resources/js/Components/Crm/StatsCard.vue
+++ b/resources/js/Components/Crm/StatsCard.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+        <p class="text-xs uppercase tracking-[0.3em] text-violet-200">{{ label }}</p>
+        <p class="text-3xl font-semibold mt-2">{{ value }}</p>
+        <p v-if="hint" class="text-sm text-violet-200 mt-3">{{ hint }}</p>
+        <slot />
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    label: {
+        type: String,
+        required: true,
+    },
+    value: {
+        type: [String, Number],
+        default: '—',
+    },
+    hint: {
+        type: String,
+        default: null,
+    },
+});
+</script>

--- a/resources/js/Pages/Activities/Index.vue
+++ b/resources/js/Pages/Activities/Index.vue
@@ -1,49 +1,251 @@
 <template>
     <AppLayout>
-    <div>
-        <h1>Actividades</h1>
-        <inertia-link :href="route('activities.create')" class="btn btn-primary">Crear Actividad</inertia-link>
-        <table>
-            <thead>
-            <tr>
-                <th>Tipo</th>
-                <th>Fecha</th>
-                <th>Descripción</th>
-                <th>Acciones</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="activity in activities.data" :key="activity.id">
-                <td>{{ activity.type }}</td>
-                <td>{{ activity.date }}</td>
-                <td>{{ activity.description }}</td>
-                <td>
-                    <inertia-link :href="route('activities.show', activity.id)" class="btn btn-info">Ver</inertia-link>
-                    <inertia-link :href="route('activities.edit', activity.id)" class="btn btn-warning">Editar</inertia-link>
-                    <button @click="deleteActivity(activity.id)" class="btn btn-danger">Eliminar</button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
-    </AppLayout>
+        <div class="min-h-screen bg-slate-950 pb-20">
+            <div class="bg-gradient-to-r from-violet-700 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="space-y-2">
+                        <p class="text-violet-200 text-sm uppercase tracking-widest">Actividades</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Organiza cada interacción comercial</h1>
+                        <p class="text-sm text-violet-200">Coordina reuniones, llamadas y seguimientos para mantener el impulso de cada oportunidad.</p>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <StatsCard label="Total" :value="totalActivities" :hint="`Programadas ${upcomingActivities}`" />
+                        <StatsCard label="Completadas" :value="completedActivities" :hint="`Pendientes ${pendingActivities}`" />
+                        <StatsCard label="Tipos" :value="uniqueTypes" :hint="mostCommonType" />
+                        <StatsCard label="Última actividad" :value="latestActivityDate" :hint="'Mantén el ritmo de tu pipeline'" />
+                    </div>
+                </div>
+            </div>
 
+            <div class="max-w-7xl mx-auto px-6 -mt-16 space-y-10">
+                <SectionCard title="Flujo comercial" description="Las actividades conectan oportunidades con tareas ejecutables y aseguran el progreso constante.">
+                    <FlowStepper :steps="flowSteps" :active-index="2" />
+                </SectionCard>
+
+                <SectionCard title="Cronología de actividades" description="Filtra por tipo o estado y visualiza las interacciones recientes y futuras." >
+                    <template #actions>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <select v-model="filters.type" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todos los tipos</option>
+                                <option v-for="type in activityTypes" :key="type" :value="type">{{ type }}</option>
+                            </select>
+                            <select v-model="filters.state" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todos los estados</option>
+                                <option value="pending">Pendientes</option>
+                                <option value="completed">Completadas</option>
+                                <option value="overdue">Vencidas</option>
+                            </select>
+                            <input v-model="filters.search" type="text" placeholder="Buscar por título o descripción" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200" />
+                            <NavLink :href="route('activities.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                <span>Nueva actividad</span>
+                                <AddIcon class="h-4 w-4 fill-white" />
+                            </NavLink>
+                        </div>
+                    </template>
+
+                    <div v-if="hasError" class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+                        {{ errorMessage }}
+                    </div>
+                    <div v-else-if="isLoading" class="space-y-4">
+                        <div v-for="i in 4" :key="i" class="flex gap-4 rounded-2xl border border-slate-200/60 bg-white/60 p-6 animate-pulse">
+                            <div class="h-10 w-10 rounded-full bg-slate-200"></div>
+                            <div class="flex-1 space-y-2">
+                                <div class="h-4 w-48 rounded-full bg-slate-200"></div>
+                                <div class="h-3 w-3/4 rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-2/3 rounded-full bg-slate-100"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else>
+                        <div v-if="filteredActivities.length" class="space-y-6">
+                            <div v-for="activity in filteredActivities" :key="activity.id" class="relative flex gap-6">
+                                <div class="flex flex-col items-center">
+                                    <div class="flex h-12 w-12 items-center justify-center rounded-full border-2 border-violet-200 bg-white text-sm font-semibold text-violet-600 shadow-lg shadow-violet-200/40">
+                                        {{ activity.type?.[0] ?? 'A' }}
+                                    </div>
+                                    <div class="mt-2 h-full w-px bg-gradient-to-b from-violet-200 to-transparent"></div>
+                                </div>
+                                <div class="flex-1 rounded-2xl border border-slate-200/70 bg-white p-6 shadow-sm transition hover:border-violet-200 hover:shadow-lg hover:shadow-violet-200/30">
+                                    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                        <div>
+                                            <p class="text-xs uppercase tracking-widest text-slate-400">{{ activity.type ?? 'Sin tipo' }}</p>
+                                            <h3 class="mt-1 text-lg font-semibold text-slate-800">{{ activity.title ?? 'Actividad sin título' }}</h3>
+                                            <p class="mt-2 text-sm text-slate-500">{{ activity.description ?? 'Sin descripción registrada.' }}</p>
+                                            <div class="mt-4 flex flex-wrap gap-3 text-xs text-slate-500">
+                                                <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                    </svg>
+                                                    {{ formatDateTime(activity.date) }}
+                                                </span>
+                                                <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 11.25h3.75m-3.75 3H18M15 17.25h1.5M4.5 6h15M4.5 9.75h15M4.5 13.5h6.75" />
+                                                    </svg>
+                                                    Estado: {{ readableState(activity) }}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div class="flex flex-col items-start gap-3 sm:items-end">
+                                            <NavLink :href="route('activities.show', activity.id)" class="rounded-full border border-violet-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-violet-600 transition hover:bg-violet-600 hover:text-white">Ver</NavLink>
+                                            <NavLink :href="route('activities.edit', activity.id)" class="rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-amber-600 transition hover:bg-amber-500 hover:text-white">Editar</NavLink>
+                                            <button @click="deleteActivity(activity.id)" class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-500 transition hover:bg-red-500 hover:text-white">Eliminar</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <EmptyState v-else title="No hay actividades registradas" description="Programa reuniones, llamadas o tareas para mantener comunicación constante.">
+                            <template #action>
+                                <NavLink :href="route('activities.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                    <AddIcon class="h-4 w-4 fill-white" />
+                                    Crear actividad
+                                </NavLink>
+                            </template>
+                        </EmptyState>
+                    </div>
+                </SectionCard>
+            </div>
+        </div>
+    </AppLayout>
 </template>
 
-<script>
+<script setup>
+import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-export default {
-    components: {AppLayout},
-    props: {
-        activities: Object,
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import StatsCard from '@/Components/Crm/StatsCard.vue';
+import SectionCard from '@/Components/Crm/SectionCard.vue';
+import FlowStepper from '@/Components/Crm/FlowStepper.vue';
+import EmptyState from '@/Components/Crm/EmptyState.vue';
+
+const props = defineProps({
+    activities: {
+        type: [Array, Object],
+        default: () => ([]),
     },
-    methods: {
-        deleteActivity(id) {
-            if (confirm('¿Estás seguro de eliminar esta actividad?')) {
-                Inertia.delete(route('activities.destroy', id));
-            }
-        },
+    isLoading: {
+        type: Boolean,
+        default: false,
     },
+    error: {
+        type: [String, Object],
+        default: null,
+    },
+});
+
+const activities = computed(() => {
+    if (Array.isArray(props.activities)) return props.activities;
+    return props.activities?.data ?? [];
+});
+
+const filters = reactive({
+    type: 'all',
+    state: 'all',
+    search: '',
+});
+
+const totalActivities = computed(() => activities.value.length);
+const completedActivities = computed(() => activities.value.filter(activity => ['completed', 'completada', 'done'].includes((activity.status || '').toLowerCase())).length);
+const pendingActivities = computed(() => activities.value.filter(activity => ['pending', 'pendiente'].includes((activity.status || '').toLowerCase())).length);
+const upcomingActivities = computed(() => activities.value.filter(activity => {
+    if (!activity.date) return false;
+    return new Date(activity.date) > new Date();
+}).length);
+const uniqueTypes = computed(() => {
+    const set = new Set(activities.value.map(activity => activity.type).filter(Boolean));
+    return set.size || '—';
+});
+const mostCommonType = computed(() => {
+    if (!activities.value.length) return 'Sin datos';
+    const counts = activities.value.reduce((acc, activity) => {
+        const type = activity.type ?? 'Otro';
+        acc[type] = (acc[type] || 0) + 1;
+        return acc;
+    }, {});
+    const [type] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] || [];
+    return type ? `Tipo más habitual: ${type}` : 'Sin datos';
+});
+const latestActivityDate = computed(() => {
+    if (!activities.value.length) return '—';
+    const latest = [...activities.value].sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0))[0];
+    return latest?.date ? formatDate(latest.date) : '—';
+});
+
+const activityTypes = computed(() => {
+    const set = new Set(activities.value.map(activity => activity.type).filter(Boolean));
+    return Array.from(set);
+});
+
+const filteredActivities = computed(() => {
+    return activities.value
+        .filter(activity => {
+            const typeMatch = filters.type === 'all' ? true : (activity.type ?? '').toLowerCase() === filters.type.toLowerCase();
+            const stateMatch = (() => {
+                if (filters.state === 'all') return true;
+                const state = (activity.status ?? '').toLowerCase();
+                if (filters.state === 'pending') return ['pending', 'pendiente'].includes(state);
+                if (filters.state === 'completed') return ['completed', 'completada', 'done'].includes(state);
+                if (filters.state === 'overdue') {
+                    const isPast = activity.date ? new Date(activity.date) < new Date() : false;
+                    return ['pending', 'pendiente'].includes(state) && isPast;
+                }
+                return true;
+            })();
+            const searchMatch = filters.search
+                ? [activity.title, activity.description].some(value => value?.toLowerCase().includes(filters.search.toLowerCase()))
+                : true;
+            return typeMatch && stateMatch && searchMatch;
+        })
+        .sort((a, b) => new Date(a.date || 0) - new Date(b.date || 0));
+});
+
+const flowSteps = computed(() => ([
+    {
+        label: 'Lead',
+        description: 'Información calificada y perfilado',
+    },
+    {
+        label: 'Oportunidad',
+        description: 'Seguimiento comercial activo',
+    },
+    {
+        label: 'Tareas',
+        description: 'Ejecución coordinada para cerrar',
+    },
+]));
+
+const isLoading = computed(() => props.isLoading);
+const hasError = computed(() => Boolean(props.error));
+const errorMessage = computed(() => (typeof props.error === 'string' ? props.error : props.error?.message ?? 'No se pudo cargar la información.'));
+
+const deleteActivity = id => {
+    if (confirm('¿Estás seguro de eliminar esta actividad?')) {
+        Inertia.delete(route('activities.destroy', id));
+    }
+};
+
+const readableState = activity => {
+    const state = (activity.status ?? '').toLowerCase();
+    if (['completed', 'completada', 'done'].includes(state)) return 'Completada';
+    if (['pending', 'pendiente'].includes(state)) {
+        if (activity.date && new Date(activity.date) < new Date()) {
+            return 'Vencida';
+        }
+        return 'Pendiente';
+    }
+    return activity.status ?? 'Sin estado';
+};
+
+const formatDate = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleDateString();
+};
+
+const formatDateTime = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleString();
 };
 </script>

--- a/resources/js/Pages/DashboardCrm.structure.md
+++ b/resources/js/Pages/DashboardCrm.structure.md
@@ -1,0 +1,12 @@
+# Dashboard CRM – Componentes visuales e interacciones
+
+- **Encabezado hero**: bloque con degradado `from-violet-700 via-blue-700 to-slate-900`, títulos y descripción introductoria.
+- **Tarjetas KPI**: cuatro tarjetas con borde translúcido y blur que muestran métricas (`Leads`, `Oportunidades`, `Notas`, `Actividades`). Incluyen valores, subtítulos y utilizan `computed` para totals.
+- **Gráfico de líneas**: sección "Actividad mensual" envuelta en tarjeta blanca (`rounded-3xl shadow-xl`) que renderiza `<LineChart>` con datos agregados de actividades.
+- **Próximas acciones**: lista desplazable (`max-h-80`) con actividades futuras, cada elemento es tarjeta con borde suave y punto de estado.
+- **Gráficos secundarios**: tres tarjetas blancas con `<PieChart>`, `<BarChart>` y `<PolarChart>` mostrando origen de leads, conversión de oportunidades y embudo respectivamente.
+- **Estados vacíos**: lista "Próximas acciones" muestra mensaje "No hay actividades programadas" cuando no hay datos.
+- **Interacciones**:
+  - Computados para totales, tasas y embudo (`conversionRate`, `salesFunnelChart`).
+  - Ordenamientos y filtrado para `upcomingActivities` y agregaciones mensuales.
+  - Formateo de fechas a través de `formatDate` helper.

--- a/resources/js/Pages/Leads/Index.vue
+++ b/resources/js/Pages/Leads/Index.vue
@@ -1,92 +1,231 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Leads</h2>
-                        <p class="text-blue-300 text-2xl">{{ totalLeads }}</p>
+        <div class="min-h-screen bg-slate-950 pb-20">
+            <div class="bg-gradient-to-r from-violet-700 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="space-y-2">
+                        <p class="text-violet-200 text-sm uppercase tracking-widest">Gestión de leads</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Impulsa tus oportunidades comerciales</h1>
+                        <p class="text-sm text-violet-200">Centraliza el seguimiento de leads y prepara la conversión hacia oportunidades.</p>
                     </div>
-                </div>
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Leads Activos</h2>
-                        <p class="text-blue-300 text-2xl">{{ activeLeads }}</p>
-                    </div>
-                </div>
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Leads Inactivos</h2>
-                        <p class="text-blue-300 text-2xl">{{ inactiveLeads }}</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <StatsCard label="Leads" :value="totalLeads" :hint="`Activos ${activeLeads}`" />
+                        <StatsCard label="Conversión estimada" :value="conversionRate + '%'" :hint="`Seguidos ${followUpLeads}`" />
+                        <StatsCard label="Nuevos este mes" :value="recentLeads" :hint="`Último ingreso ${latestLeadDate}`" />
+                        <StatsCard label="Fuentes" :value="uniqueSources" :hint="topSourceLabel" />
                     </div>
                 </div>
             </div>
 
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('leads.create')" class="bg-blue-500 hover:text-gray-50 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Agregar nuevo Lead
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-3"/>
-                </NavLink>
-                <table class="w-full table-auto">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 space-y-10">
+                <SectionCard title="Flujo comercial" description="Controla la transición de lead a oportunidad y asegúrate de que cada contacto tenga un siguiente paso definido.">
+                    <FlowStepper :steps="flowSteps" :active-index="0" />
+                </SectionCard>
 
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Email</th>
-                        <th class="px-4 py-2 text-left">Teléfono</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="lead in filteredLeads" :key="lead.id" class="border-t">
-                        <td class="px-4 py-2">{{ lead.name }}</td>
-                        <td class="px-4 py-2">{{ lead.email }}</td>
-                        <td class="px-4 py-2">{{ lead.phone }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('leads.show', lead.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
+                <SectionCard title="Leads" description="Filtra y gestiona tu cartera actual para planificar la conversión.">
+                    <template #actions>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <input v-model="filters.search" type="text" placeholder="Buscar por nombre o empresa" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200" />
+                            <select v-model="filters.status" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todos los estados</option>
+                                <option value="active">Activos</option>
+                                <option value="qualified">Calificados</option>
+                                <option value="inactive">Inactivos</option>
+                            </select>
+                            <select v-model="filters.source" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todas las fuentes</option>
+                                <option v-for="source in sources" :key="source" :value="source">{{ source }}</option>
+                            </select>
+                            <NavLink :href="route('leads.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                <span>Nuevo lead</span>
+                                <AddIcon class="h-4 w-4 fill-white" />
                             </NavLink>
-                            <NavLink :href="route('leads.edit', lead.id)" class="text-yellow-500">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteLead(lead.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
-                        </td>
-                    </tr>
+                        </div>
+                    </template>
 
-                    </tbody>
-                </table>
+                    <div v-if="hasError" class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+                        {{ errorMessage }}
+                    </div>
+                    <div v-else-if="isLoading" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div v-for="i in 4" :key="i" class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/60 p-6">
+                            <div class="h-4 w-24 rounded-full bg-slate-200"></div>
+                            <div class="mt-4 h-6 w-3/4 rounded-full bg-slate-200"></div>
+                            <div class="mt-6 space-y-2">
+                                <div class="h-3 w-full rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-5/6 rounded-full bg-slate-100"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else>
+                        <div v-if="filteredLeads.length" class="space-y-4">
+                            <div v-for="lead in filteredLeads" :key="lead.id" class="rounded-2xl border border-slate-200/70 p-6 transition hover:border-violet-200 hover:shadow-lg hover:shadow-violet-200/30">
+                                <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <div class="flex items-center gap-3">
+                                            <h3 class="text-lg font-semibold text-slate-800">{{ lead.name }}</h3>
+                                            <span class="rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-violet-600">
+                                                {{ lead.status ?? 'Sin estado' }}
+                                            </span>
+                                        </div>
+                                        <p class="mt-1 text-sm text-slate-500">{{ lead.company ?? lead.email ?? 'Sin información de contacto' }}</p>
+                                        <div class="mt-4 flex flex-wrap gap-3 text-xs text-slate-500">
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0-.414.336-.75.75-.75h4.5a.75.75 0 01.75.75v1.5a.75.75 0 01-.75.75H4.5v9h3a.75.75 0 010 1.5h-3A1.5 1.5 0 013 18.75v-12zm12 1.5a.75.75 0 01.75-.75h4.5c.414 0 .75.336.75.75v12a1.5 1.5 0 01-1.5 1.5h-3a.75.75 0 010-1.5h3v-9h-3a.75.75 0 01-.75-.75v-1.5z" />
+                                                </svg>
+                                                {{ lead.source ?? 'Fuente desconocida' }}
+                                            </span>
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75V19.5A1.5 1.5 0 006 21h12a1.5 1.5 0 001.5-1.5V9.75M8.25 21v-6a1.5 1.5 0 011.5-1.5h4.5a1.5 1.5 0 011.5 1.5v6" />
+                                                </svg>
+                                                {{ lead.city ?? 'Localización no definida' }}
+                                            </span>
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                </svg>
+                                                {{ formatDate(lead.created_at) }}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="flex flex-col items-start gap-3 sm:items-end">
+                                        <div class="flex gap-2">
+                                            <NavLink :href="route('leads.show', lead.id)" class="rounded-full border border-violet-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-violet-600 transition hover:bg-violet-600 hover:text-white">Ver</NavLink>
+                                            <NavLink :href="route('leads.edit', lead.id)" class="rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-amber-600 transition hover:bg-amber-500 hover:text-white">Editar</NavLink>
+                                            <button @click="deleteLead(lead.id)" class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-500 transition hover:bg-red-500 hover:text-white">Eliminar</button>
+                                        </div>
+                                        <p class="text-xs text-slate-400">Probabilidad estimada: {{ lead.probability ? `${lead.probability}%` : 'Pendiente' }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <EmptyState v-else title="Aún no tienes leads" description="Registra contactos comerciales y comienza a nutrir tu pipeline.">
+                            <template #action>
+                                <NavLink :href="route('leads.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                    <AddIcon class="h-4 w-4 fill-white" />
+                                    Crear primer lead
+                                </NavLink>
+                            </template>
+                        </EmptyState>
+                    </div>
+                </SectionCard>
             </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
 import { computed, reactive } from 'vue';
-import { defineProps } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import StatsCard from '@/Components/Crm/StatsCard.vue';
+import SectionCard from '@/Components/Crm/SectionCard.vue';
+import FlowStepper from '@/Components/Crm/FlowStepper.vue';
+import EmptyState from '@/Components/Crm/EmptyState.vue';
 
 const props = defineProps({
-    leads: Array,
+    leads: {
+        type: Array,
+        default: () => [],
+    },
+    isLoading: {
+        type: Boolean,
+        default: false,
+    },
+    error: {
+        type: [String, Object],
+        default: null,
+    },
 });
 
-const filteredLeads = props.leads;
-const totalLeads = computed(() => filteredLeads.length);
-const activeLeads = computed(() => filteredLeads.filter(lead => lead.status === 'active').length);
-const inactiveLeads = computed(() => totalLeads.value - activeLeads.value);
+const filters = reactive({
+    search: '',
+    status: 'all',
+    source: 'all',
+});
 
+const leads = computed(() => props.leads ?? []);
+const totalLeads = computed(() => leads.value.length);
+const activeLeads = computed(() => leads.value.filter(lead => ['active', 'qualified'].includes((lead.status || '').toLowerCase())).length);
+const followUpLeads = computed(() => leads.value.filter(lead => ['follow_up', 'seguimiento'].includes((lead.status || '').toLowerCase())).length);
+const recentLeads = computed(() => leads.value.filter(lead => {
+    if (!lead.created_at) return false;
+    const created = new Date(lead.created_at);
+    const now = new Date();
+    return created.getMonth() === now.getMonth() && created.getFullYear() === now.getFullYear();
+}).length);
+const latestLeadDate = computed(() => {
+    if (!leads.value.length) return '—';
+    const latest = [...leads.value].sort((a, b) => new Date(b.created_at || 0) - new Date(a.created_at || 0))[0];
+    return latest?.created_at ? formatDate(latest.created_at) : '—';
+});
+const uniqueSources = computed(() => {
+    const set = new Set(leads.value.map(lead => lead.source).filter(Boolean));
+    return set.size || '—';
+});
+const topSourceLabel = computed(() => {
+    if (!leads.value.length) return 'Sin datos de fuente';
+    const counts = leads.value.reduce((acc, lead) => {
+        const source = lead.source ?? 'Desconocida';
+        acc[source] = (acc[source] || 0) + 1;
+        return acc;
+    }, {});
+    const [top] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] || [];
+    return top ? `Principal: ${top}` : 'Sin datos de fuente';
+});
+const conversionRate = computed(() => {
+    if (!totalLeads.value) return 0;
+    const converted = leads.value.filter(lead => ['qualified', 'opportunity', 'ganado'].includes((lead.status || '').toLowerCase())).length;
+    return Math.round((converted / totalLeads.value) * 100);
+});
 
-const deleteLead = (leadId) => {
-    if (confirm("¿Estás seguro de que deseas eliminar este lead?")) {
+const sources = computed(() => {
+    const set = new Set(leads.value.map(lead => lead.source).filter(Boolean));
+    return Array.from(set);
+});
+
+const filteredLeads = computed(() => {
+    return leads.value.filter(lead => {
+        const matchesSearch = filters.search
+            ? [lead.name, lead.company, lead.email].some(value => value?.toLowerCase().includes(filters.search.toLowerCase()))
+            : true;
+        const status = (lead.status || 'sin_estado').toLowerCase();
+        const matchesStatus = filters.status === 'all' ? true : status === filters.status || (filters.status === 'active' && ['active', 'activo'].includes(status));
+        const matchesSource = filters.source === 'all' ? true : (lead.source ?? '').toLowerCase() === filters.source.toLowerCase();
+        return matchesSearch && matchesStatus && matchesSource;
+    });
+});
+
+const flowSteps = computed(() => ([
+    {
+        label: 'Lead',
+        description: 'Captación y registro del contacto',
+    },
+    {
+        label: 'Oportunidad',
+        description: 'Calificación y valoración económica',
+    },
+    {
+        label: 'Tareas',
+        description: 'Acciones de seguimiento asignadas',
+    },
+]));
+
+const isLoading = computed(() => props.isLoading);
+const hasError = computed(() => Boolean(props.error));
+const errorMessage = computed(() => (typeof props.error === 'string' ? props.error : props.error?.message ?? 'No se pudo cargar la información.'));
+
+const deleteLead = leadId => {
+    if (confirm('¿Estás seguro de que deseas eliminar este lead?')) {
         Inertia.delete(route('leads.destroy', leadId));
     }
 };
 
+const formatDate = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleDateString();
+};
 </script>

--- a/resources/js/Pages/Notes/Index.vue
+++ b/resources/js/Pages/Notes/Index.vue
@@ -1,47 +1,216 @@
 <template>
     <AppLayout>
-    <div>
-        <h1>Notas</h1>
-        <inertia-link :href="route('notes.create')" class="btn btn-primary">Crear Nota</inertia-link>
-        <table>
-            <thead>
-            <tr>
-                <th>Contenido</th>
-                <th>Tipo Relacionado</th>
-                <th>Acciones</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="note in notes.data" :key="note.id">
-                <td>{{ note.content }}</td>
-                <td>{{ note.noteable_type }}</td>
-                <td>
-                    <inertia-link :href="route('notes.show', note.id)" class="btn btn-info">Ver</inertia-link>
-                    <inertia-link :href="route('notes.edit', note.id)" class="btn btn-warning">Editar</inertia-link>
-                    <button @click="deleteNote(note.id)" class="btn btn-danger">Eliminar</button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
-    </AppLayout>
+        <div class="min-h-screen bg-slate-950 pb-20">
+            <div class="bg-gradient-to-r from-violet-700 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="space-y-2">
+                        <p class="text-violet-200 text-sm uppercase tracking-widest">Notas compartidas</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Captura conocimiento clave del equipo</h1>
+                        <p class="text-sm text-violet-200">Documenta conversaciones, acuerdos y próximos pasos para mantener alineado al equipo comercial.</p>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <StatsCard label="Notas" :value="totalNotes" :hint="`Últimas 7 días ${recentNotes}`" />
+                        <StatsCard label="Vinculadas a leads" :value="notesByType('App\\\\Models\\\\Lead')" :hint="'Contexto comercial activo'" />
+                        <StatsCard label="Vinculadas a oportunidades" :value="notesByType('App\\\\Models\\\\Opportunity')" :hint="'Seguimiento de pipeline'" />
+                        <StatsCard label="Autores" :value="uniqueAuthors" :hint="topAuthorLabel" />
+                    </div>
+                </div>
+            </div>
 
+            <div class="max-w-7xl mx-auto px-6 -mt-16 space-y-10">
+                <SectionCard title="Flujo comercial" description="Las notas fortalecen la colaboración entre quienes atraen leads, gestionan oportunidades y ejecutan tareas.">
+                    <FlowStepper :steps="flowSteps" :active-index="1" />
+                </SectionCard>
+
+                <SectionCard title="Notas recientes" description="Filtra por tipo de entidad o autor para acceder rápidamente a la información relevante.">
+                    <template #actions>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <select v-model="filters.relatedType" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todas las relaciones</option>
+                                <option v-for="type in relatedTypes" :key="type" :value="type">{{ readableType(type) }}</option>
+                            </select>
+                            <input v-model="filters.search" type="text" placeholder="Buscar por contenido o autor" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200" />
+                            <NavLink :href="route('notes.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                <span>Nueva nota</span>
+                                <AddIcon class="h-4 w-4 fill-white" />
+                            </NavLink>
+                        </div>
+                    </template>
+
+                    <div v-if="hasError" class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+                        {{ errorMessage }}
+                    </div>
+                    <div v-else-if="isLoading" class="grid grid-cols-1 gap-4">
+                        <div v-for="i in 4" :key="i" class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/60 p-6">
+                            <div class="h-4 w-24 rounded-full bg-slate-200"></div>
+                            <div class="mt-4 h-6 w-3/4 rounded-full bg-slate-200"></div>
+                            <div class="mt-6 space-y-2">
+                                <div class="h-3 w-full rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-5/6 rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-2/3 rounded-full bg-slate-100"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else>
+                        <div v-if="filteredNotes.length" class="space-y-4">
+                            <div v-for="note in filteredNotes" :key="note.id" class="rounded-2xl border border-slate-200/70 bg-white p-6 transition hover:border-violet-200 hover:shadow-lg hover:shadow-violet-200/30">
+                                <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div class="space-y-3">
+                                        <div class="flex items-center gap-3">
+                                            <div class="rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-violet-600">{{ readableType(note.noteable_type) }}</div>
+                                            <p class="text-xs uppercase tracking-widest text-slate-400">{{ formatDateTime(note.created_at) }}</p>
+                                        </div>
+                                        <p class="text-sm text-slate-600">{{ note.content }}</p>
+                                        <div class="flex flex-wrap gap-3 text-xs text-slate-500">
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 20.25a8.25 8.25 0 0115 0" />
+                                                </svg>
+                                                {{ note.author?.name ?? 'Autor desconocido' }}
+                                            </span>
+                                            <span v-if="note.tags?.length" class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 7.5A2.25 2.25 0 017.5 5.25h9A2.25 2.25 0 0118.75 7.5v9a2.25 2.25 0 01-2.25 2.25h-9A2.25 2.25 0 015.25 16.5v-9z" />
+                                                </svg>
+                                                {{ note.tags.join(', ') }}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="flex flex-col items-start gap-3 sm:items-end">
+                                        <NavLink :href="route('notes.show', note.id)" class="rounded-full border border-violet-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-violet-600 transition hover:bg-violet-600 hover:text-white">Ver</NavLink>
+                                        <NavLink :href="route('notes.edit', note.id)" class="rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-amber-600 transition hover:bg-amber-500 hover:text-white">Editar</NavLink>
+                                        <button @click="deleteNote(note.id)" class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-500 transition hover:bg-red-500 hover:text-white">Eliminar</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <EmptyState v-else title="Todavía no hay notas" description="Comparte aprendizajes clave para que el equipo avance coordinado.">
+                            <template #action>
+                                <NavLink :href="route('notes.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                    <AddIcon class="h-4 w-4 fill-white" />
+                                    Crear nota
+                                </NavLink>
+                            </template>
+                        </EmptyState>
+                    </div>
+                </SectionCard>
+            </div>
+        </div>
+    </AppLayout>
 </template>
 
-<script>
+<script setup>
+import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-export default {
-    components: {AppLayout},
-    props: {
-        notes: Object,
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import StatsCard from '@/Components/Crm/StatsCard.vue';
+import SectionCard from '@/Components/Crm/SectionCard.vue';
+import FlowStepper from '@/Components/Crm/FlowStepper.vue';
+import EmptyState from '@/Components/Crm/EmptyState.vue';
+
+const props = defineProps({
+    notes: {
+        type: [Array, Object],
+        default: () => ([]),
     },
-    methods: {
-        deleteNote(id) {
-            if (confirm('¿Estás seguro de eliminar esta nota?')) {
-                Inertia.delete(route('notes.destroy', id));
-            }
-        },
+    isLoading: {
+        type: Boolean,
+        default: false,
     },
+    error: {
+        type: [String, Object],
+        default: null,
+    },
+});
+
+const notes = computed(() => {
+    if (Array.isArray(props.notes)) return props.notes;
+    return props.notes?.data ?? [];
+});
+
+const filters = reactive({
+    relatedType: 'all',
+    search: '',
+});
+
+const totalNotes = computed(() => notes.value.length);
+const recentNotes = computed(() => notes.value.filter(note => {
+    if (!note.created_at) return false;
+    const created = new Date(note.created_at);
+    const now = new Date();
+    const diff = (now - created) / (1000 * 60 * 60 * 24);
+    return diff <= 7;
+}).length);
+const uniqueAuthors = computed(() => {
+    const set = new Set(notes.value.map(note => note.author?.id).filter(Boolean));
+    return set.size || '—';
+});
+const topAuthorLabel = computed(() => {
+    if (!notes.value.length) return 'Sin autores registrados';
+    const counts = notes.value.reduce((acc, note) => {
+        const name = note.author?.name ?? 'Sin autor';
+        acc[name] = (acc[name] || 0) + 1;
+        return acc;
+    }, {});
+    const [author] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] || [];
+    return author ? `Autor destacado: ${author}` : 'Sin autores registrados';
+});
+
+const notesByType = type => notes.value.filter(note => note.noteable_type === type).length;
+
+const relatedTypes = computed(() => {
+    const set = new Set(notes.value.map(note => note.noteable_type).filter(Boolean));
+    return Array.from(set);
+});
+
+const filteredNotes = computed(() => {
+    return notes.value.filter(note => {
+        const typeMatch = filters.relatedType === 'all' ? true : note.noteable_type === filters.relatedType;
+        const searchMatch = filters.search
+            ? [note.content, note.author?.name, note.author?.email].some(value => value?.toLowerCase().includes(filters.search.toLowerCase()))
+            : true;
+        return typeMatch && searchMatch;
+    });
+});
+
+const flowSteps = computed(() => ([
+    {
+        label: 'Lead',
+        description: 'Información calificada y perfilado',
+    },
+    {
+        label: 'Oportunidad',
+        description: 'Seguimiento comercial activo',
+    },
+    {
+        label: 'Tareas',
+        description: 'Ejecución coordinada para cerrar',
+    },
+]));
+
+const isLoading = computed(() => props.isLoading);
+const hasError = computed(() => Boolean(props.error));
+const errorMessage = computed(() => (typeof props.error === 'string' ? props.error : props.error?.message ?? 'No se pudo cargar la información.'));
+
+const deleteNote = id => {
+    if (confirm('¿Estás seguro de eliminar esta nota?')) {
+        Inertia.delete(route('notes.destroy', id));
+    }
+};
+
+const readableType = type => {
+    if (!type) return 'General';
+    if (type.endsWith('Lead')) return 'Lead';
+    if (type.endsWith('Opportunity')) return 'Oportunidad';
+    if (type.endsWith('Task')) return 'Tarea';
+    return type.split('\\').pop();
+};
+
+const formatDateTime = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleString();
 };
 </script>

--- a/resources/js/Pages/Opportunities/Index.vue
+++ b/resources/js/Pages/Opportunities/Index.vue
@@ -1,101 +1,272 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <!-- Estadísticas generales -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-6">
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Total Oportunidades</h2>
-                        <p class="text-blue-300 text-2xl">{{ totalOpportunities }}</p>
+        <div class="min-h-screen bg-slate-950 pb-20">
+            <div class="bg-gradient-to-r from-violet-700 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="space-y-2">
+                        <p class="text-violet-200 text-sm uppercase tracking-widest">Pipeline de oportunidades</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Convierte relaciones en negocios sostenibles</h1>
+                        <p class="text-sm text-violet-200">Supervisa el estado, probabilidad y acciones relacionadas a cada oportunidad.</p>
                     </div>
-                </div>
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Oportunidades Abiertas</h2>
-                        <p class="text-blue-300 text-2xl">{{ openOpportunities }}</p>
-                    </div>
-                </div>
-                <div class="bg-white p-4 shadow-md rounded-lg flex items-center justify-between">
-                    <div>
-                        <h2 class="text-lg text-blue-500 font-semibold">Oportunidades Ganadas</h2>
-                        <p class="text-blue-300 text-2xl">{{ wonOpportunities }}</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <StatsCard label="Oportunidades" :value="totalOpportunities" :hint="`Abiertas ${openOpportunities}`" />
+                        <StatsCard label="Ganadas" :value="wonOpportunities" :hint="`Tasa ${conversionRate}%`" />
+                        <StatsCard label="Valor proyectado" :value="formattedTotalValue" :hint="`Abierto ${formattedOpenValue}`" />
+                        <StatsCard label="Ciclo medio" :value="`${averageCycle} días`" :hint="stageHighlight" />
                     </div>
                 </div>
             </div>
 
-            <!-- Tabla de oportunidades -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <NavLink :href="route('opportunities.create')" class="bg-blue-500 hover:text-gray-50 text-white font-bold py-2 px-4 rounded mb-4 inline-block">
-                    Crear nueva Oportunidad
-                    <AddIcon class="w-6 h-6 fill-gray-200 ml-3"/>
-                </NavLink>
+            <div class="max-w-7xl mx-auto px-6 -mt-16 space-y-10">
+                <SectionCard title="Flujo comercial" description="Mantén alineados a marketing y ventas asegurando un seguimiento continuo desde el lead hacia la ejecución de tareas.">
+                    <FlowStepper :steps="flowSteps" :active-index="1" />
+                </SectionCard>
 
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Lead</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Probabilidad</th>
-
-                        <th class="px-4 py-2 text-left">Valor</th>
-                        <th class="px-4 py-2 text-left">Estado</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="opportunity in opportunities" :key="opportunity.id" class="border-t">
-                        <template v-for="lead in props.leads">
-
-                        <td v-if="opportunity.lead_id === lead.id" class="px-4 py-2">{{ lead.name }}</td>
-
-                        </template>
-                        <td class="px-4 py-2">{{ opportunity.description }}</td>
-                        <td class="px-4 py-2">{{ opportunity.probability }}%</td>
-                        <td class="px-4 py-2">{{ opportunity.value }}</td>
-                        <td class="px-4 py-2">{{ opportunity.status }}</td>
-                        <td class="px-4 py-2 flex items-center">
-                            <NavLink :href="route('opportunities.show', opportunity.id)" class="text-blue-500">
-                                <InfoIcon class="w-5 h-5"/>
+                <SectionCard title="Oportunidades" description="Visualiza la salud del pipeline y prioriza las oportunidades de mayor impacto.">
+                    <template #actions>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <select v-model="filters.status" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todos los estados</option>
+                                <option value="Abierta">Abiertas</option>
+                                <option value="Ganada">Ganadas</option>
+                                <option value="Perdida">Perdidas</option>
+                            </select>
+                            <select v-model="filters.stage" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todas las etapas</option>
+                                <option v-for="stage in stages" :key="stage" :value="stage">{{ stage }}</option>
+                            </select>
+                            <input v-model="filters.search" type="text" placeholder="Buscar por lead o descripción" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200" />
+                            <NavLink :href="route('opportunities.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                <span>Nueva oportunidad</span>
+                                <AddIcon class="h-4 w-4 fill-white" />
                             </NavLink>
-                            <NavLink :href="route('opportunities.edit', opportunity.id)" class="text-yellow-500 ml-2">
-                                <EditIcon class="w-5 h-5"/>
-                            </NavLink>
-                            <button @click="deleteOpportunity(opportunity.id)" class="text-red-500 ml-2">
-                                <DeleteIcon class="w-5 h-5"/>
-                            </button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
+                        </div>
+                    </template>
+
+                    <div v-if="hasError" class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+                        {{ errorMessage }}
+                    </div>
+                    <div v-else-if="isLoading" class="grid grid-cols-1 gap-4">
+                        <div v-for="i in 3" :key="i" class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/60 p-6">
+                            <div class="h-5 w-32 rounded-full bg-slate-200"></div>
+                            <div class="mt-4 h-6 w-1/2 rounded-full bg-slate-200"></div>
+                            <div class="mt-6 space-y-2">
+                                <div class="h-3 w-full rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-5/6 rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-2/3 rounded-full bg-slate-100"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else>
+                        <div v-if="filteredOpportunities.length" class="space-y-4">
+                            <div v-for="opportunity in filteredOpportunities" :key="opportunity.id" class="rounded-2xl border border-slate-200/70 p-6 transition hover:border-violet-200 hover:shadow-lg hover:shadow-violet-200/30">
+                                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                    <div class="space-y-3">
+                                        <div class="flex flex-wrap items-center gap-3">
+                                            <h3 class="text-lg font-semibold text-slate-800">{{ opportunity.description ?? 'Oportunidad sin título' }}</h3>
+                                            <span class="rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-violet-600">{{ opportunity.status ?? 'Sin estado' }}</span>
+                                            <span v-if="opportunity.stage" class="rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-blue-600">{{ opportunity.stage }}</span>
+                                        </div>
+                                        <div class="flex flex-wrap gap-3 text-xs text-slate-500">
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25h13.5v13.5H5.25z" />
+                                                </svg>
+                                                Valor: {{ formatCurrency(opportunity.value) }}
+                                            </span>
+                                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                </svg>
+                                                Última actualización: {{ formatDate(opportunity.updated_at || opportunity.created_at) }}
+                                            </span>
+                                            <span v-if="opportunity.probability" class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18" />
+                                                </svg>
+                                                Probabilidad: {{ opportunity.probability }}%
+                                            </span>
+                                        </div>
+                                        <div class="rounded-2xl bg-slate-50 p-4">
+                                            <p class="text-xs uppercase tracking-widest text-slate-400">Lead asociado</p>
+                                            <p class="mt-2 text-sm font-semibold text-slate-700">{{ leadName(opportunity.lead_id) }}</p>
+                                            <p class="text-xs text-slate-500">{{ leadContact(opportunity.lead_id) }}</p>
+                                        </div>
+                                    </div>
+                                    <div class="flex flex-col items-start gap-3 lg:items-end">
+                                        <div class="flex gap-2">
+                                            <NavLink :href="route('opportunities.show', opportunity.id)" class="rounded-full border border-violet-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-violet-600 transition hover:bg-violet-600 hover:text-white">Ver</NavLink>
+                                            <NavLink :href="route('opportunities.edit', opportunity.id)" class="rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-amber-600 transition hover:bg-amber-500 hover:text-white">Editar</NavLink>
+                                            <button @click="deleteOpportunity(opportunity.id)" class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-500 transition hover:bg-red-500 hover:text-white">Eliminar</button>
+                                        </div>
+                                        <p class="text-xs text-slate-400">Tiempo en etapa: {{ daysInStage(opportunity) }} días</p>
+                                    </div>
+                                </div>
+
+                                <div class="mt-6 border-t border-slate-100 pt-6">
+                                    <p class="text-xs uppercase tracking-widest text-slate-400">Próximos pasos</p>
+                                    <ul class="mt-3 space-y-2 text-sm text-slate-600">
+                                        <li v-if="opportunity.next_action" class="flex items-center gap-2">
+                                            <span class="h-2 w-2 rounded-full bg-violet-500"></span>
+                                            {{ opportunity.next_action }}
+                                        </li>
+                                        <li v-else class="text-slate-400">Sin tareas registradas. Crea una desde el módulo de tareas.</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <EmptyState v-else title="No se registran oportunidades" description="Promociona leads calificados y construye propuestas para generar nuevas oportunidades.">
+                            <template #action>
+                                <NavLink :href="route('opportunities.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                    <AddIcon class="h-4 w-4 fill-white" />
+                                    Crear oportunidad
+                                </NavLink>
+                            </template>
+                        </EmptyState>
+                    </div>
+                </SectionCard>
             </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import AddIcon from "@/Components/Icons/AddIcon.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
-import { computed } from 'vue';
-import { defineProps } from 'vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import StatsCard from '@/Components/Crm/StatsCard.vue';
+import SectionCard from '@/Components/Crm/SectionCard.vue';
+import FlowStepper from '@/Components/Crm/FlowStepper.vue';
+import EmptyState from '@/Components/Crm/EmptyState.vue';
 
 const props = defineProps({
-    opportunities: Object,
-    leads: Array,
+    opportunities: {
+        type: Array,
+        default: () => [],
+    },
+    leads: {
+        type: Array,
+        default: () => [],
+    },
+    isLoading: {
+        type: Boolean,
+        default: false,
+    },
+    error: {
+        type: [String, Object],
+        default: null,
+    },
 });
-const opportunities = props.opportunities;
-const totalOpportunities = computed(() =>opportunities.length);
-const openOpportunities = computed(() =>opportunities.filter(o => o.status === 'Abierta').length);
-const wonOpportunities = computed(() =>opportunities.filter(o => o.status === 'Ganada').length);
 
-const deleteOpportunity = (opportunityId) => {
-    if (confirm("¿Estás seguro de que deseas eliminar esta oportunidad?")) {
+const opportunities = computed(() => props.opportunities ?? []);
+const leads = computed(() => props.leads ?? []);
+
+const filters = reactive({
+    status: 'all',
+    stage: 'all',
+    search: '',
+});
+
+const leadMap = computed(() => {
+    return leads.value.reduce((acc, lead) => {
+        acc[lead.id] = lead;
+        return acc;
+    }, {});
+});
+
+const totalOpportunities = computed(() => opportunities.value.length);
+const openOpportunities = computed(() => opportunities.value.filter(o => (o.status || '').toLowerCase() === 'abierta').length);
+const wonOpportunities = computed(() => opportunities.value.filter(o => (o.status || '').toLowerCase() === 'ganada').length);
+const totalValue = computed(() => opportunities.value.reduce((sum, opportunity) => sum + Number(opportunity.value || 0), 0));
+const openValue = computed(() => opportunities.value.filter(o => (o.status || '').toLowerCase() === 'abierta').reduce((sum, opportunity) => sum + Number(opportunity.value || 0), 0));
+const conversionRate = computed(() => {
+    if (!totalOpportunities.value) return 0;
+    return Math.round((wonOpportunities.value / totalOpportunities.value) * 100);
+});
+
+const averageCycle = computed(() => {
+    if (!opportunities.value.length) return 0;
+    const days = opportunities.value.map(opportunity => {
+        const created = new Date(opportunity.created_at || Date.now());
+        const closed = opportunity.closed_at ? new Date(opportunity.closed_at) : new Date();
+        return Math.max(1, Math.round((closed - created) / (1000 * 60 * 60 * 24)));
+    });
+    return Math.round(days.reduce((sum, day) => sum + day, 0) / days.length);
+});
+
+const stageHighlight = computed(() => {
+    if (!opportunities.value.length) return 'Sin etapas destacadas';
+    const counts = opportunities.value.reduce((acc, opportunity) => {
+        const stage = opportunity.stage ?? 'Sin etapa';
+        acc[stage] = (acc[stage] || 0) + 1;
+        return acc;
+    }, {});
+    const [stage] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] || [];
+    return stage ? `Etapa más frecuente: ${stage}` : 'Sin etapas destacadas';
+});
+
+const stages = computed(() => {
+    const set = new Set(opportunities.value.map(opportunity => opportunity.stage).filter(Boolean));
+    return Array.from(set);
+});
+
+const filteredOpportunities = computed(() => {
+    return opportunities.value.filter(opportunity => {
+        const status = filters.status === 'all' ? true : (opportunity.status ?? '').toLowerCase() === filters.status.toLowerCase();
+        const stage = filters.stage === 'all' ? true : (opportunity.stage ?? '').toLowerCase() === filters.stage.toLowerCase();
+        const text = [opportunity.description, leadName(opportunity.lead_id)].join(' ').toLowerCase();
+        const search = filters.search.toLowerCase();
+        return status && stage && (!search || text.includes(search));
+    });
+});
+
+const flowSteps = computed(() => ([
+    {
+        label: 'Lead',
+        description: 'Información calificada y perfilado',
+    },
+    {
+        label: 'Oportunidad',
+        description: 'Seguimiento comercial activo',
+    },
+    {
+        label: 'Tareas',
+        description: 'Ejecución coordinada para cerrar',
+    },
+]));
+
+const isLoading = computed(() => props.isLoading);
+const hasError = computed(() => Boolean(props.error));
+const errorMessage = computed(() => (typeof props.error === 'string' ? props.error : props.error?.message ?? 'No se pudo cargar la información.'));
+
+const formattedTotalValue = computed(() => formatCurrency(totalValue.value));
+const formattedOpenValue = computed(() => formatCurrency(openValue.value));
+
+const deleteOpportunity = opportunityId => {
+    if (confirm('¿Estás seguro de que deseas eliminar esta oportunidad?')) {
         Inertia.delete(route('opportunities.destroy', opportunityId));
-
     }
+};
+
+const leadName = leadId => leadMap.value[leadId]?.name ?? 'Lead no asignado';
+const leadContact = leadId => leadMap.value[leadId]?.email ?? leadMap.value[leadId]?.phone ?? 'Sin contacto registrado';
+
+const daysInStage = opportunity => {
+    if (!opportunity.stage_entered_at) return 0;
+    const entered = new Date(opportunity.stage_entered_at);
+    const now = new Date();
+    return Math.max(1, Math.round((now - entered) / (1000 * 60 * 60 * 24)));
+};
+
+function formatCurrency(value) {
+    const number = Number(value || 0);
+    return number.toLocaleString('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+}
+
+const formatDate = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleDateString();
 };
 </script>

--- a/resources/js/Pages/Tasks/Index.vue
+++ b/resources/js/Pages/Tasks/Index.vue
@@ -1,51 +1,270 @@
 <template>
     <AppLayout>
-    <div>
-        <h1>Tareas</h1>
-        <inertia-link :href="route('tasks.create')" class="btn btn-primary">Crear Tarea</inertia-link>
-        <table>
-            <thead>
-            <tr>
-                <th>Título</th>
-                <th>Descripción</th>
-                <th>Fecha de Vencimiento</th>
-                <th>Estado</th>
-                <th>Acciones</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="task in tasks.data" :key="task.id">
-                <td>{{ task.title }}</td>
-                <td>{{ task.description }}</td>
-                <td>{{ task.due_date }}</td>
-                <td>{{ task.status }}</td>
-                <td>
-                    <inertia-link :href="route('tasks.show', task.id)" class="btn btn-info">Ver</inertia-link>
-                    <inertia-link :href="route('tasks.edit', task.id)" class="btn btn-warning">Editar</inertia-link>
-                    <button @click="deleteTask(task.id)" class="btn btn-danger">Eliminar</button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
+        <div class="min-h-screen bg-slate-950 pb-20">
+            <div class="bg-gradient-to-r from-violet-700 via-blue-700 to-slate-900 pb-24">
+                <div class="max-w-7xl mx-auto px-6 pt-10">
+                    <div class="space-y-2">
+                        <p class="text-violet-200 text-sm uppercase tracking-widest">Tareas</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Coordina la ejecución con tu equipo</h1>
+                        <p class="text-sm text-violet-200">Distribuye responsabilidades y haz seguimiento de los compromisos derivados de cada oportunidad.</p>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                        <StatsCard label="Tareas" :value="totalTasks" :hint="`Pendientes ${pendingTasks}`" />
+                        <StatsCard label="En progreso" :value="inProgressTasks" :hint="`Completadas ${completedTasks}`" />
+                        <StatsCard label="Vencidas" :value="overdueTasks" :hint="'Prioriza acciones críticas'" />
+                        <StatsCard label="Asignadas" :value="assignedUsers" :hint="topAssigneeLabel" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="max-w-7xl mx-auto px-6 -mt-16 space-y-10">
+                <SectionCard title="Flujo comercial" description="Las tareas consolidan todo el trabajo pendiente para cerrar oportunidades con éxito.">
+                    <FlowStepper :steps="flowSteps" :active-index="2" />
+                </SectionCard>
+
+                <SectionCard title="Lista de tareas" description="Filtra por estado, prioridad o responsable para asegurar el cumplimiento de compromisos.">
+                    <template #actions>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <select v-model="filters.status" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todos los estados</option>
+                                <option value="pending">Pendientes</option>
+                                <option value="in_progress">En progreso</option>
+                                <option value="completed">Completadas</option>
+                            </select>
+                            <select v-model="filters.priority" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200">
+                                <option value="all">Todas las prioridades</option>
+                                <option value="low">Baja</option>
+                                <option value="medium">Media</option>
+                                <option value="high">Alta</option>
+                            </select>
+                            <input v-model="filters.search" type="text" placeholder="Buscar por título, oportunidad o responsable" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-200" />
+                            <NavLink :href="route('tasks.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                <span>Nueva tarea</span>
+                                <AddIcon class="h-4 w-4 fill-white" />
+                            </NavLink>
+                        </div>
+                    </template>
+
+                    <div v-if="hasError" class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-600">
+                        {{ errorMessage }}
+                    </div>
+                    <div v-else-if="isLoading" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div v-for="i in 4" :key="i" class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/60 p-6">
+                            <div class="h-4 w-24 rounded-full bg-slate-200"></div>
+                            <div class="mt-4 h-6 w-3/4 rounded-full bg-slate-200"></div>
+                            <div class="mt-6 space-y-2">
+                                <div class="h-3 w-full rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-5/6 rounded-full bg-slate-100"></div>
+                                <div class="h-3 w-2/3 rounded-full bg-slate-100"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else>
+                        <div v-if="filteredTasks.length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div v-for="task in filteredTasks" :key="task.id" class="rounded-2xl border border-slate-200/70 bg-white p-6 transition hover:border-violet-200 hover:shadow-lg hover:shadow-violet-200/30">
+                                <div class="flex flex-col gap-3">
+                                    <div class="flex items-center justify-between">
+                                        <h3 class="text-lg font-semibold text-slate-800">{{ task.title }}</h3>
+                                        <span :class="['rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-widest', priorityBadge(task.priority)]">
+                                            {{ readablePriority(task.priority) }}
+                                        </span>
+                                    </div>
+                                    <p class="text-sm text-slate-500">{{ task.description ?? 'Sin descripción registrada.' }}</p>
+                                    <div class="flex flex-wrap gap-3 text-xs text-slate-500">
+                                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                            </svg>
+                                            {{ formatDate(task.due_date) }}
+                                        </span>
+                                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-9A2.25 2.25 0 002.25 5.25v13.5A2.25 2.25 0 004.5 21h9a2.25 2.25 0 002.25-2.25V15" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l3 3L21 6" />
+                                            </svg>
+                                            Estado: {{ readableStatus(task.status) }}
+                                        </span>
+                                        <span v-if="task.assigned_to" class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 20.25a8.25 8.25 0 0115 0" />
+                                            </svg>
+                                            {{ assigneeName(task.assigned_to) }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-4">
+                                    <div class="text-xs uppercase tracking-widest text-slate-400">
+                                        {{ relatedOpportunity(task.opportunity) }}
+                                    </div>
+                                    <div class="flex gap-2">
+                                        <NavLink :href="route('tasks.show', task.id)" class="rounded-full border border-violet-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-violet-600 transition hover:bg-violet-600 hover:text-white">Ver</NavLink>
+                                        <NavLink :href="route('tasks.edit', task.id)" class="rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-amber-600 transition hover:bg-amber-500 hover:text-white">Editar</NavLink>
+                                        <button @click="deleteTask(task.id)" class="rounded-full border border-red-200 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-red-500 transition hover:bg-red-500 hover:text-white">Eliminar</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <EmptyState v-else title="No hay tareas asignadas" description="Define acciones concretas para cada oportunidad y haz seguimiento al progreso.">
+                            <template #action>
+                                <NavLink :href="route('tasks.create')" class="inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-violet-600/40 transition hover:bg-violet-500">
+                                    <AddIcon class="h-4 w-4 fill-white" />
+                                    Crear tarea
+                                </NavLink>
+                            </template>
+                        </EmptyState>
+                    </div>
+                </SectionCard>
+            </div>
+        </div>
     </AppLayout>
 </template>
 
-<script>
+<script setup>
+import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
+import AppLayout from '@/Layouts/AppLayout.vue';
+import NavLink from '@/Components/NavLink.vue';
+import AddIcon from '@/Components/Icons/AddIcon.vue';
+import StatsCard from '@/Components/Crm/StatsCard.vue';
+import SectionCard from '@/Components/Crm/SectionCard.vue';
+import FlowStepper from '@/Components/Crm/FlowStepper.vue';
+import EmptyState from '@/Components/Crm/EmptyState.vue';
 
-export default {
-    components: {AppLayout},
-    props: {
-        tasks: Object,
+const props = defineProps({
+    tasks: {
+        type: [Array, Object],
+        default: () => ([]),
     },
-    methods: {
-        deleteTask(id) {
-            if (confirm('¿Estás seguro de eliminar esta tarea?')) {
-                Inertia.delete(route('tasks.destroy', id));
-            }
-        },
+    isLoading: {
+        type: Boolean,
+        default: false,
     },
+    error: {
+        type: [String, Object],
+        default: null,
+    },
+});
+
+const tasks = computed(() => {
+    if (Array.isArray(props.tasks)) return props.tasks;
+    return props.tasks?.data ?? [];
+});
+
+const filters = reactive({
+    status: 'all',
+    priority: 'all',
+    search: '',
+});
+
+const totalTasks = computed(() => tasks.value.length);
+const pendingTasks = computed(() => tasks.value.filter(task => ['pending', 'pendiente'].includes((task.status || '').toLowerCase())).length);
+const inProgressTasks = computed(() => tasks.value.filter(task => ['in_progress', 'en progreso', 'en_progreso'].includes((task.status || '').toLowerCase())).length);
+const completedTasks = computed(() => tasks.value.filter(task => ['completed', 'completada', 'hecha'].includes((task.status || '').toLowerCase())).length);
+const overdueTasks = computed(() => tasks.value.filter(task => {
+    if (!task.due_date) return false;
+    const due = new Date(task.due_date);
+    return due < new Date() && !['completed', 'completada', 'hecha'].includes((task.status || '').toLowerCase());
+}).length);
+const assignedUsers = computed(() => {
+    const set = new Set(tasks.value.map(task => task.assigned_to?.id ?? task.assigned_to).filter(Boolean));
+    return set.size || '—';
+});
+const topAssigneeLabel = computed(() => {
+    if (!tasks.value.length) return 'Sin responsables destacados';
+    const counts = tasks.value.reduce((acc, task) => {
+        const name = task.assigned_to?.name ?? task.assigned_to?.full_name ?? (typeof task.assigned_to === 'string' ? task.assigned_to : 'Sin asignar');
+        acc[name] = (acc[name] || 0) + 1;
+        return acc;
+    }, {});
+    const [name] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] || [];
+    return name ? `Responsable destacado: ${name}` : 'Sin responsables destacados';
+});
+
+const filteredTasks = computed(() => {
+    return tasks.value.filter(task => {
+        const status = (task.status || '').toLowerCase();
+        const priority = (task.priority || '').toLowerCase();
+        const statusMatch = (() => {
+            if (filters.status === 'all') return true;
+            if (filters.status === 'pending') return ['pending', 'pendiente'].includes(status);
+            if (filters.status === 'in_progress') return ['in_progress', 'en progreso', 'en_progreso'].includes(status);
+            if (filters.status === 'completed') return ['completed', 'completada', 'hecha'].includes(status);
+            return true;
+        })();
+        const priorityMatch = filters.priority === 'all' ? true : priority === filters.priority;
+        const searchSpace = [task.title, task.description, relatedOpportunity(task.opportunity), assigneeName(task.assigned_to)].join(' ').toLowerCase();
+        const searchMatch = filters.search ? searchSpace.includes(filters.search.toLowerCase()) : true;
+        return statusMatch && priorityMatch && searchMatch;
+    });
+});
+
+const flowSteps = computed(() => ([
+    {
+        label: 'Lead',
+        description: 'Información calificada y perfilado',
+    },
+    {
+        label: 'Oportunidad',
+        description: 'Seguimiento comercial activo',
+    },
+    {
+        label: 'Tareas',
+        description: 'Ejecución coordinada para cerrar',
+    },
+]));
+
+const isLoading = computed(() => props.isLoading);
+const hasError = computed(() => Boolean(props.error));
+const errorMessage = computed(() => (typeof props.error === 'string' ? props.error : props.error?.message ?? 'No se pudo cargar la información.'));
+
+const deleteTask = id => {
+    if (confirm('¿Estás seguro de eliminar esta tarea?')) {
+        Inertia.delete(route('tasks.destroy', id));
+    }
+};
+
+const readableStatus = status => {
+    const value = (status || '').toLowerCase();
+    if (['completed', 'completada', 'hecha'].includes(value)) return 'Completada';
+    if (['in_progress', 'en progreso', 'en_progreso'].includes(value)) return 'En progreso';
+    if (['pending', 'pendiente'].includes(value)) return 'Pendiente';
+    return status ?? 'Sin estado';
+};
+
+const readablePriority = priority => {
+    const value = (priority || '').toLowerCase();
+    if (value === 'high') return 'Alta';
+    if (value === 'medium') return 'Media';
+    if (value === 'low') return 'Baja';
+    return priority ?? 'Sin prioridad';
+};
+
+const priorityBadge = priority => {
+    const value = (priority || '').toLowerCase();
+    if (value === 'high') return 'bg-rose-100 text-rose-600';
+    if (value === 'medium') return 'bg-amber-100 text-amber-600';
+    if (value === 'low') return 'bg-emerald-100 text-emerald-600';
+    return 'bg-slate-100 text-slate-500';
+};
+
+const formatDate = date => {
+    if (!date) return '—';
+    return new Date(date).toLocaleDateString();
+};
+
+const assigneeName = assignee => {
+    if (!assignee) return 'Sin asignar';
+    if (typeof assignee === 'string') return assignee;
+    return assignee.name ?? assignee.full_name ?? 'Sin asignar';
+};
+
+const relatedOpportunity = opportunity => {
+    if (!opportunity) return 'Sin oportunidad relacionada';
+    if (typeof opportunity === 'string') return `Oportunidad: ${opportunity}`;
+    if (typeof opportunity === 'object') {
+        return `Oportunidad: ${opportunity.description ?? opportunity.title ?? opportunity.name ?? opportunity.id}`;
+    }
+    return 'Sin oportunidad relacionada';
 };
 </script>


### PR DESCRIPTION
## Summary
- document the visual and interaction architecture of the CRM dashboard for future reference
- introduce reusable CRM layout components (stats, sections, flow stepper, empty state) to standardize cards, timelines, and filters
- restyle leads, opportunities, activities, notes, and tasks pages with the new components, unified funnel flow, and consistent loading/empty/error handling

## Testing
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js" in the local container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5dfd4ce4832397e06b7db4649492