### PR TITLE
Adjust almacen module gradient colors

### DIFF
--- a/resources/js/Components/Inventory/inventoryTheme.js
+++ b/resources/js/Components/Inventory/inventoryTheme.js
@@ -1,6 +1,6 @@
 export const inventoryPalette = {
     background: 'bg-slate-950',
-    gradient: 'from-yellow-500 via-amber-600 to-black',
+    gradient: 'from-yellow-400 via-yellow-600 to-black',
     surface: 'bg-white',
     surfaceMuted: 'bg-white/80 backdrop-blur',
     border: 'border-amber-500/20',


### PR DESCRIPTION
## Summary
- update the inventory theme gradient to use a yellow-to-black palette for almacen views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7e6359d08323bf9c2c72dbc00382