### PR TITLE
Fix tickets index prop defaults causing Vue build failure

### DIFF
--- a/resources/js/Pages/Tikets/Index.vue
+++ b/resources/js/Pages/Tikets/Index.vue
@@ -170,7 +170,7 @@ import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import PrintIcon from '@/Components/Icons/PrintIcon.vue';
 
-const props = withDefaults(defineProps({
+const props = defineProps({
     tickets: {
         type: Array,
         default: () => [],
@@ -187,11 +187,6 @@ const props = withDefaults(defineProps({
         type: Array,
         default: () => [],
     },
-}), {
-    tickets: () => [],
-    ticketItems: () => [],
-    products: () => [],
-    categories: () => [],
 });
 
 const startDate = ref('');


### PR DESCRIPTION
## Summary
- remove the improper `withDefaults` wrapper around the Tickets index props so Vite can compile the page

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de66442f3c8323b501dbf3355d5ff8