### PR TITLE
Refine admin UI with reusable dashboard components

### DIFF
--- a/resources/js/Components/Dashboard/AdminPage.vue
+++ b/resources/js/Components/Dashboard/AdminPage.vue
@@ -1,0 +1,37 @@
+<template>
+    <div class="min-h-screen bg-slate-950">
+        <div v-if="!flushHeader || $slots.header" :class="headerWrapperClasses">
+            <div class="max-w-7xl mx-auto px-6 pt-10">
+                <slot name="header" />
+            </div>
+        </div>
+        <div :class="contentWrapperClasses">
+            <slot />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+const props = defineProps({
+    flushHeader: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const slots = useSlots();
+
+const hasHeader = computed(() => Boolean(slots.header));
+
+const headerWrapperClasses = computed(() => [
+    'pb-24',
+    props.flushHeader ? 'bg-slate-950' : 'bg-gradient-to-r from-slate-900 via-blue-900 to-indigo-900',
+]);
+
+const contentWrapperClasses = computed(() => [
+    'max-w-7xl mx-auto px-6 pb-16 space-y-10',
+    hasHeader.value ? '-mt-16' : 'pt-10',
+]);
+</script>

--- a/resources/js/Components/Dashboard/AdminPanel.vue
+++ b/resources/js/Components/Dashboard/AdminPanel.vue
@@ -1,0 +1,50 @@
+<template>
+    <section class="bg-white rounded-3xl shadow-xl">
+        <header v-if="hasHeader" class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 px-6 pt-6 pb-5">
+            <div>
+                <h2 v-if="title" class="text-xl font-semibold text-slate-800">{{ title }}</h2>
+                <p v-if="description" class="mt-1 text-sm text-slate-500">{{ description }}</p>
+                <slot name="subtitle" />
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+                <slot name="actions" />
+            </div>
+        </header>
+        <div :class="bodyClasses">
+            <slot />
+        </div>
+    </section>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+const props = defineProps({
+    title: {
+        type: String,
+        default: '',
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    padding: {
+        type: String,
+        default: 'px-6 pb-6',
+    },
+});
+
+const slots = useSlots();
+
+const hasHeader = computed(() => Boolean(
+    props.title ||
+    props.description ||
+    slots.subtitle ||
+    slots.actions
+));
+
+const bodyClasses = computed(() => [
+    props.padding,
+    'pt-6',
+]);
+</script>

--- a/resources/js/Components/Dashboard/AdminStatCard.vue
+++ b/resources/js/Components/Dashboard/AdminStatCard.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl p-6 text-white shadow-lg">
+        <p v-if="label" class="text-xs uppercase tracking-[0.3em] text-blue-200">{{ label }}</p>
+        <div class="mt-2 flex items-baseline justify-between gap-4">
+            <p class="text-3xl font-semibold">{{ value }}</p>
+            <slot name="badge" />
+        </div>
+        <p v-if="description" class="mt-3 text-sm text-blue-200">{{ description }}</p>
+        <slot />
+    </div>
+</template>
+
+<script setup>
+defineProps({
+    label: {
+        type: String,
+        default: '',
+    },
+    value: {
+        type: [String, Number],
+        default: '',
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+});
+</script>

--- a/resources/js/Components/Dashboard/AdminTable.vue
+++ b/resources/js/Components/Dashboard/AdminTable.vue
@@ -1,0 +1,9 @@
+<template>
+    <div class="overflow-hidden rounded-3xl bg-white shadow-xl">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-600">
+                <slot />
+            </table>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/AdminUser/Dashboard.vue
+++ b/resources/js/Pages/AdminUser/Dashboard.vue
@@ -1,146 +1,150 @@
 <template>
     <AppLayout>
-    <div class="p-6 bg-gray-100 min-h-screen">
-        <div class="mb-6 flex justify-between items-center">
-            <h1 class="text-3xl font-bold text-blue-600">Admin Dashboard</h1>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Panel administrativo</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Resumen general</h1>
+                        <p class="text-sm text-blue-200">Gestiona compañías, usuarios y monitoriza la actividad desde un mismo lugar.</p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-3">
+                        <NavLink :href="route('companies.create')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 transition hover:bg-white/20">
+                            Crear compañía
+                        </NavLink>
+                        <NavLink :href="route('users.adminCreate')" class="inline-flex items-center gap-2 rounded-xl border border-white/30 px-4 py-2 text-sm font-semibold text-white/80 backdrop-blur transition hover:bg-white/10">
+                            Crear usuario
+                        </NavLink>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <AdminStatCard label="Compañías" :value="companiesLength" description="Registradas en la plataforma" />
+                    <AdminStatCard label="Usuarios totales" :value="userLength" description="Cuentas creadas" />
+                    <AdminStatCard label="Usuarios activos" :value="activeUsersCount" description="Con actividad reciente" />
+                    <AdminStatCard label="Estados registrados" :value="statusTypes" description="Variantes de estado de usuario" />
+                </div>
+            </template>
 
-            <!-- Botones para crear compañías y usuarios -->
-            <div class="space-x-4">
-                <NavLink :href="route('companies.create')"
-                    class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg"
-                >
-                    Crear Compañía
-                </NavLink>
-                <NavLink :href="route('users.adminCreate')"
-                    class="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg"
-                >
-                    Crear Usuario
-                </NavLink>
+            <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
+                <AdminPanel title="Compañías registradas por mes" description="Visualiza el crecimiento de la red de compañías." :padding="'px-6 pb-6'">
+                    <canvas ref="companiesChartRef" class="mt-2"></canvas>
+                </AdminPanel>
+                <AdminPanel title="Distribución de estados de usuario" description="Identifica la actividad general de los usuarios." :padding="'px-6 pb-6'">
+                    <canvas ref="usersChartRef" class="mt-2"></canvas>
+                </AdminPanel>
             </div>
-        </div>
-
-        <!-- Widgets -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <!-- Total Companies Widget -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-lg font-semibold">Total Companies</h2>
-                <p class="text-4xl font-bold text-blue-500">{{ companiesLength }}</p>
-            </div>
-
-            <!-- Total Users Widget -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-lg font-semibold">Total Users</h2>
-                <p class="text-4xl font-bold text-blue-500">{{ userLength }}</p>
-            </div>
-
-            <!-- Active Users Widget -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-lg font-semibold">Active Users</h2>
-                <p class="text-4xl font-bold text-green-500">{{ activeUsersCount }}</p>
-            </div>
-        </div>
-
-        <!-- Charts Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
-            <!-- Companies per Month Bar Chart -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-lg font-semibold mb-4">Companies Registered per Month</h2>
-                <canvas id="companiesBarChart"></canvas>
-            </div>
-
-            <!-- Users Activity Pie Chart -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-lg font-semibold mb-4">User Activity Breakdown</h2>
-                <canvas id="userPieChart"></canvas>
-            </div>
-        </div>
-    </div>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import { defineProps, computed, onMounted } from 'vue'
-import Chart from 'chart.js/auto'
-import {Inertia} from "@inertiajs/inertia";
-import NavLink from "@/Components/NavLink.vue";
+import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
+import Chart from 'chart.js/auto';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
     companies: Array,
     users: Array,
-})
+});
 
-const userLength = props.users.length
-const companiesLength = props.companies.length
+const userLength = computed(() => props.users.length);
+const companiesLength = computed(() => props.companies.length);
+const activeUsersCount = computed(() => props.users.filter((user) => user.isActive).length);
+const statusTypes = computed(() => new Set(props.users.map((user) => user.status ?? 'Sin estado')).size);
 
-// Computed property for active users count
-const activeUsersCount = computed(() => props.users.filter(user => user.isActive).length)
+const companiesChartRef = ref(null);
+const usersChartRef = ref(null);
+let companiesChartInstance = null;
+let usersChartInstance = null;
 
