### PR TITLE
Fix runtime props usage in budgets create page

### DIFF
--- a/resources/js/Pages/Budgets/Create.vue
+++ b/resources/js/Pages/Budgets/Create.vue
@@ -318,23 +318,20 @@ import MenuClientsIcon from '@/Components/Icons/MenuClientsIcon.vue';
 import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
-const props = withDefaults(
-    defineProps({
-        clients: {
-            type: Array,
-            default: () => [],
-        },
-        products: {
-            type: Array,
-            default: () => [],
-        },
-        categories: {
-            type: Array,
-            default: () => [],
-        },
-    }),
-    {}
-);
+const props = defineProps({
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+    products: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+});
 
 const budget = ref({
     date: new Date().toISOString().split('T')[0],


### PR DESCRIPTION
## Summary
- remove withDefaults wrapper from the Budgets create page props declaration to restore compatibility with runtime prop definitions

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*


------
https://chatgpt.com/codex/tasks/task_e_68df71503dec8323ab94151b3ea6ab22