### PR TITLE
Fix build failure in invoice create page props

### DIFF
--- a/resources/js/Pages/Invoices/Create.vue
+++ b/resources/js/Pages/Invoices/Create.vue
@@ -353,23 +353,20 @@ import MenuClientsIcon from '@/Components/Icons/MenuClientsIcon.vue';
 import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
-const props = withDefaults(
-    defineProps({
-        clients: {
-            type: Array,
-            default: () => [],
-        },
-        products: {
-            type: Array,
-            default: () => [],
-        },
-        categories: {
-            type: Array,
-            default: () => [],
-        },
-    }),
-    {}
-);
+const props = defineProps({
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+    products: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+});
 
 const invoice = ref({
     date: new Date().toISOString().split('T')[0],


### PR DESCRIPTION
## Summary
- replace the use of `withDefaults` on the invoice create page with a plain `defineProps` call so runtime prop defaults remain compatible with the Vue compiler

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy")*


------
https://chatgpt.com/codex/tasks/task_e_68df78529e808323870b5debdf78096c