-// Function to handle company creation
+const monthlyCompanies = computed(() => {
+    const summary = props.companies.reduce((acc, company) => {
+        if (!company.registrationDate) {
+            return acc;
+        }
+        const date = new Date(company.registrationDate);
+        const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+    const sortedKeys = Object.keys(summary).sort();
+    return {
+        labels: sortedKeys.map((key) => {
+            const [year, month] = key.split('-');
+            return new Date(Number(year), Number(month) - 1).toLocaleString('default', { month: 'short', year: 'numeric' });
+        }),
+        values: sortedKeys.map((key) => summary[key]),
+    };
+});
 
-
-// Function to handle user creation
-const createUser = () => {
-return Inertia.get(route('user.createAdmin'))}
+const userStatusDistribution = computed(() => {
+    const summary = props.users.reduce((acc, user) => {
+        const key = user.status ?? 'Sin estado';
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+    return {
+        labels: Object.keys(summary),
+        values: Object.values(summary),
+    };
+});
 
 onMounted(() => {
-    // Bar Chart for Companies per Month
-    const companiesCtx = document.getElementById('companiesBarChart').getContext('2d')
-    const companiesData = props.companies.reduce((acc, company) => {
-        const month = new Date(company.registrationDate).toLocaleString('default', { month: 'short' })
-        acc[month] = (acc[month] || 0) + 1
-        return acc
-    }, {})
-
-    new Chart(companiesCtx, {
-        type: 'bar',
-        data: {
-            labels: Object.keys(companiesData),
-            datasets: [{
-                label: 'Companies',
-                data: Object.values(companiesData),
-                backgroundColor: 'rgba(54, 162, 235, 0.6)',
-            }]
-        },
-        options: {
-            responsive: true,
-            scales: {
-                y: {
-                    beginAtZero: true,
+    if (companiesChartRef.value) {
+        companiesChartInstance = new Chart(companiesChartRef.value.getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: monthlyCompanies.value.labels,
+                datasets: [
+                    {
+                        label: 'Compañías',
+                        data: monthlyCompanies.value.values,
+                        backgroundColor: 'rgba(59, 130, 246, 0.45)',
+                        borderRadius: 12,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        grid: { color: 'rgba(148, 163, 184, 0.2)' },
+                    },
+                    x: {
+                        grid: { display: false },
+                    },
                 },
             },
-        },
-    })
+        });
+    }
 
-    // Pie Chart for Users Activity
-    const userActivityData = props.users.reduce((acc, user) => {
-        acc[user.status] = (acc[user.status] || 0) + 1
-        return acc
-    }, {})
-
-    const userCtx = document.getElementById('userPieChart').getContext('2d')
-    new Chart(userCtx, {
-        type: 'pie',
-        data: {
-            labels: Object.keys(userActivityData),
-            datasets: [{
-                label: 'Users',
-                data: Object.values(userActivityData),
-                backgroundColor: [
-                    'rgba(255, 99, 132, 0.6)',
-                    'rgba(54, 162, 235, 0.6)',
-                    'rgba(75, 192, 192, 0.6)',
-                    'rgba(153, 102, 255, 0.6)',
+    if (usersChartRef.value) {
+        usersChartInstance = new Chart(usersChartRef.value.getContext('2d'), {
+            type: 'pie',
+            data: {
+                labels: userStatusDistribution.value.labels,
+                datasets: [
+                    {
+                        label: 'Usuarios',
+                        data: userStatusDistribution.value.values,
+                        backgroundColor: ['#6366F1', '#22D3EE', '#F97316', '#A855F7', '#14B8A6'],
+                    },
                 ],
-            }]
-        },
-        options: {
-            responsive: true,
-        },
-    })
-})
-</script>
+            },
+            options: {
+                responsive: true,
+            },
+        });
+    }
+});
 
-<style scoped>
-/* Custom styles for widgets and charts */
-</style>
+onBeforeUnmount(() => {
+    companiesChartInstance?.destroy();
+    usersChartInstance?.destroy();
+});
+</script>

--- a/resources/js/Pages/AdminUser/Login.vue
+++ b/resources/js/Pages/AdminUser/Login.vue
@@ -1,40 +1,40 @@
 <template>
-    <div class="container mx-auto">
-        <h1 class="text-xl font-bold">Admin Login</h1>
-        <form @submit.prevent="login">
-            <div class="mb-4">
-                <label for="email" class="block">Email</label>
-                <input v-model="form.email" type="email" id="email" class="border w-full" required />
-            </div>
-            <div class="mb-4">
-                <label for="password" class="block">Password</label>
-                <input v-model="form.password" type="password" id="password" class="border w-full" required />
-            </div>
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Login</button>
-            <p v-if="errors" class="text-red-500 mt-2">{{ errors }}</p>
-        </form>
-    </div>
+    <AdminPage :flushHeader="true">
+        <div class="mx-auto mt-24 w-full max-w-md">
+            <AdminPanel title="Acceso de administrador" description="Introduce tus credenciales para continuar.">
+                <form @submit.prevent="submit" class="space-y-5">
+                    <div class="space-y-2">
+                        <label for="email" class="block text-sm font-medium text-slate-600">Correo electrónico</label>
+                        <input id="email" v-model="form.email" type="email" :class="inputClasses" required autocomplete="email" />
+                        <p v-if="form.errors.email" class="text-xs text-rose-500">{{ form.errors.email }}</p>
+                    </div>
+                    <div class="space-y-2">
+                        <label for="password" class="block text-sm font-medium text-slate-600">Contraseña</label>
+                        <input id="password" v-model="form.password" type="password" :class="inputClasses" required autocomplete="current-password" />
+                        <p v-if="form.errors.password" class="text-xs text-rose-500">{{ form.errors.password }}</p>
+                    </div>
+                    <button type="submit" class="w-full rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition" :disabled="form.processing">
+                        {{ form.processing ? 'Accediendo...' : 'Iniciar sesión' }}
+                    </button>
+                </form>
+            </AdminPanel>
+        </div>
+    </AdminPage>
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue';
 import { useForm } from '@inertiajs/vue3';
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
-const form = reactive({
+const form = useForm({
     email: '',
     password: '',
 });
 
-const errors = ref(null);
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
-const login = () => {
-    useForm({
-        email: form.email,
-        password: form.password,
-    }).post(route('admin.login'), {
-        onError: (error) => {
-            errors.value = error.email || 'Invalid credentials';
-        },
-    });
+const submit = () => {
+    form.post(route('admin.login'));
 };
 </script>

--- a/resources/js/Pages/AdminUser/Register.vue
+++ b/resources/js/Pages/AdminUser/Register.vue
@@ -1,47 +1,51 @@
 <template>
-    <div class="container mx-auto">
-        <h1 class="text-xl font-bold">Admin Register</h1>
-        <form @submit.prevent="register">
-            <div class="mb-4">
-                <label for="name" class="block">Name</label>
-                <input v-model="form.name" type="text" id="name" class="border w-full" required />
-            </div>
-            <div class="mb-4">
-                <label for="email" class="block">Email</label>
-                <input v-model="form.email" type="email" id="email" class="border w-full" required />
-            </div>
-            <div class="mb-4">
-                <label for="password" class="block">Password</label>
-                <input v-model="form.password" type="password" id="password" class="border w-full" required />
-            </div>
-            <div class="mb-4">
-                <label for="password_confirmation" class="block">Confirm Password</label>
-                <input v-model="form.password_confirmation" type="password" id="password_confirmation" class="border w-full" required />
-            </div>
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Register</button>
-            <p v-if="errors" class="text-red-500 mt-2">{{ errors }}</p>
-        </form>
-    </div>
+    <AdminPage :flushHeader="true">
+        <div class="mx-auto mt-24 w-full max-w-md">
+            <AdminPanel title="Crear cuenta administradora" description="Introduce los datos necesarios para generar un acceso.">
+                <form @submit.prevent="submit" class="space-y-5">
+                    <div class="space-y-2">
+                        <label for="name" class="block text-sm font-medium text-slate-600">Nombre</label>
+                        <input id="name" v-model="form.name" type="text" :class="inputClasses" required autocomplete="name" />
+                        <p v-if="form.errors.name" class="text-xs text-rose-500">{{ form.errors.name }}</p>
+                    </div>
+                    <div class="space-y-2">
+                        <label for="email" class="block text-sm font-medium text-slate-600">Correo electrónico</label>
+                        <input id="email" v-model="form.email" type="email" :class="inputClasses" required autocomplete="email" />
+                        <p v-if="form.errors.email" class="text-xs text-rose-500">{{ form.errors.email }}</p>
+                    </div>
+                    <div class="space-y-2">
+                        <label for="password" class="block text-sm font-medium text-slate-600">Contraseña</label>
+                        <input id="password" v-model="form.password" type="password" :class="inputClasses" required autocomplete="new-password" />
+                        <p v-if="form.errors.password" class="text-xs text-rose-500">{{ form.errors.password }}</p>
+                    </div>
+                    <div class="space-y-2">
+                        <label for="password_confirmation" class="block text-sm font-medium text-slate-600">Confirmar contraseña</label>
+                        <input id="password_confirmation" v-model="form.password_confirmation" type="password" :class="inputClasses" required autocomplete="new-password" />
+                    </div>
+                    <button type="submit" class="w-full rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition" :disabled="form.processing">
+                        {{ form.processing ? 'Creando...' : 'Registrar cuenta' }}
+                    </button>
+                </form>
+            </AdminPanel>
+        </div>
+    </AdminPage>
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue';
 import { useForm } from '@inertiajs/vue3';
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
-const form = reactive({
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
+const form = useForm({
     name: '',
     email: '',
     password: '',
     password_confirmation: '',
 });
 
-const errors = ref(null);
-
-const register = () => {
-    useForm(form).post(route('admin.register'), {
-        onError: (error) => {
-            errors.value = error;
-        },
-    });
+const submit = () => {
+    form.post(route('admin.register'));
 };
 </script>

--- a/resources/js/Pages/Companies/ChangePlan.vue
+++ b/resources/js/Pages/Companies/ChangePlan.vue
@@ -1,88 +1,96 @@
 <template>
     <AppLayout>
-    <div class="p-8 bg-gray-50 min-h-screen">
-        <h1 class="text-2xl font-bold text-gray-800 mb-6">Cambiar de Plan</h1>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div
-                v-for="plan in plansWithFeatures"
-                :key="plan.id"
-                class="bg-white shadow-md rounded-lg p-6 relative"
-                :class="{ 'border-4 border-blue-500': plan.id === planActual.id }"
-            >
-                <h2 class="text-xl font-semibold mb-4">{{ plan.name }}</h2>
-                <p class="text-gray-600 mb-2">Precio: {{ plan.price }} €/ mes</p>
-                <p class="text-gray-500 text-sm mb-4">{{ plan.description }}</p>
-                <h3 class="text-lg font-semibold mb-2">Características</h3>
-                <ul class="mb-6">
-                    <li>
-                        <p class="text-gray-700 flex items-center gap-2 mb-2">Limite de Usuarios:   {{plan.user_limit}}</p>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Planes</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Cambiar plan</h1>
+                        <p class="text-sm text-blue-200 max-w-2xl">Selecciona la suscripción que mejor se ajuste a las necesidades de tu compañía.</p>
+                    </div>
+                    <div class="grid grid-cols-1 gap-3">
+                        <AdminStatCard label="Plan actual" :value="plan.name" :description="`${plan.price} €/mes`">
+                            <template #badge>
+                                <span class="inline-flex items-center rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 ring-1 ring-emerald-400/30">Activo</span>
+                            </template>
+                        </AdminStatCard>
+                    </div>
+                </div>
+            </template>
 
-                    </li>
-                    <li
-                        v-for="feature in plan.features"
-                        :key="feature.id"
-                        class="text-gray-700 flex items-center gap-2"
+            <AdminPanel title="Planes disponibles" description="Compara las características y selecciona el plan que quieras activar.">
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+                    <article
+                        v-for="option in plansWithFeatures"
+                        :key="option.id"
+                        :class="planCardClasses(option.id === currentPlanId)"
                     >
-                        <p>✔</p> {{ feature.name }}
-                    </li>
-                </ul>
-                    <button
-                        v-if="plan.id !== planActual.id"
-                        @click="selectPlan(plan.id)"
-                        class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
-                    >
-                        Seleccionar
-                    </button>
-                    <span
-                        v-else
-                        class="absolute top-2 right-2 bg-green-100 text-green-600 px-2 py-1 rounded text-sm"
-                    >
-                     Plan actual
-                                </span>
-
-
-
-            </div>
-        </div>
-    </div>
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <h2 class="text-lg font-semibold text-slate-800">{{ option.name }}</h2>
+                                <p class="text-sm text-slate-500">{{ option.description }}</p>
+                            </div>
+                            <span v-if="option.id === currentPlanId" class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600">Plan actual</span>
+                        </div>
+                        <p class="mt-4 text-3xl font-semibold text-slate-900">{{ option.price }}<span class="text-base font-medium text-slate-500"> €/mes</span></p>
+                        <p class="mt-2 text-sm text-slate-500">Capacidad de usuarios: <span class="font-semibold text-slate-700">{{ option.user_limit }}</span></p>
+                        <ul class="mt-4 space-y-2 text-sm text-slate-600">
+                            <li v-for="feature in option.features" :key="feature.id" class="flex items-center gap-2">
+                                <span class="h-2 w-2 rounded-full bg-blue-500"></span>
+                                <span>{{ feature.name }}</span>
+                            </li>
+                            <li v-if="!option.features.length" class="text-xs text-slate-400">Sin características asociadas.</li>
+                        </ul>
+                        <button
+                            v-if="option.id !== currentPlanId"
+                            @click="selectPlan(option.id)"
+                            class="mt-6 inline-flex w-full items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition"
+                        >
+                            Seleccionar plan
+                        </button>
+                    </article>
+                </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
 import { computed } from 'vue';
-import { defineProps } from 'vue';
-import AppLayout from '@/Layouts/AppLayout.vue';
-import {Inertia} from "@inertiajs/inertia";
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from "@/Layouts/AppLayout.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+
 const props = defineProps({
-    company: Object, // Datos de la compañía
-    plan: Object, // Plan actual de la compañía
-    plans: Array, // Lista de planes disponibles
-    features: Array, // Todas las características posibles
-    planFeatures: Array, // Relación entre características y planes
+    company: Object,
+    plan: Object,
+    plans: Array,
+    features: Array,
+    planFeatures: Array,
 });
 
-// Computed para obtener el plan actual de la compañía
-const planActual = computed(() => props.plan);
+const currentPlanId = computed(() => props.plan?.id ?? null);
 
-// Computed para vincular características a cada plan
 const plansWithFeatures = computed(() => {
-    return props.plans.map((plan) => {
+    return props.plans.map((planOption) => {
         const relatedFeatures = props.planFeatures
-            .filter((pf) => pf.plan_id === plan.id)
-            .map((pf) => props.features.find((feature) => feature.id === pf.feature_id));
-        return { ...plan, features: relatedFeatures };
+            .filter((pf) => pf.plan_id === planOption.id)
+            .map((pf) => props.features.find((feature) => feature.id === pf.feature_id))
+            .filter(Boolean);
+        return { ...planOption, features: relatedFeatures };
     });
 });
 
-// Método para seleccionar un nuevo plan
+const planCardClasses = (isActive) => [
+    'flex flex-col rounded-3xl border px-6 py-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg',
+    isActive ? 'border-blue-400 bg-blue-50/60 ring-2 ring-blue-300/60' : 'border-slate-200 bg-white',
+];
+
 const selectPlan = (planId) => {
-    //Confirmación de elección
     if (confirm('¿Estás seguro de querer cambiar de plan?')) {
-        // Redirección a la ruta de cambio de plan
         Inertia.post(route('company.updatePlan', props.company.id), { plan_id: planId });
     }
 };
 </script>
-
-<style scoped>
-</style>

--- a/resources/js/Pages/Companies/Create.vue
+++ b/resources/js/Pages/Companies/Create.vue
@@ -1,95 +1,74 @@
 <template>
     <AppLayout>
-    <div class="p-6 bg-gray-100 min-h-screen">
-        <h1 class="text-3xl font-bold text-blue-600 mb-6">Crear Compañía</h1>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-3">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Compañías</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear compañía</h1>
+                        <p class="text-sm text-blue-200 max-w-2xl">Registra una nueva organización para asignar licencias, usuarios y configuraciones específicas.</p>
+                    </div>
+                    <NavLink :href="route('companies.index')" class="inline-flex items-center gap-2 rounded-xl border border-white/30 px-4 py-2 text-sm font-semibold text-white/80 backdrop-blur transition hover:bg-white/10">
+                        Volver al listado
+                    </NavLink>
+                </div>
+            </template>
 
-        <form @submit.prevent="createCompany" class="bg-white p-6 rounded-lg shadow-md">
-            <div class="mb-4">
-                <label for="name" class="block text-sm font-medium text-gray-700">Nombre</label>
-                <input
-                    type="text"
-                    id="name"
-                    v-model="data.form.name"
-                    class="mt-1 block w-full border border-gray-300 rounded-lg py-2 px-3 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    required
-                />
-            </div>
-
-            <div class="mb-4">
-                <label for="nif" class="block text-sm font-medium text-gray-700">NIF</label>
-                <input
-                    type="text"
-                    id="nif"
-                    v-model="data.form.nif"
-                    class="mt-1 block w-full border border-gray-300 rounded-lg py-2 px-3 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    required
-                />
-            </div>
-
-            <div class="mb-4">
-                <label for="phone" class="block text-sm font-medium text-gray-700">Teléfono</label>
-                <input
-                    type="text"
-                    id="phone"
-                    v-model="data.form.phone"
-                    class="mt-1 block w-full border border-gray-300 rounded-lg py-2 px-3 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    required
-                />
-            </div>
-
-            <div class="mb-4">
-                <label for="mail" class="block text-sm font-medium text-gray-700">Correo Electrónico</label>
-                <input
-                    type="email"
-                    id="mail"
-                    v-model="data.form.email"
-                    class="mt-1 block w-full border border-gray-300 rounded-lg py-2 px-3 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    required
-                />
-            </div>
-            <div class="mb-4">
-                <label for="mail" class="block text-sm font-medium text-gray-700">Direccion de facturación</label>
-                <input
-                    type="text"
-                    id="address"
-                    v-model="data.form.address"
-                    class="mt-1 block w-full border border-gray-300 rounded-lg py-2 px-3 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    required
-                />
-            </div>
-
-            <button
-                type="submit"
-                class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg"
-            >
-                Crear Compañía
-            </button>
-        </form>
-    </div>
+            <AdminPanel title="Datos generales" description="Completa la información fiscal y de contacto para habilitar la cuenta.">
+                <form @submit.prevent="createCompany" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-2">
+                            <label for="name" class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input id="name" v-model="form.name" type="text" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2">
+                            <label for="nif" class="block text-sm font-medium text-slate-600">NIF</label>
+                            <input id="nif" v-model="form.nif" type="text" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2">
+                            <label for="phone" class="block text-sm font-medium text-slate-600">Teléfono</label>
+                            <input id="phone" v-model="form.phone" type="text" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2">
+                            <label for="email" class="block text-sm font-medium text-slate-600">Correo electrónico</label>
+                            <input id="email" v-model="form.email" type="email" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2 md:col-span-2">
+                            <label for="address" class="block text-sm font-medium text-slate-600">Dirección de facturación</label>
+                            <input id="address" v-model="form.address" type="text" :class="inputClasses" required />
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('companies.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Crear compañía
+                        </button>
+                    </div>
+                </form>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import {reactive, ref} from 'vue'
-import {Inertia} from "@inertiajs/inertia";
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
-const data = reactive({
-    form:{
-        name: '',
-        nif: '',
-        phone: '',
-        email: '',
-        address:''
-    }
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
-})
+const form = reactive({
+    name: '',
+    nif: '',
+    phone: '',
+    email: '',
+    address: '',
+});
 
 const createCompany = () => {
-    Inertia.post(route('companies.store',data.form))
-}
+    Inertia.post(route('companies.store'), form);
+};
 </script>
-
-<style scoped>
-/* Custom styles if needed */
-</style>

--- a/resources/js/Pages/Companies/Edit.vue
+++ b/resources/js/Pages/Companies/Edit.vue
@@ -1,73 +1,78 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h1 class="text-lg text-blue-500 font-semibold mb-4">Editar Compañía</h1>
-                <form @submit.prevent="submit">
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-3">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Compañías</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Editar compañía</h1>
+                        <p class="text-sm text-blue-200 max-w-2xl">Actualiza los datos principales y mantén la información fiscal y de contacto al día.</p>
+                    </div>
+                    <NavLink :href="route('companies.show', company.id)" class="inline-flex items-center gap-2 rounded-xl border border-white/30 px-4 py-2 text-sm font-semibold text-white/80 backdrop-blur transition hover:bg-white/10">
+                        Ver detalles
+                    </NavLink>
+                </div>
+            </template>
+
+            <AdminPanel title="Información general" description="Revisa cada campo antes de guardar los cambios.">
+                <form @submit.prevent="submit" class="space-y-6">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Nombre</label>
-                            <input v-model="form.name" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input v-model="form.name" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Correo Electrónico</label>
-                            <input v-model="form.email" type="email" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Correo electrónico</label>
+                            <input v-model="form.email" type="email" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Teléfono</label>
-                            <input v-model="form.phone" type="text" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Teléfono</label>
+                            <input v-model="form.phone" type="text" :class="inputClasses" />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Dirección</label>
-                            <textarea v-model="form.address" class="w-full p-2 border rounded-md" rows="3"></textarea>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">NIF</label>
+                            <input v-model="form.nif" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">NIF</label>
-                            <input v-model="form.nif" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Dirección</label>
+                            <textarea v-model="form.address" rows="3" :class="[inputClasses, 'min-h-[120px]']"></textarea>
                         </div>
                     </div>
-                    <div class="mt-6 flex justify-end">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
-                            Guardar Cambios
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('companies.show', company.id)" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar cambios
                         </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { ref } from "vue";
-import { Inertia } from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    company: Object, // Datos de la compañía a editar
+    company: Object,
 });
 
-const form = ref({
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
+const form = reactive({
     name: props.company.name,
     email: props.company.email,
     phone: props.company.phone,
     nif: props.company.nif,
     address: props.company.address,
-    // website: props.company.website,
-    // logo: props.company.logo,
 });
 
-// const handleLogoChange = (event) => {
-//     const file = event.target.files[0];
-//     if (file) {
-//         const reader = new FileReader();
-//         reader.onload = (e) => {
-//             form.value.logo = e.target.result;
-//         };
-//         reader.readAsDataURL(file);
-//     }
-// };
-
 const submit = () => {
-    Inertia.put(route('companies.update', props.company.id), form.value);
+    Inertia.put(route('companies.update', props.company.id), form);
 };
 </script>

--- a/resources/js/Pages/Companies/ShowKeys.vue
+++ b/resources/js/Pages/Companies/ShowKeys.vue
@@ -1,8 +1,64 @@
+<template>
+    <AppLayout>
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Compañías</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Gestión de claves API</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Administra las credenciales públicas y privadas utilizadas para integrar la plataforma con otros sistemas.</p>
+                </div>
+            </template>
+
+            <AdminPanel title="Claves de autenticación" description="Guarda los cambios para activar las credenciales o genera un nuevo par de claves.">
+                <form @submit.prevent="saveKeys" class="space-y-6">
+                    <div class="space-y-2">
+                        <label for="public_key" class="block text-sm font-medium text-slate-600">Clave pública</label>
+                        <textarea
+                            id="public_key"
+                            v-model="form.public_key"
+                            rows="5"
+                            :class="textareaClasses"
+                            placeholder="Introduce aquí la clave pública"
+                        ></textarea>
+                    </div>
+                    <div class="space-y-2">
+                        <label for="private_key" class="block text-sm font-medium text-slate-600">Clave privada</label>
+                        <textarea
+                            id="private_key"
+                            v-model="form.private_key"
+                            rows="5"
+                            :class="textareaClasses"
+                            placeholder="Introduce aquí la clave privada"
+                        ></textarea>
+                    </div>
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <button
+                            type="button"
+                            @click="generateKeys"
+                            class="inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition hover:text-blue-600"
+                        >
+                            Generar nuevas claves
+                        </button>
+                        <div class="flex gap-3">
+                            <NavLink :href="route('companies.show', company.id)" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                            <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                                Guardar claves
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </AdminPanel>
+        </AdminPage>
+    </AppLayout>
+</template>
+
 <script setup>
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { defineProps, reactive, watchEffect } from 'vue';
-import { Inertia } from "@inertiajs/inertia";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
     company: Object,
@@ -10,79 +66,18 @@ const props = defineProps({
     private_key: String,
 });
 
-// Reactive form object
+const textareaClasses = 'w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
 const form = reactive({
     public_key: props.public_key,
     private_key: props.private_key,
 });
 
-
-
 const saveKeys = () => {
-    console.log(form);
-    return Inertia.put(route('companies.updateKeys', props.company.id), form);
+    Inertia.put(route('companies.updateKeys', props.company.id), form);
 };
 
 const generateKeys = () => {
-    console.log('Generating new keys');
-    return Inertia.get(route('companies.generateKeys', props.company.id));
+    Inertia.get(route('companies.generateKeys', props.company.id));
 };
 </script>
-
-<template>
-    <AppLayout>
-        <div class="p-6 bg-white shadow rounded-lg">
-            <h2 class="text-xl font-bold mb-4">Manage Company Keys</h2>
-
-            <form @submit.prevent="saveKeys">
-                <!-- Public Key Field -->
-                <div class="mb-4">
-                    <label for="public_key" class="block text-gray-700 font-medium mb-2">Public Key</label>
-                    <textarea
-                        id="public_key"
-                        v-model="form.public_key"
-                        class="w-full p-3 border rounded-lg focus:ring focus:ring-blue-300"
-                        rows="6"
-                        placeholder="Enter public key here"
-                    ></textarea>
-                </div>
-
-                <!-- Private Key Field -->
-                <div class="mb-4">
-                    <label for="private_key" class="block text-gray-700 font-medium mb-2">Private Key</label>
-                    <textarea
-                        id="private_key"
-                        v-model="form.private_key"
-                        class="w-full p-3 border rounded-lg focus:ring focus:ring-blue-300"
-                        rows="6"
-                        placeholder="Enter private key here"
-                    ></textarea>
-                </div>
-
-                <!-- Submit Button -->
-                <div class="text-right">
-                    <button
-                        type="submit"
-                        class="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring"
-                    >
-                        <SaveIcon class="w-6 h-6 fill-white stroke-gray-400" />
-                    </button>
-                </div>
-
-                <!-- Generate Keys Button -->
-                <div>
-                    <button
-                        type="button"
-                        @click="generateKeys"
-                        class="px-6 py-2 text-gray-500 hover:border-b hover:pb-2 hover:text-blue-500 focus:outline-none focus:ring"
-                    >
-                        No tengo claves, generar nuevas
-                    </button>
-                </div>
-            </form>
-        </div>
-    </AppLayout>
-</template>
-
-<style scoped>
-</style>

--- a/resources/js/Pages/EmailConfiguration/Edit.vue
+++ b/resources/js/Pages/EmailConfiguration/Edit.vue
@@ -1,107 +1,86 @@
 <template>
     <AppLayout>
-    <div class="p-6 bg-white rounded-lg shadow-md">
-        <h1 class="text-2xl font-semibold text-gray-700 mb-4">Editar Configuración de Correo</h1>
-        <form @submit.prevent="handleSubmit">
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Correo transaccional</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Configurar envío de correos</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Actualiza las credenciales SMTP para garantizar el envío seguro de comunicaciones.</p>
+                </div>
+            </template>
 
-            <div class="mb-4">
-                <label for="smtp_host" class="block text-gray-700">SMTP Host</label>
-                <input
-                    type="text"
-                    id="smtp_host"
-                    v-model="form.smtp_host"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <div class="mb-4">
-                <label for="smtp_port" class="block text-gray-700">SMTP Port</label>
-                <input
-                    type="text"
-                    id="smtp_port"
-                    v-model="form.smtp_port"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <div class="mb-4">
-                <label for="smtp_port" class="block text-gray-700">STMP Encrypt Type</label>
-                <select v-model="form.smtp_encryption" class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
-                    <option value="ssl">SSL</option>
-                    <option value="tls">TLS</option>
-                </select>
-            </div>
-            <div class="mb-4">
-                <label for="smtp_username" class="block text-gray-700">SMTP Username</label>
-                <input
-                    type="text"
-                    id="smtp_username"
-                    v-model="form.smtp_username"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <div class="mb-4">
-                <label for="smtp_password" class="block text-gray-700">SMTP Password</label>
-                <input
-                    type="password"
-                    id="smtp_password"
-                    v-model="form.smtp_password"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <div class="mb-4">
-                <label for="from_email" class="block text-gray-700">Correo Remitente</label>
-                <input
-                    type="email"
-                    id="from_email"
-                    v-model="form.from_email"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <div class="mb-4">
-                <label for="from_name" class="block text-gray-700">Nombre Remitente</label>
-                <input
-                    type="text"
-                    id="from_name"
-                    v-model="form.from_name"
-                    class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-            </div>
-            <button
-                type="submit"
-                class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-900 focus:outline-none"
-            >
-                <SaveIcon class="w-5 h-5 fill-gray-50 stroke-gray-400"/>
-            </button>
-        </form>
-    </div>
+            <AdminPanel title="Parámetros SMTP" description="Revisa los datos proporcionados por tu proveedor y guarda los cambios.">
+                <form @submit.prevent="handleSubmit" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">SMTP Host</label>
+                            <input v-model="form.smtp_host" type="text" :class="inputClasses" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">SMTP Port</label>
+                            <input v-model="form.smtp_port" type="text" :class="inputClasses" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Cifrado</label>
+                            <select v-model="form.smtp_encryption" :class="inputClasses">
+                                <option value="ssl">SSL</option>
+                                <option value="tls">TLS</option>
+                            </select>
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Usuario SMTP</label>
+                            <input v-model="form.smtp_username" type="text" :class="inputClasses" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Contraseña SMTP</label>
+                            <input v-model="form.smtp_password" type="password" :class="inputClasses" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Correo remitente</label>
+                            <input v-model="form.from_email" type="email" :class="inputClasses" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre remitente</label>
+                            <input v-model="form.from_name" type="text" :class="inputClasses" />
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('dashboard')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar configuración
+                        </button>
+                    </div>
+                </form>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
-import {Inertia} from "@inertiajs/inertia";
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
- const props = defineProps({
-            emailConfiguration: Object,
-        });
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
-        const form = ref({
-            smtp_host: props.emailConfiguration.smtp_host,
-            smtp_port: props.emailConfiguration.smtp_port,
-            smtp_username: props.emailConfiguration.smtp_username,
-            smtp_password: props.emailConfiguration.smtp_password,
-            smtp_encryption: props.emailConfiguration.smtp_encryption,
-            from_email: props.emailConfiguration.from_email,
-            from_name: props.emailConfiguration.from_name,
-        });
+const props = defineProps({
+    emailConfiguration: Object,
+});
 
-        const handleSubmit = () => {
-            console.log(form.value);
-            return Inertia.put(route('email-configurations.update', props.emailConfiguration.id), form.value);
-        };
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
+const form = reactive({
+    smtp_host: props.emailConfiguration.smtp_host,
+    smtp_port: props.emailConfiguration.smtp_port,
+    smtp_username: props.emailConfiguration.smtp_username,
+    smtp_password: props.emailConfiguration.smtp_password,
+    smtp_encryption: props.emailConfiguration.smtp_encryption,
+    from_email: props.emailConfiguration.from_email,
+    from_name: props.emailConfiguration.from_name,
+});
 
-
-
-
+const handleSubmit = () => {
+    Inertia.put(route('email-configurations.update', props.emailConfiguration.id), form);
+};
 </script>

--- a/resources/js/Pages/Plans/Index.vue
+++ b/resources/js/Pages/Plans/Index.vue
@@ -1,56 +1,104 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6 flex justify-between items-center">
-                <h1 class="text-lg text-blue-500 font-semibold">Planes</h1>
-                <NavLink :href="route('plans.create')" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
-                    <AddIcon class="w-5 h-5 inline-block mr-2" /> Nuevo Plan
-                </NavLink>
-            </div>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Planes</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Catálogo de planes</h1>
+                        <p class="text-sm text-blue-200">Consulta los planes disponibles y gestiona su configuración comercial.</p>
+                    </div>
+                    <NavLink :href="route('plans.create')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 transition hover:bg-white/20">
+                        <AddIcon class="w-4 h-4" /> Nuevo plan
+                    </NavLink>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <AdminStatCard label="Planes activos" :value="totalPlans" :description="totalPlans === 1 ? 'Plan publicado' : 'Planes publicados'" />
+                    <AdminStatCard label="Precio medio" :value="`${averagePrice} €`" description="Promedio mensual" />
+                    <AdminStatCard label="Límite máximo" :value="highestUserLimit" description="Usuarios máximos por plan" />
+                    <AdminStatCard label="Ingresos potenciales" :value="`${estimatedMonthly} €`" description="Basado en precio medio" />
+                </div>
+            </template>
 
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
+            <AdminPanel title="Listado de planes" description="Gestiona cada plan y accede a sus detalles específicos.">
+                <AdminTable>
+                    <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Nombre</th>
+                            <th scope="col" class="px-6 py-3">Descripción</th>
+                            <th scope="col" class="px-6 py-3">Precio</th>
+                            <th scope="col" class="px-6 py-3 text-right">Acciones</th>
+                        </tr>
                     </thead>
-                    <tbody>
-                    <tr v-for="plan in plans" :key="plan.id" class="border-t">
-                        <td class="px-4 py-2">{{ plan.name }}</td>
-                        <td class="px-4 py-2">{{ plan.description }}</td>
-                        <td class="px-4 py-2">
-                            <NavLink :href="route('plans.show', plan.id)" class="text-blue-500 mr-2">
-                                <InfoIcon class="w-5 h-5" />
-                            </NavLink>
-                            <NavLink :href="route('plans.edit', plan.id)" class="text-yellow-500 mr-2">
-                                <EditIcon class="w-5 h-5" />
-                            </NavLink>
-                            <button @click="deletePlan(plan.id)" class="text-red-500">
-                                <DeleteIcon class="w-5 h-5" />
-                            </button>
-                        </td>
-                    </tr>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                        <tr v-for="plan in plans" :key="plan.id" class="hover:bg-slate-50/60 transition">
+                            <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ plan.name }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600">{{ plan.description }}</td>
+                            <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ plan.price }} €</td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-3 text-slate-500">
+                                    <NavLink :href="route('plans.show', plan.id)" class="transition hover:text-blue-500">
+                                        <InfoIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <NavLink :href="route('plans.edit', plan.id)" class="transition hover:text-amber-500">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button @click="deletePlan(plan.id)" class="transition hover:text-rose-500">
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr v-if="plans.length === 0">
+                            <td colspan="4" class="px-6 py-6 text-center text-sm text-slate-500">Aún no hay planes configurados.</td>
+                        </tr>
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </AdminTable>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+import AdminTable from "@/Components/Dashboard/AdminTable.vue";
 
 const props = defineProps({
     plans: Array,
+});
+
+const totalPlans = computed(() => props.plans.length);
+const planPrices = computed(() => props.plans.map((plan) => Number(plan.price) || 0));
+const averagePrice = computed(() => {
+    if (!planPrices.value.length) {
+        return '0.00';
+    }
+    const sum = planPrices.value.reduce((acc, price) => acc + price, 0);
+    return (sum / planPrices.value.length).toFixed(2);
+});
+const highestUserLimit = computed(() => {
+    if (!props.plans.length) {
+        return '—';
+    }
+    const limits = props.plans.map((plan) => plan.user_limit ?? 0);
+    const max = Math.max(...limits);
+    return max > 0 ? max : '—';
+});
+const estimatedMonthly = computed(() => {
+    if (!planPrices.value.length) {
+        return '0.00';
+    }
+    return (planPrices.value.reduce((acc, price) => acc + price, 0)).toFixed(2);
 });
 
 const deletePlan = (planId) => {
@@ -59,7 +107,3 @@ const deletePlan = (planId) => {
     }
 };
 </script>
-
-<style scoped>
-/* Estilos personalizados aquí */
-</style>

--- a/resources/js/Pages/Roles/Create.vue
+++ b/resources/js/Pages/Roles/Create.vue
@@ -1,55 +1,78 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h1 class="text-lg text-blue-500 font-semibold mb-4">Crear Rol</h1>
-                <form @submit.prevent="submit">
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de roles</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear rol</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Define un nuevo perfil de permisos para adaptar la plataforma a la operativa de tu organización.</p>
+                </div>
+            </template>
+
+            <AdminPanel title="Configuración del rol" description="Selecciona el nombre, descripción y permisos que describan su alcance.">
+                <form @submit.prevent="submit" class="space-y-6">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Nombre</label>
-                            <input v-model="form.name" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input v-model="form.name" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Descripción</label>
-                            <textarea v-model="form.description" class="w-full p-2 border rounded-md" rows="3" required></textarea>
-                        </div>
-                    </div>
-                    <div class="mt-6">
-                        <label class="block text-gray-700 font-medium mb-1">Permisos</label>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <div v-for="feature in features" :key="feature.id" class="flex items-center">
-                                <input v-model="form.feature_ids" :value="feature.id" type="checkbox" class="mr-2" />
-                                <label class="text-gray-700">{{ feature.name }}</label>
-                            </div>
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Descripción</label>
+                            <textarea v-model="form.description" rows="3" :class="[inputClasses, 'min-h-[120px]']" required></textarea>
                         </div>
                     </div>
-                    <div class="mt-6 flex justify-end">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
-                            Crear Rol
+                    <div class="space-y-3">
+                        <label class="block text-sm font-medium text-slate-600">Permisos</label>
+                        <p class="text-xs text-slate-400">Marca las funcionalidades a las que tendrá acceso este rol.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                            <label
+                                v-for="feature in features"
+                                :key="feature.id"
+                                class="flex items-center gap-3 rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm transition hover:border-blue-400"
+                            >
+                                <input
+                                    v-model="form.feature_ids"
+                                    :value="feature.id"
+                                    type="checkbox"
+                                    class="h-4 w-4 rounded border-slate-300 text-indigo-500 focus:ring-indigo-500"
+                                />
+                                <span>{{ feature.name }}</span>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('roles.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Crear rol
                         </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { ref } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { ref } from "vue";
-import { Inertia } from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    features: Array, // Lista de características disponibles
+    features: Array,
 });
 
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
 const form = ref({
-    name: "",
-    description: "",
-    feature_ids: [], // IDs de las características seleccionadas
+    name: '',
+    description: '',
+    feature_ids: [],
 });
 
 const submit = () => {
-    Inertia.post(route("roles.store"), form.value);
+    Inertia.post(route('roles.store'), form.value);
 };
 </script>

--- a/resources/js/Pages/Roles/Edit.vue
+++ b/resources/js/Pages/Roles/Edit.vue
@@ -1,63 +1,81 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h1 class="text-lg text-blue-500 font-semibold mb-4">Editar Rol</h1>
-                <form @submit.prevent="submit">
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de roles</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Editar rol</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Ajusta los permisos y la descripción para mantener el control sobre la seguridad de la plataforma.</p>
+                </div>
+            </template>
+
+            <AdminPanel title="Información del rol" description="Actualiza los datos necesarios y revisa los accesos asignados.">
+                <form @submit.prevent="submit" class="space-y-6">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Nombre</label>
-                            <input v-model="form.name" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input v-model="form.name" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Descripción</label>
-                            <textarea v-model="form.description" class="w-full p-2 border rounded-md" rows="3" required></textarea>
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Descripción</label>
+                            <textarea v-model="form.description" rows="3" :class="[inputClasses, 'min-h-[120px]']" required></textarea>
                         </div>
                     </div>
-                    <div class="mt-6">
-                        <label class="block text-gray-700 font-medium mb-1">Permisos</label>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <div v-for="feature in features" :key="feature.id" class="flex items-center">
+                    <div class="space-y-3">
+                        <label class="block text-sm font-medium text-slate-600">Permisos</label>
+                        <p class="text-xs text-slate-400">Asegúrate de que solo dispone de los accesos necesarios.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                            <label
+                                v-for="feature in features"
+                                :key="feature.id"
+                                class="flex items-center gap-3 rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm transition hover:border-blue-400"
+                            >
                                 <input
                                     v-model="form.feature_ids"
                                     :value="feature.id"
                                     type="checkbox"
-                                    class="mr-2"
+                                    class="h-4 w-4 rounded border-slate-300 text-indigo-500 focus:ring-indigo-500"
                                 />
-                                <label class="text-gray-700">{{ feature.name }}</label>
-                            </div>
+                                <span>{{ feature.name }}</span>
+                            </label>
                         </div>
                     </div>
-                    <div class="mt-6 flex justify-end">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
-                            Guardar Cambios
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('roles.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar cambios
                         </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { ref } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { ref } from "vue";
-import { Inertia } from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    role: Object, // Rol a editar
-    features: Array, // Lista de características disponibles
+    role: Object,
+    features: Array,
 });
 
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
+const initialFeatures = props.role?.feature_ids ?? (props.role?.features ? props.role.features.map((feature) => feature.id) : []);
 
 const form = ref({
     name: props.role.name,
     description: props.role.description,
-    feature_ids: [], // Inicializar con las características seleccionadas
+    feature_ids: [...initialFeatures],
 });
 
 const submit = () => {
-    Inertia.put(route("roles.update", props.role.id), form.value);
+    Inertia.put(route('roles.update', props.role.id), form.value);
 };
 </script>

--- a/resources/js/Pages/Roles/Index.vue
+++ b/resources/js/Pages/Roles/Index.vue
@@ -1,57 +1,87 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6 flex justify-between items-center">
-                <h1 class="text-lg text-blue-500 font-semibold">Roles</h1>
-                <NavLink :href="route('roles.create')" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
-                    <AddIcon class="w-5 h-5 inline-block mr-2" /> Nuevo Rol
-                </NavLink>
-            </div>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de roles</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Roles y permisos</h1>
+                        <p class="text-sm text-blue-200">Organiza los niveles de acceso y asigna responsabilidades a tu equipo.</p>
+                    </div>
+                    <NavLink
+                        :href="route('roles.create')"
+                        class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 transition hover:bg-white/20"
+                    >
+                        <AddIcon class="w-4 h-4" /> Nuevo rol
+                    </NavLink>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <AdminStatCard label="Roles creados" :value="totalRoles" :description="totalRoles === 1 ? 'Rol disponible' : 'Roles disponibles'" />
+                    <AdminStatCard label="Roles sin descripción" :value="missingDescription" description="Completa la información para orientar a tu equipo" />
+                    <AdminStatCard label="Roles protegidos" :value="protectedRoles" description="No eliminables" />
+                    <AdminStatCard label="Roles editables" :value="editableRoles" description="Puedes ajustar sus permisos" />
+                </div>
+            </template>
 
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Descripción</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
+            <AdminPanel title="Listado de roles" description="Consulta cada rol definido y gestiona sus acciones disponibles.">
+                <AdminTable>
+                    <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Nombre</th>
+                            <th scope="col" class="px-6 py-3">Descripción</th>
+                            <th scope="col" class="px-6 py-3 text-right">Acciones</th>
+                        </tr>
                     </thead>
-                    <tbody>
-                    <tr v-for="role in roles" :key="role.id" class="border-t">
-                        <td class="px-4 py-2">{{ role.name }}</td>
-                        <td class="px-4 py-2">{{ role.description }}</td>
-                        <td class="px-4 py-2">
-<!--                            <NavLink :href="route('roles.show', role.id)" class="text-blue-500 mr-2">-->
-<!--                                <InfoIcon class="w-5 h-5" />-->
-<!--                            </NavLink>-->
-                            <NavLink :href="route('roles.edit', role.id)" class="text-yellow-500 mr-2">
-                                <EditIcon class="w-5 h-5" />
-                            </NavLink>
-                            <button v-if="role.name!== 'Administrador'" @click="deleteRole(role.id)" class="text-red-500">
-                                <DeleteIcon class="w-5 h-5" />
-                            </button>
-                        </td>
-                    </tr>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                        <tr v-for="role in roles" :key="role.id" class="hover:bg-slate-50/60 transition">
+                            <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ role.name }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600">{{ role.description || 'Sin descripción' }}</td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-3 text-slate-500">
+                                    <NavLink :href="route('roles.edit', role.id)" class="transition hover:text-amber-500">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button
+                                        v-if="role.name !== 'Administrador'"
+                                        @click="deleteRole(role.id)"
+                                        class="transition hover:text-rose-500"
+                                    >
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr v-if="roles.length === 0">
+                            <td colspan="3" class="px-6 py-6 text-center text-sm text-slate-500">Aún no se han configurado roles.</td>
+                        </tr>
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </AdminTable>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+import AdminTable from "@/Components/Dashboard/AdminTable.vue";
 
 const props = defineProps({
     roles: Array,
 });
+
+const totalRoles = computed(() => props.roles.length);
+const missingDescription = computed(() => props.roles.filter(role => !role.description).length);
+const protectedRoles = computed(() => props.roles.filter(role => role.name === 'Administrador').length);
+const editableRoles = computed(() => Math.max(totalRoles.value - protectedRoles.value, 0));
 
 const deleteRole = (roleId) => {
     if (confirm("¿Estás seguro de que deseas eliminar este rol?")) {
@@ -59,7 +89,3 @@ const deleteRole = (roleId) => {
     }
 };
 </script>
-
-<style scoped>
-/* Estilos personalizados aquí */
-</style>

--- a/resources/js/Pages/User_tasks/AdminCreate.vue
+++ b/resources/js/Pages/User_tasks/AdminCreate.vue
@@ -1,54 +1,71 @@
 <template>
     <AppLayout>
-    <div class="max-w-lg mx-auto mt-10 p-6 bg-white rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold text-gray-700 mb-6">Crear Nueva Tarea</h2>
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear tarea</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Define una nueva tarea y asígnala a un miembro del equipo para mantener el seguimiento centralizado.</p>
+                </div>
+            </template>
 
-        <form @submit.prevent="createTask">
-            <div class="mb-4">
-                <label class="block text-gray-600 mb-2">Título</label>
-                <input v-model="form.title" type="text" class="w-full p-2 border rounded-lg" required />
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-600 mb-2">Descripción</label>
-                <textarea v-model="form.description" class="w-full p-2 border rounded-lg" required></textarea>
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-600 mb-2">Fecha de Finalización</label>
-                <input v-model="form.due_date" type="date" class="w-full p-2 border rounded-lg" required />
-            </div>
-
-            <div class="mb-4">
-                <label class="block text-gray-600 mb-2">Asignar a Usuario</label>
-                <select v-model="form.user_id" class="w-full p-2 border rounded-lg" required>
-                    <option v-for="user in users" :key="user.id" :value="user.id">{{ user.name }}</option>
-                </select>
-            </div>
-
-            <button type="submit" class="w-full bg-blue-500 text-white py-2 rounded-lg hover:bg-blue-600">Crear Tarea</button>
-        </form>
-    </div>
+            <AdminPanel title="Información de la tarea" description="Completa los campos necesarios antes de guardar.">
+                <form @submit.prevent="createTask" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Título</label>
+                            <input v-model="form.title" type="text" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Descripción</label>
+                            <textarea v-model="form.description" rows="4" :class="[inputClasses, 'min-h-[120px]']" required></textarea>
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Fecha de finalización</label>
+                            <input v-model="form.due_date" type="date" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Asignar a</label>
+                            <select v-model="form.user_id" :class="inputClasses" required>
+                                <option value="" disabled>Selecciona un usuario</option>
+                                <option v-for="user in users" :key="user.id" :value="user.id">{{ user.name }}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('user_tasks.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Crear tarea
+                        </button>
+                    </div>
+                </form>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import { router } from '@inertiajs/vue3';
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
     users: Array,
 });
 
-const form = ref({
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
+const form = reactive({
     title: '',
     description: '',
     due_date: '',
     user_id: '',
 });
 
-function createTask() {
-    router.post(route('user_tasks.adminStore'), form.value);
-}
+const createTask = () => {
+    Inertia.post(route('user_tasks.adminStore'), form);
+};
 </script>

--- a/resources/js/Pages/User_tasks/AdminEdit.vue
+++ b/resources/js/Pages/User_tasks/AdminEdit.vue
@@ -1,64 +1,72 @@
 <template>
     <AppLayout>
-    <div class="max-w-lg mx-auto mt-10 p-8 bg-white rounded-lg shadow-lg">
-        <h2 class="text-2xl font-semibold text-gray-700 mb-6">Editar Tarea</h2>
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Editar tarea</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Actualiza los datos y mantiene informados a los responsables.</p>
+                </div>
+            </template>
 
-        <form @submit.prevent="updateTask">
-            <div class="mb-4">
-                <label for="title" class="block text-gray-600 font-medium">Título</label>
-                <input type="text" id="title" v-model="form.title" class="w-full p-2 border rounded-lg" required />
-            </div>
-
-            <div class="mb-4">
-                <label for="description" class="block text-gray-600 font-medium">Descripción</label>
-                <textarea id="description" v-model="form.description" class="w-full p-2 border rounded-lg" required></textarea>
-            </div>
-
-            <div class="mb-4">
-                <label for="due_date" class="block text-gray-600 font-medium">Fecha de Finalización</label>
-                <input type="date" id="due_date" v-model="form.due_date" class="w-full p-2 border rounded-lg" required />
-            </div>
-
-
-
-            <div class="mb-4">
-                <label for="user" class="block text-gray-600 font-medium">Asignar a Usuario</label>
-                <select id="user" v-model="form.user_id" class="w-full p-2 border rounded-lg">
-                    <option v-for="user in users" :key="user.id" :value="user.id">{{ user.name }}</option>
-                </select>
-            </div>
-
-            <button type="submit" class="w-full bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600">Actualizar Tarea</button>
-        </form>
-    </div>
+            <AdminPanel title="Detalle de la tarea" description="Modifica solo los campos necesarios antes de guardar.">
+                <form @submit.prevent="updateTask" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Título</label>
+                            <input v-model="form.title" type="text" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2 md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-600">Descripción</label>
+                            <textarea v-model="form.description" rows="4" :class="[inputClasses, 'min-h-[120px]']" required></textarea>
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Fecha de finalización</label>
+                            <input v-model="form.due_date" type="date" :class="inputClasses" required />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Asignar a</label>
+                            <select v-model="form.user_id" :class="inputClasses" required>
+                                <option value="" disabled>Selecciona un usuario</option>
+                                <option v-for="user in users" :key="user.id" :value="user.id">{{ user.name }}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('user_tasks.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar cambios
+                        </button>
+                    </div>
+                </form>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { reactive } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import {ref} from "vue";
-import {Inertia} from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
     task: Object,
     users: Array,
 });
 
-const form = ref({
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
+const form = reactive({
     title: props.task.title,
     description: props.task.description,
     due_date: props.task.due_date,
     user_id: props.task.user_id,
 });
 
-function updateTask() {
-    Inertia.put(route('user_tasks.adminUpdate', props.task.id), form.value);
-}
-
+const updateTask = () => {
+    Inertia.put(route('user_tasks.adminUpdate', props.task.id), form);
+};
 </script>
-
-<style scoped>
-input, textarea, select {
-    outline: none;
-}
-</style>

--- a/resources/js/Pages/User_tasks/Create.vue
+++ b/resources/js/Pages/User_tasks/Create.vue
@@ -1,58 +1,57 @@
 <template>
     <AppLayout>
-        <div class="flex flex-col bg-gray-100 min-h-screen p-6">
-            <!-- Encabezado -->
-            <div class="flex items-center bg-white rounded-lg p-5 shadow-md justify-between mb-6">
-                <h1 class="text-2xl font-bold text-gray-700">Crear Nueva Tarea</h1>
-            </div>
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear tarea personal</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Registra una nueva tarea para organizar tu trabajo pendiente.</p>
+                </div>
+            </template>
 
-            <!-- Formulario de Creación de Tarea -->
-            <div class="bg-white shadow-md rounded-lg p-6">
-                <form @submit.prevent="submit">
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="title">Título</label>
-                        <input type="text" v-model="form.title" id="title" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            <AdminPanel title="Detalles de la tarea" description="Completa el formulario con la información básica.">
+                <form @submit.prevent="submit" class="space-y-6">
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="title">Título</label>
+                        <input id="title" v-model="form.title" type="text" :class="inputClasses" required />
                     </div>
-
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="description">Descripción</label>
-                        <textarea v-model="form.description" id="description" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="description">Descripción</label>
+                        <textarea id="description" v-model="form.description" rows="4" :class="[inputClasses, 'min-h-[120px]']"></textarea>
                     </div>
-
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="due_date">Fecha de Finalización</label>
-                        <input type="date" v-model="form.due_date" id="due_date" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="due_date">Fecha de finalización</label>
+                        <input id="due_date" v-model="form.due_date" type="date" :class="inputClasses" required />
                     </div>
-
-                    <div class="flex justify-end">
-                        <NavLink :href="route('user_tasks.index')" class="text-gray-700 bg-gray-300 hover:bg-gray-400 rounded-lg px-4 py-2 mr-2">Cancelar</NavLink>
-                        <button type="submit" class="bg-blue-500 text-white hover:bg-blue-600 rounded-lg px-4 py-2">Crear Tarea</button>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('user_tasks.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Crear tarea
+                        </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
 import { reactive } from 'vue';
-import { router } from '@inertiajs/vue3';
-import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from '@/Components/NavLink.vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
 const form = reactive({
     title: '',
     description: '',
-    due_date: ''
+    due_date: '',
 });
 
-function submit() {
-    router.post(route('user_tasks.store'), form);
-}
+const submit = () => {
+    Inertia.post(route('user_tasks.store'), form);
+};
 </script>
-
-<style scoped>
-label {
-    font-weight: 500;
-}
-</style>

--- a/resources/js/Pages/User_tasks/Edit.vue
+++ b/resources/js/Pages/User_tasks/Edit.vue
@@ -1,63 +1,61 @@
 <template>
     <AppLayout>
-        <div class="flex flex-col bg-gray-100 min-h-screen p-6">
-            <!-- Encabezado -->
-            <div class="flex items-center bg-white rounded-lg p-5 shadow-md justify-between mb-6">
-                <h1 class="text-2xl font-bold text-gray-700">Editar Tarea</h1>
-            </div>
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Editar tarea personal</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Revisa y actualiza el progreso de tu tarea.</p>
+                </div>
+            </template>
 
-            <!-- Formulario de Edición de Tarea -->
-            <div class="bg-white shadow-md rounded-lg p-6">
-                <form @submit.prevent="submit">
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="title">Título</label>
-                        <input type="text" v-model="form.title" id="title" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            <AdminPanel title="Información básica" description="Modifica la tarea y guarda los cambios.">
+                <form @submit.prevent="submit" class="space-y-6">
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="title">Título</label>
+                        <input id="title" v-model="form.title" type="text" :class="inputClasses" required />
                     </div>
-
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="description">Descripción</label>
-                        <textarea v-model="form.description" id="description" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="description">Descripción</label>
+                        <textarea id="description" v-model="form.description" rows="4" :class="[inputClasses, 'min-h-[120px]']"></textarea>
                     </div>
-
-                    <div class="mb-4">
-                        <label class="block text-gray-700 text-sm font-bold mb-2" for="due_date">Fecha de Finalización</label>
-                        <input type="date" v-model="form.due_date" id="due_date" class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-slate-600" for="due_date">Fecha de finalización</label>
+                        <input id="due_date" v-model="form.due_date" type="date" :class="inputClasses" required />
                     </div>
-
-                    <div class="flex justify-end">
-                        <NavLink :href="route('user_tasks.index')" class="text-gray-700 bg-gray-300 hover:bg-gray-400 rounded-lg px-4 py-2 mr-2">Cancelar</NavLink>
-                        <button type="submit" class="bg-blue-500 text-white hover:bg-blue-600 rounded-lg px-4 py-2">Actualizar Tarea</button>
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('user_tasks.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Actualizar tarea
+                        </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
 import { reactive } from 'vue';
-import { router } from '@inertiajs/vue3';
-import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from '@/Components/NavLink.vue';
-import { defineProps } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    task: Object
+    task: Object,
 });
+
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
 const form = reactive({
     title: props.task.title,
     description: props.task.description,
-    due_date: props.task.due_date
+    due_date: props.task.due_date,
 });
 
-function submit() {
-    router.put(route('user_tasks.update', props.task.id), form);
-}
+const submit = () => {
+    Inertia.put(route('user_tasks.update', props.task.id), form);
+};
 </script>
-
-<style scoped>
-label {
-    font-weight: 500;
-}
-</style>

--- a/resources/js/Pages/User_tasks/Index.vue
+++ b/resources/js/Pages/User_tasks/Index.vue
@@ -1,63 +1,93 @@
 <template>
     <AppLayout>
-    <div class="mt-6 m-5">
-        <div class="flex w-full justify-between items-center">
-            <h3 class="text-lg font-semibold text-gray-600 mb-3">Tareas ({{ tasks.length }})</h3>
-            <NavLink :href="route('user_tasks.adminCreate')" class="text-white bg-blue-500 m-2 rounded-lg hover:bg-blue-600 px-4 py-2">
-                Nueva Tarea
-            </NavLink>
-        </div>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Gestión de tareas</h1>
+                        <p class="text-sm text-blue-200">Controla el flujo de trabajo del equipo y consulta el estado de las asignaciones.</p>
+                    </div>
+                    <NavLink :href="route('user_tasks.adminCreate')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 transition hover:bg-white/20">
+                        Nueva tarea
+                    </NavLink>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <AdminStatCard label="Tareas registradas" :value="totalTasks" :description="totalTasks === 1 ? 'Tarea activa' : 'Tareas activas'" />
+                    <AdminStatCard label="Usuarios involucrados" :value="assignedUsers" description="Personas con tareas" />
+                    <AdminStatCard label="Con fecha límite" :value="tasksWithDueDate" description="Tareas planificadas" />
+                    <AdminStatCard label="Estados distintos" :value="distinctStatuses" description="Tipos de seguimiento" />
+                </div>
+            </template>
 
-        <div class="overflow-x-auto">
-            <table class="w-full table-auto bg-white shadow-md rounded-lg overflow-hidden">
-                <thead class="bg-gray-200">
-                <tr>
-                    <th class="px-4 py-2 text-gray-700">Tarea</th>
-                    <th class="px-4 py-2 text-gray-700">Descripción</th>
-                    <th class="px-4 py-2 text-gray-700">Fecha de Finalización</th>
-                    <th class="px-4 py-2 text-gray-700">Estado</th>
-                    <th class="px-4 py-2 text-gray-700">Usuario Asignado</th>
-                    <th class="px-4 py-2 text-gray-700">Acciones</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr v-for="task in tasks" :key="task.id" class="border-b hover:bg-gray-50">
-                    <td class="px-4 py-3 text-gray-600">{{ task.title }}</td>
-                    <td class="px-4 py-3 text-gray-500 truncate w-40">{{ task.description }}</td>
-                    <td class="px-4 py-3 text-gray-400">{{ task.due_date }}</td>
-                    <td class="px-4 py-3 text-gray-400">{{ task.status }}</td>
-                    <template v-for="user in users">
-                        <td class="px-4 py-3 text-gray-500" v-if="task.user_id===user.id">{{ user.name }}</td>
-                    </template>
-                    <td class="px-4 py-3 flex space-x-2">
-                        <NavLink :href="route('user_tasks.adminEdit', task.id)" class="text-yellow-500 hover:text-yellow-700"><EditIcon class="w-5 h-5 fill-gray-950"/></NavLink>
-                        <button @click="deleteTask(task.id)" class="text-red-500 hover:text-red-700"><DeleteIcon class="w-5 h-5 fill-gray-950"/></button>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
+            <AdminPanel title="Listado de tareas" description="Revisa los detalles y aplica acciones rápidas sobre cada registro.">
+                <AdminTable>
+                    <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Tarea</th>
+                            <th scope="col" class="px-6 py-3">Descripción</th>
+                            <th scope="col" class="px-6 py-3">Fecha límite</th>
+                            <th scope="col" class="px-6 py-3">Estado</th>
+                            <th scope="col" class="px-6 py-3">Asignado a</th>
+                            <th scope="col" class="px-6 py-3 text-right">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                        <tr v-for="task in tasks" :key="task.id" class="hover:bg-slate-50/60 transition">
+                            <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ task.title }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600 max-w-xs truncate">{{ task.description }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-500">{{ task.due_date ?? 'Sin fecha' }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-500">{{ task.status ?? '—' }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600">{{ assignedUser(task.user_id) }}</td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-3 text-slate-500">
+                                    <NavLink :href="route('user_tasks.adminEdit', task.id)" class="transition hover:text-amber-500">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button @click="deleteTask(task.id)" class="transition hover:text-rose-500">
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr v-if="tasks.length === 0">
+                            <td colspan="6" class="px-6 py-6 text-center text-sm text-slate-500">No hay tareas registradas por el momento.</td>
+                        </tr>
+                    </tbody>
+                </AdminTable>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import { defineProps } from 'vue';
-import { router } from '@inertiajs/vue3';
-import AppLayout from '@/Layouts/AppLayout.vue';
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
+import { computed } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
-import NavLink from "../../../../vendor/laravel/jetstream/stubs/inertia/resources/js/Components/NavLink.vue";
+import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+import AdminTable from "@/Components/Dashboard/AdminTable.vue";
 
 const props = defineProps({
     tasks: Array,
     users: Array,
 });
 
+const totalTasks = computed(() => props.tasks.length);
+const assignedUsers = computed(() => new Set(props.tasks.map((task) => task.user_id).filter(Boolean)).size);
+const tasksWithDueDate = computed(() => props.tasks.filter((task) => Boolean(task.due_date)).length);
+const distinctStatuses = computed(() => new Set(props.tasks.map((task) => task.status ?? 'Sin estado')).size);
+
+const usersById = computed(() => Object.fromEntries(props.users.map((user) => [user.id, user.name])));
+const assignedUser = (userId) => usersById.value[userId] ?? 'Sin asignar';
+
 const deleteTask = (id) => {
     if (confirm('¿Estás seguro de que deseas eliminar esta tarea?')) {
-        router.delete(route('user_tasks.destroy', id));
+        Inertia.delete(route('user_tasks.destroy', id));
     }
 };
 </script>

--- a/resources/js/Pages/User_tasks/Show.vue
+++ b/resources/js/Pages/User_tasks/Show.vue
@@ -1,44 +1,57 @@
 <template>
     <AppLayout>
-        <div class="flex flex-col bg-gray-100 min-h-screen p-6">
-            <!-- Encabezado -->
-            <div class="flex items-center bg-white rounded-lg p-5 shadow-md justify-between mb-6">
-                <h1 class="text-2xl font-bold text-gray-700">Detalles de la Tarea</h1>
-                <a class="bg-blue-500 text-gray-50 p-2 rounded-lg" href="/dashboard">Volver</a>
-            </div>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Tareas</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Detalle de la tarea</h1>
+                        <p class="text-sm text-blue-200 max-w-2xl">Consulta la información actualizada y gestiona el seguimiento.</p>
+                    </div>
+                    <NavLink :href="route('user_tasks.index')" class="inline-flex items-center gap-2 rounded-xl border border-white/30 px-4 py-2 text-sm font-semibold text-white/80 backdrop-blur transition hover:bg-white/10">
+                        Volver al listado
+                    </NavLink>
+                </div>
+            </template>
 
-            <!-- Detalles de la Tarea -->
-            <div class="bg-white shadow-md rounded-lg p-6">
-                <p class="text-xl font-semibold text-gray-800 mb-4">{{ task.title }}</p>
-                <p class="text-gray-600 mb-4"><strong>Descripción:</strong> {{ task.description }}</p>
-                <p class="text-gray-600 mb-4"><strong>Fecha de Finalización:</strong> {{ task.due_date }}</p>
-                <p class="text-gray-600 mb-4"><strong>Estado:</strong> <span>{{ task.status }}</span></p>
-            </div>
-
-            <!-- Botones de Acción -->
-            <div class="mt-6 flex space-x-4">
-                <NavLink :href="route('user_tasks.edit', task.id)" class="text-yellow-500 hover:text-yellow-700">Editar</NavLink>
-            </div>
-        </div>
+            <AdminPanel title="Información general">
+                <div class="space-y-4 text-sm text-slate-600">
+                    <div>
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Título</p>
+                        <p class="mt-1 text-base font-semibold text-slate-800">{{ task.title }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Descripción</p>
+                        <p class="mt-1 text-slate-600">{{ task.description || 'Sin descripción' }}</p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <p class="text-xs uppercase tracking-widest text-slate-400">Fecha de finalización</p>
+                            <p class="mt-1 text-slate-600">{{ task.due_date ?? 'Sin definir' }}</p>
+                        </div>
+                        <div>
+                            <p class="text-xs uppercase tracking-widest text-slate-400">Estado</p>
+                            <p class="mt-1 inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">{{ task.status ?? 'Sin estado' }}</p>
+                        </div>
+                    </div>
+                </div>
+                <template #actions>
+                    <NavLink :href="route('user_tasks.edit', task.id)" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                        Editar tarea
+                    </NavLink>
+                </template>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
-import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from '@/Components/NavLink.vue';
-import { router } from '@inertiajs/vue3';
+import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 defineProps({
-    task: Object
+    task: Object,
 });
-
-
-
-
 </script>
-
-<style scoped>
-label {
-    font-weight: 500;
-}
-</style>

--- a/resources/js/Pages/Users/Create.vue
+++ b/resources/js/Pages/Users/Create.vue
@@ -1,67 +1,81 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h1 class="text-lg text-blue-500 font-semibold mb-4">Crear Usuario</h1>
-                <form @submit.prevent="submit">
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de usuarios</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear usuario</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Completa la información del nuevo miembro para incorporarlo al equipo y asignarle los accesos correspondientes.</p>
+                </div>
+            </template>
+
+            <AdminPanel title="Datos del usuario" description="Revisa cuidadosamente la información antes de confirmar el registro.">
+                <form @submit.prevent="submit" class="space-y-6">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Nombre</label>
-                            <input v-model="form.name" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input v-model="form.name" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Email</label>
-                            <input v-model="form.email" type="email" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Email</label>
+                            <input v-model="form.email" type="email" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Contraseña</label>
-                            <input v-model="form.password" type="password" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Contraseña</label>
+                            <input v-model="form.password" type="password" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Teléfono</label>
-                            <input v-model="form.phone" type="text" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Teléfono</label>
+                            <input v-model="form.phone" type="text" :class="inputClasses" />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Dirección</label>
-                            <input v-model="form.address" type="text" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Dirección</label>
+                            <input v-model="form.address" type="text" :class="inputClasses" />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Rol</label>
-                            <select v-model="form.role_id" class="w-full p-2 border rounded-md" required>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Rol</label>
+                            <select v-model="form.role_id" :class="inputClasses" required>
+                                <option value="" disabled>Selecciona un rol</option>
                                 <option v-for="role in roles" :key="role.id" :value="role.id">{{ role.name }}</option>
                             </select>
                         </div>
                     </div>
-                    <div class="mt-6 flex justify-end">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
-                            Crear Usuario
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('users.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar usuario
                         </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { ref } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { ref } from "vue";
-import { Inertia } from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    roles: Array, // Los roles disponibles para asignar al usuario
+    roles: Array,
 });
 
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
+
 const form = ref({
-    name: "",
-    email: "",
-    password: "",
-    phone: "",
-    address: "",
-    role_id: null,
+    name: '',
+    email: '',
+    password: '',
+    phone: '',
+    address: '',
+    role_id: '',
 });
 
 const submit = () => {
-    Inertia.post(route("users.store"), form.value);
+    Inertia.post(route('users.store'), form.value);
 };
 </script>

--- a/resources/js/Pages/Users/Edit.vue
+++ b/resources/js/Pages/Users/Edit.vue
@@ -1,68 +1,83 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h1 class="text-lg text-blue-500 font-semibold mb-4">Editar Usuario</h1>
-                <form @submit.prevent="submit">
+        <AdminPage>
+            <template #header>
+                <div class="space-y-3">
+                    <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de usuarios</p>
+                    <h1 class="text-3xl sm:text-4xl font-semibold text-white">Editar usuario</h1>
+                    <p class="text-sm text-blue-200 max-w-2xl">Actualiza los datos del colaborador para mantener la información corporativa al día.</p>
+                </div>
+            </template>
+
+            <AdminPanel title="Información principal" description="Modifica solo los campos necesarios. Las contraseñas se actualizan únicamente si se indica un nuevo valor.">
+                <form @submit.prevent="submit" class="space-y-6">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Nombre</label>
-                            <input v-model="form.name" type="text" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Nombre</label>
+                            <input v-model="form.name" type="text" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Email</label>
-                            <input v-model="form.email" type="email" class="w-full p-2 border rounded-md" required />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Email</label>
+                            <input v-model="form.email" type="email" :class="inputClasses" required />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Teléfono</label>
-                            <input v-model="form.phone" type="text" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Teléfono</label>
+                            <input v-model="form.phone" type="text" :class="inputClasses" />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Contraseña</label>
-                            <input v-model="form.password" type="password" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Contraseña</label>
+                            <input v-model="form.password" type="password" :class="inputClasses" placeholder="••••••" />
+                            <p class="text-xs text-slate-400">Deja el campo vacío para conservar la contraseña actual.</p>
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Dirección</label>
-                            <input v-model="form.address" type="text" class="w-full p-2 border rounded-md" />
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Dirección</label>
+                            <input v-model="form.address" type="text" :class="inputClasses" />
                         </div>
-                        <div>
-                            <label class="block text-gray-700 font-medium mb-1">Rol</label>
-                            <select v-model="form.role_id" class="w-full p-2 border rounded-md" required>
+                        <div class="space-y-2">
+                            <label class="block text-sm font-medium text-slate-600">Rol</label>
+                            <select v-model="form.role_id" :class="inputClasses" required>
+                                <option value="" disabled>Selecciona un rol</option>
                                 <option v-for="role in roles" :key="role.id" :value="role.id">{{ role.name }}</option>
                             </select>
                         </div>
                     </div>
-                    <div class="mt-6 flex justify-end">
-                        <button type="submit" class="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
-                            Guardar Cambios
+                    <div class="flex justify-end gap-3">
+                        <NavLink :href="route('users.index')" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50">Cancelar</NavLink>
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700 transition">
+                            Guardar cambios
                         </button>
                     </div>
                 </form>
-            </div>
-        </div>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { ref } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
-import { ref } from "vue";
-import { Inertia } from "@inertiajs/inertia";
+import NavLink from "@/Components/NavLink.vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
 
 const props = defineProps({
-    user: Object, // Usuario a editar
-    roles: Array, // Lista de roles disponibles
+    user: Object,
+    roles: Array,
 });
+
+const inputClasses = 'w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none transition';
 
 const form = ref({
     name: props.user.name,
     email: props.user.email,
     phone: props.user.phone,
-    password: "",
+    password: '',
     address: props.user.address,
     role_id: props.user.role_id,
 });
 
 const submit = () => {
-    Inertia.put(route("users.update", props.user.id), form.value);
+    Inertia.put(route('users.update', props.user.id), form.value);
 };
 </script>

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -1,85 +1,115 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6 flex justify-between items-center">
-                <h1 class="text-lg text-blue-500 font-semibold">Usuarios</h1>
-                <NavLink
-                    v-if="canCreateUser"
-                    :href="route('users.create')"
-                    class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
-                    <AddIcon class="w-5 h-5 inline-block mr-2" /> Nuevo Usuario
-                </NavLink>
-                <span v-else class="bg-gray-300 text-gray-500 font-bold py-2 px-4 rounded cursor-not-allowed">
-                    <NavLink :href="route('company.changePlan', props.company)" class="text-gray-500 font-bold py-2 px-4 rounded">
-                        <AddIcon class="w-5 h-5 inline-block mr-2" /> Límite alcanzado
-                    </NavLink>
+        <AdminPage>
+            <template #header>
+                <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+                    <div class="space-y-2">
+                        <p class="text-blue-200 text-sm uppercase tracking-widest">Gestión de usuarios</p>
+                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Usuarios</h1>
+                        <p class="text-sm text-blue-200">Administra los miembros del equipo y controla los permisos asignados.</p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-3">
+                        <NavLink
+                            v-if="canCreateUser"
+                            :href="route('users.create')"
+                            class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 transition hover:bg-white/20"
+                        >
+                            <AddIcon class="w-4 h-4" /> Nuevo usuario
+                        </NavLink>
+                        <NavLink
+                            v-else
+                            :href="route('company.changePlan', company)"
+                            class="inline-flex items-center gap-2 rounded-xl border border-white/30 px-4 py-2 text-sm font-semibold text-white/80 backdrop-blur transition hover:bg-white/10"
+                        >
+                            <AddIcon class="w-4 h-4" /> Amplía tu plan
+                        </NavLink>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <AdminStatCard label="Usuarios activos" :value="totalUsers" :description="`${seatsRemaining} lugares disponibles`" />
+                    <AdminStatCard label="Roles disponibles" :value="rolesCount" :description="rolesCount === 1 ? 'Rol configurado' : 'Roles configurados'" />
+                    <AdminStatCard label="Límite del plan" :value="planLimit" :description="planName" />
+                    <AdminStatCard label="Estado" :value="canCreateUser ? 'Con capacidad' : 'Límite alcanzado'">
+                        <template #badge>
+                            <span :class="statusBadgeClasses">{{ canCreateUser ? 'Disponible' : 'Completo' }}</span>
+                        </template>
+                    </AdminStatCard>
+                </div>
+            </template>
 
-                </span>
-
-            </div>
-
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <table class="w-full table-auto">
-                    <thead>
-                    <tr class="bg-gray-100">
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Email</th>
-                        <th class="px-4 py-2 text-left">Rol</th>
-                        <th class="px-4 py-2 text-left">Acciones</th>
-                    </tr>
+            <AdminPanel title="Listado de usuarios" description="Consulta la información clave de cada miembro y gestiona sus acciones.">
+                <AdminTable>
+                    <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Nombre</th>
+                            <th scope="col" class="px-6 py-3">Email</th>
+                            <th scope="col" class="px-6 py-3">Rol</th>
+                            <th scope="col" class="px-6 py-3 text-right">Acciones</th>
+                        </tr>
                     </thead>
-                    <tbody>
-                    <tr v-for="user in users" :key="user.id" class="border-t">
-                        <td class="px-4 py-2">{{ user.name }}</td>
-                        <td class="px-4 py-2">{{ user.email }}</td>
-                        <td class="px-4 py-2">{{ getUserRole(user.role_id) }}</td>
-                        <td class="px-4 py-2">
-<!--                            <NavLink :href="route('users.show', user.id)" class="text-blue-500 mr-2">-->
-<!--                                <InfoIcon class="w-5 h-5" />-->
-<!--                            </NavLink>-->
-                            <NavLink :href="route('users.edit', user.id)" class="text-yellow-500 mr-2">
-                                <EditIcon class="w-5 h-5" />
-                            </NavLink>
-                            <button v-if="getUserRole(user.role_id) !== 'Administrador'" @click="deleteUser(user.id)" class="text-red-500">
-                                <DeleteIcon class="w-5 h-5" />
-                            </button>
-
-                        </td>
-                    </tr>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                        <tr v-for="user in users" :key="user.id" class="hover:bg-slate-50/60 transition">
+                            <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ user.name }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600">{{ user.email }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-600">{{ getUserRole(user.role_id) }}</td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex justify-end gap-3 text-slate-500">
+                                    <NavLink :href="route('users.edit', user.id)" class="transition hover:text-amber-500">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button
+                                        v-if="getUserRole(user.role_id) !== 'Administrador'"
+                                        @click="deleteUser(user.id)"
+                                        class="transition hover:text-rose-500"
+                                    >
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </AdminTable>
+            </AdminPanel>
+        </AdminPage>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from "@/Layouts/AppLayout.vue";
+import NavLink from "@/Components/NavLink.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import InfoIcon from "@/Components/Icons/InfoIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
-import {computed} from "vue";
+import AdminPage from "@/Components/Dashboard/AdminPage.vue";
+import AdminPanel from "@/Components/Dashboard/AdminPanel.vue";
+import AdminStatCard from "@/Components/Dashboard/AdminStatCard.vue";
+import AdminTable from "@/Components/Dashboard/AdminTable.vue";
 
 const props = defineProps({
     users: Array,
     roles: Array,
-    plan: Object, // { user_limit: Number, current_users: Number }
-    company: Object
+    plan: Object,
+    company: Object,
 });
 
+const totalUsers = computed(() => props.users.length);
+const rolesCount = computed(() => props.roles.length);
+const planLimit = computed(() => props.plan?.user_limit ?? 0);
+const planName = computed(() => props.plan?.name ?? 'Plan actual');
+const seatsRemaining = computed(() => Math.max(planLimit.value - totalUsers.value, 0));
+const canCreateUser = computed(() => totalUsers.value < planLimit.value);
+
+const statusBadgeClasses = computed(() => [
+    'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide',
+    canCreateUser.value ? 'bg-emerald-500/20 text-emerald-300 ring-1 ring-emerald-400/30' : 'bg-rose-500/20 text-rose-300 ring-1 ring-rose-400/30',
+]);
 
 const getUserRole = (roleId) => {
     const role = props.roles.find((r) => r.id === roleId);
-    return role ? role.name : 'Sin Rol';
+    return role ? role.name : 'Sin rol';
 };
-
-const canCreateUser = computed(() => {
-    return props.users.length < props.plan.user_limit;
-});
-
 
 const deleteUser = (userId) => {
     if (confirm("¿Estás seguro de que deseas eliminar este usuario?")) {
@@ -87,7 +117,3 @@ const deleteUser = (userId) => {
     }
 };
 </script>
-
-<style scoped>
-/* Estilos personalizados aquí */
-</style>


### PR DESCRIPTION
## Summary
- add reusable AdminPage, AdminPanel, AdminStatCard, and AdminTable components to centralize dashboard styling
- refactor user, role, company, plan, email configuration, user task, and admin dashboard views to use the shared layout and metrics
- align administrative forms and detail panels with consistent spacing, typography, and call-to-action patterns

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de5dfee3548323bfcf721d283995d7