### PR TITLE
Fix invoice prop defaults to restore production build

### DIFF
--- a/resources/js/Pages/Invoices/Create.vue
+++ b/resources/js/Pages/Invoices/Create.vue
@@ -153,9 +153,9 @@ import AddProductIcon from "@/Components/Icons/AddProductIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 
 const props = defineProps({
-    clients: Array,
-    products: Array,
-    categories: Array,
+    clients: { type: Array, default: () => [] },
+    products: { type: Array, default: () => [] },
+    categories: { type: Array, default: () => [] },
     projects: { type: Array, default: () => [] },
 });
 


### PR DESCRIPTION
## Summary
- ensure the Invoices Create view uses runtime prop defaults compatible with Vue's compiler

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68df77609a088323aa2f5a42100f3d96