### PR TITLE
Fix Vite build failure caused by Vue withDefaults usage

### DIFF
--- a/resources/js/Components/KpiCard.vue
+++ b/resources/js/Components/KpiCard.vue
@@ -21,7 +21,7 @@
 <script setup>
 import { computed } from 'vue';
 
-const props = withDefaults(defineProps({
+const props = defineProps({
     subtitle: {
         type: String,
         required: true,
@@ -46,8 +46,6 @@ const props = withDefaults(defineProps({
         type: String,
         default: 'p-6',
     },
-}), {
-    description: '',
 });
 
 const subtitleClass = computed(() => props.gradient ? 'text-fuchsia-200' : 'text-slate-500');


### PR DESCRIPTION
## Summary
- remove the withDefaults wrapper from KpiCard props to comply with Vue's type-based defineProps requirement

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68de694753948323bc7ce4aadfeb3921