### PR TITLE
Fix create view defaults for invoices and budgets

### DIFF
--- a/resources/js/Pages/Budgets/Create.vue
+++ b/resources/js/Pages/Budgets/Create.vue
@@ -318,11 +318,23 @@ import MenuClientsIcon from '@/Components/Icons/MenuClientsIcon.vue';
 import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
-const props = defineProps({
-    clients: Array,
-    products: Array,
-    categories: Array,
-});
+const props = withDefaults(
+    defineProps({
+        clients: {
+            type: Array,
+            default: () => [],
+        },
+        products: {
+            type: Array,
+            default: () => [],
+        },
+        categories: {
+            type: Array,
+            default: () => [],
+        },
+    }),
+    {}
+);
 
 const budget = ref({
     date: new Date().toISOString().split('T')[0],

--- a/resources/js/Pages/Invoices/Create.vue
+++ b/resources/js/Pages/Invoices/Create.vue
@@ -353,11 +353,23 @@ import MenuClientsIcon from '@/Components/Icons/MenuClientsIcon.vue';
 import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
-const props = defineProps({
-    clients: Array,
-    products: Array,
-    categories: Array,
-});
+const props = withDefaults(
+    defineProps({
+        clients: {
+            type: Array,
+            default: () => [],
+        },
+        products: {
+            type: Array,
+            default: () => [],
+        },
+        categories: {
+            type: Array,
+            default: () => [],
+        },
+    }),
+    {}
+);
 
 const invoice = ref({
     date: new Date().toISOString().split('T')[0],


### PR DESCRIPTION
## Summary
- add default empty arrays for clients, products, and categories in invoice and budget create views to prevent runtime errors when props are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df703ecb108323b19430eac9bf8dda