### PR TITLE
Refreshed accounting CRUD views

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -61,11 +61,13 @@ class CategoryController extends Controller
         return Inertia::location(route('categories.index'));
     }
 
-    //show
-
-    public function show()
+    public function show(Category $category)
     {
+        $category->load('company');
 
+        return Inertia::render('Categories/Show', [
+            'category' => $category,
+        ]);
     }
 
     public function destroy(Category $category)

--- a/app/Http/Controllers/PaymentMethodController.php
+++ b/app/Http/Controllers/PaymentMethodController.php
@@ -37,6 +37,8 @@ class PaymentMethodController extends Controller
 
     public function show(PaymentMethod $paymentMethod)
     {
+        $paymentMethod->load('company');
+
         return Inertia::render('PaymentMethods/Show', [
             'paymentMethod' => $paymentMethod
         ]);
@@ -54,8 +56,9 @@ class PaymentMethodController extends Controller
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'company_id' => 'required|exists:companies,id',
         ]);
+
+        $validated['company_id'] = Auth::user()->company_id;
 
         $paymentMethod->update($validated);
 

--- a/resources/js/Pages/Categories/Create.vue
+++ b/resources/js/Pages/Categories/Create.vue
@@ -1,50 +1,56 @@
 <template>
     <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Create Category</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" type="text" class="mt-1 block w-full border border-gray-300 p-2 rounded" placeholder="Category name">
-                <span v-if="errors.name" class="text-red-500">{{ errors.name }}</span>
-            </div>
+        <div class="container mx-auto max-w-3xl bg-gray-50 min-h-screen p-6">
+            <h1 class="text-3xl font-semibold text-gray-800 mb-6">Crear categoría</h1>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Description</label>
-                <textarea v-model="form.description" class="mt-1 block w-full border border-gray-300 p-2 rounded" placeholder="Category description"></textarea>
-                <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-            </div>
+            <form @submit.prevent="submit" class="space-y-6 bg-white p-6 rounded-lg shadow">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700" for="name">Nombre</label>
+                    <input
+                        id="name"
+                        v-model="form.name"
+                        type="text"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        placeholder="Ej. Servicios, Productos..."
+                    >
+                    <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
+                </div>
 
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                <SaveIcon /> Save Category
-            </button>
-        </form>
-    </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700" for="description">Descripción</label>
+                    <textarea
+                        id="description"
+                        v-model="form.description"
+                        rows="3"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        placeholder="Describe brevemente la categoría"
+                    ></textarea>
+                    <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
+                </div>
+
+                <div class="flex items-center justify-between">
+                    <Link :href="route('categories.index')" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                    <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                        <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                        Guardar categoría
+                    </button>
+                </div>
+            </form>
+        </div>
     </AppLayout>
 </template>
 
-<script>
-import { useForm } from '@inertiajs/inertia-vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+<script setup>
+import { Link, useForm } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
-export default {
-    components: {SaveIcon, AppLayout},
-    setup() {
-        const form = useForm({
-            name: '',
-            description: '',
-        });
+const form = useForm({
+    name: '',
+    description: '',
+});
 
-        const submit = () => {
-            form.post(route('categories.store'));
-        };
-
-        return {
-            form,
-            submit,
-            errors: form.errors,
-        };
-    }
+const submit = () => {
+    form.post(route('categories.store'));
 };
 </script>

--- a/resources/js/Pages/Categories/Edit.vue
+++ b/resources/js/Pages/Categories/Edit.vue
@@ -1,53 +1,58 @@
 <template>
     <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Edit Category</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" type="text" class="mt-1 block w-full border border-gray-300 p-2 rounded">
-                <span v-if="errors.name" class="text-red-500">{{ errors.name }}</span>
-            </div>
+        <div class="container mx-auto max-w-3xl bg-gray-50 min-h-screen p-6">
+            <h1 class="text-3xl font-semibold text-gray-800 mb-6">Editar categoría</h1>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Description</label>
-                <textarea v-model="form.description" class="mt-1 block w-full border border-gray-300 p-2 rounded"></textarea>
-                <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-            </div>
+            <form @submit.prevent="submit" class="space-y-6 bg-white p-6 rounded-lg shadow">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700" for="name">Nombre</label>
+                    <input
+                        id="name"
+                        v-model="form.name"
+                        type="text"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    >
+                    <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
+                </div>
 
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                <SaveIcon /> Update
-            </button>
-        </form>
-    </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700" for="description">Descripción</label>
+                    <textarea
+                        id="description"
+                        v-model="form.description"
+                        rows="3"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    ></textarea>
+                    <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
+                </div>
+
+                <div class="flex items-center justify-between">
+                    <Link :href="route('categories.show', category.id)" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                    <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                        <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                        Guardar cambios
+                    </button>
+                </div>
+            </form>
+        </div>
     </AppLayout>
 </template>
 
-<script>
-import { useForm } from '@inertiajs/inertia-vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+<script setup>
+import { Link, useForm } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
-export default {
-    components: {SaveIcon, AppLayout},
-    props: {
-        category: Object
-    },
-    setup(props) {
-        const form = useForm({
-            name: props.category.name,
-            description: props.category.description,
-        });
+const props = defineProps({
+    category: Object,
+});
 
-        const submit = () => {
-            form.put(route('categories.update', props.category.id));
-        };
+const form = useForm({
+    name: props.category?.name ?? '',
+    description: props.category?.description ?? '',
+});
 
-        return {
-            form,
-            submit,
-            errors: form.errors,
-        };
-    }
+const submit = () => {
+    form.put(route('categories.update', props.category.id));
 };
 </script>

--- a/resources/js/Pages/Categories/Show.vue
+++ b/resources/js/Pages/Categories/Show.vue
@@ -1,0 +1,69 @@
+<template>
+    <AppLayout>
+        <div class="container mx-auto max-w-3xl bg-gray-50 min-h-screen p-6">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <h1 class="text-3xl font-semibold text-gray-800">Detalle de la categoría</h1>
+                    <p class="text-sm text-gray-500">Consulta los datos registrados para esta categoría de inventario.</p>
+                </div>
+                <div class="flex gap-2">
+                    <Link :href="route('categories.edit', category.id)" class="rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200" title="Editar">
+                        <EditIcon class="h-5 w-5" />
+                    </Link>
+                    <button @click="destroy" class="rounded-full bg-red-100 p-2 text-red-600 hover:bg-red-200" title="Eliminar">
+                        <DeleteIcon class="h-5 w-5" />
+                    </button>
+                </div>
+            </div>
+
+            <div class="space-y-6">
+                <div class="rounded-lg bg-white p-6 shadow">
+                    <dl class="space-y-4 text-sm text-gray-700">
+                        <div>
+                            <dt class="font-semibold text-gray-500">Nombre</dt>
+                            <dd class="text-gray-900">{{ category.name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="font-semibold text-gray-500">Descripción</dt>
+                            <dd class="text-gray-900 whitespace-pre-line">{{ category.description || 'Sin descripción' }}</dd>
+                        </div>
+                        <div v-if="category.company" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <dt class="font-semibold text-gray-500">Empresa</dt>
+                                <dd class="text-gray-900">{{ category.company.name }}</dd>
+                            </div>
+                            <div>
+                                <dt class="font-semibold text-gray-500">CIF</dt>
+                                <dd class="text-gray-900">{{ category.company.cif }}</dd>
+                            </div>
+                        </div>
+                    </dl>
+                </div>
+
+                <div>
+                    <Link :href="route('categories.index')" class="text-sm font-medium text-blue-700 hover:underline">Volver al listado</Link>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+
+const props = defineProps({
+    category: Object,
+});
+
+const category = props.category;
+
+const destroy = () => {
+    if (confirm('¿Deseas eliminar esta categoría?')) {
+        Inertia.delete(route('categories.destroy', category.id));
+    }
+};
+</script>

--- a/resources/js/Pages/Expenses/Create.vue
+++ b/resources/js/Pages/Expenses/Create.vue
@@ -1,122 +1,179 @@
 <template>
     <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Crear Gasto</h1>
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-5xl">
+                <h1 class="text-3xl font-semibold mb-6 text-gray-800">Registrar gasto</h1>
 
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="date" class="block text-gray-700">Fecha</label>
-                        <input v-model="expense.date" id="date" type="date"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                <form @submit.prevent="submitForm" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white p-6 rounded-lg shadow">
+                        <div>
+                            <label for="date" class="block text-sm font-medium text-gray-700">Fecha</label>
+                            <input
+                                id="date"
+                                v-model="form.date"
+                                type="date"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.date" class="mt-2 text-sm text-red-600">{{ form.errors.date }}</p>
+                        </div>
+
+                        <div>
+                            <label for="name" class="block text-sm font-medium text-gray-700">Nombre del gasto</label>
+                            <input
+                                id="name"
+                                v-model="form.name"
+                                type="text"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                                placeholder="Ej. Suscripción software"
+                            />
+                            <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
+                        </div>
+
+                        <div>
+                            <label for="category_id" class="block text-sm font-medium text-gray-700">Categoría</label>
+                            <select
+                                id="category_id"
+                                v-model="form.expense_category_id"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            >
+                                <option value="" disabled>Selecciona una categoría</option>
+                                <option v-for="category in categories" :key="category.id" :value="category.id">
+                                    {{ category.name }}
+                                </option>
+                            </select>
+                            <p v-if="form.errors.expense_category_id" class="mt-2 text-sm text-red-600">{{ form.errors.expense_category_id }}</p>
+                        </div>
+
+                        <div>
+                            <label for="payment_method_id" class="block text-sm font-medium text-gray-700">Método de pago</label>
+                            <select
+                                id="payment_method_id"
+                                v-model="form.payment_method_id"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            >
+                                <option value="" disabled>Selecciona un método</option>
+                                <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">
+                                    {{ paymentMethod.name }}
+                                </option>
+                            </select>
+                            <p v-if="form.errors.payment_method_id" class="mt-2 text-sm text-red-600">{{ form.errors.payment_method_id }}</p>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="description" class="block text-sm font-medium text-gray-700">Descripción</label>
+                            <textarea
+                                id="description"
+                                v-model="form.description"
+                                rows="3"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                                placeholder="Detalles del gasto"
+                            ></textarea>
+                            <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
+                        </div>
+
+                        <div>
+                            <label for="amount" class="block text-sm font-medium text-gray-700">Importe sin IVA</label>
+                            <input
+                                id="amount"
+                                v-model.number="form.amount"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.amount" class="mt-2 text-sm text-red-600">{{ form.errors.amount }}</p>
+                        </div>
+
+                        <div>
+                            <label for="iva" class="block text-sm font-medium text-gray-700">IVA (%)</label>
+                            <input
+                                id="iva"
+                                v-model.number="form.iva"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.iva" class="mt-2 text-sm text-red-600">{{ form.errors.iva }}</p>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="file" class="block text-sm font-medium text-gray-700">Archivo adjunto</label>
+                            <input
+                                id="file"
+                                type="file"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                                @change="handleFileChange"
+                            />
+                            <p v-if="form.errors.file" class="mt-2 text-sm text-red-600">{{ form.errors.file }}</p>
+                        </div>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Gasto</label>
-                        <input v-model="expense.name" id="name" type="text" placeholder="Nombre del Gasto"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">Importe base</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ Number(form.amount || 0).toFixed(2) }} €</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">IVA estimado</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ taxAmount.toFixed(2) }} €</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">Total previsto</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ totalAmount.toFixed(2) }} €</p>
+                        </div>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="category_id" class="block text-gray-700">Categoría</label>
-                        <select v-model="expense.expense_category_id" id="category_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="category in categories" :key="category.id" :value="category.id">{{
-                                    category.name
-                                }}</option>
-                        </select>
+                    <div class="flex items-center justify-between">
+                        <Link :href="route('expenses.index')" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                        <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                            <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                            Guardar gasto
+                        </button>
                     </div>
-
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="expense.description" id="description" rows="4"
-                                  class="mt-1 block w-full h-11 border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del gasto"></textarea>
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="file" class="block text-gray-700">Archivo</label>
-                        <input id="file" type="file"  @change="handleFileChange"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" >
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="iva" class="block text-gray-700">IVA</label>
-                        <input v-model="expense.iva" id="iva" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="amount" class="block text-gray-700">Monto</label>
-                        <input v-model="expense.amount" id="amount" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="payment_method_id" class="block text-gray-700">Método de Pago</label>
-                        <select v-model="expense.payment_method_id" id="payment_method_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">{{
-                                    paymentMethod.name
-                                }}</option>
-                        </select>
-                    </div>
-
-                </div>
-
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Gasto">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                </form>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { computed } from 'vue';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
 const props = defineProps({
     categories: Array,
     paymentMethods: Array,
 });
 
-const expense = ref({
+const form = useForm({
     name: '',
     description: '',
     amount: 0,
     iva: 21,
-    date: new Date().toISOString().split('T')[0], // Fecha actual
+    date: new Date().toISOString().split('T')[0],
     payment_method_id: '',
     expense_category_id: '',
     file: null,
 });
 
-// Manejar el cambio de archivo
+const taxAmount = computed(() => {
+    const amount = Number(form.amount) || 0;
+    const iva = Number(form.iva) || 0;
+    return amount * iva / 100;
+});
+
+const totalAmount = computed(() => (Number(form.amount) || 0) + taxAmount.value);
+
 const handleFileChange = (event) => {
-    expense.value.file = event.target.files[0]; // Guardar el archivo en expense.file
+    form.file = event.target.files[0];
 };
 
 const submitForm = () => {
-    const formData = new FormData(); // Crear un FormData para la carga del archivo
-
-    // Agregar todos los campos al FormData excepto el archivo si está vacío
-    Object.entries(expense.value).forEach(([key, value]) => {
-        if (key !== 'file' || value) { // Solo añadir el archivo si existe
-            formData.append(key, value);
-        }
-    });
-
-    // Enviar la solicitud
-    Inertia.post(route('expenses.store'), formData, {
-        headers: {
-            'Content-Type': 'multipart/form-data', // Especificar el tipo de contenido
-        },
+    form.post(route('expenses.store'), {
+        forceFormData: true,
     });
 };
-
 </script>

--- a/resources/js/Pages/Expenses/Edit.vue
+++ b/resources/js/Pages/Expenses/Edit.vue
@@ -1,96 +1,148 @@
 <template>
     <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Editar Gasto</h1>
-            <form @submit.prevent="submitForm" enctype="multipart/form-data">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="date" class="block text-gray-700">Fecha</label>
-                        <input v-model="expense.date" id="date" type="date"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-5xl">
+                <h1 class="text-3xl font-semibold mb-6 text-gray-800">Actualizar gasto</h1>
 
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Gasto</label>
-                        <input v-model="expense.name" id="name" type="text" placeholder="Nombre del Gasto"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="category_id" class="block text-gray-700">Categoría</label>
-                        <select v-model="expense.expense_category_id" id="category_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="category in categories" :key="category.id" :value="category.id">{{
-                                    category.name
-                                }}</option>
-                        </select>
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="expense.description" id="description" rows="4"
-                                  class="mt-1 block w-full h-11 border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del gasto"></textarea>
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="file" class="block text-gray-700">Archivo</label>
-
-                        <!-- Vista previa si el archivo es una imagen -->
-                        <div v-if="expense.file && isImage(expense.file)" class="mb-2">
-                            <img :src="getFileUrl(expense.file)" alt="Archivo adjunto" class="w-40 h-auto rounded shadow">
+                <form @submit.prevent="submitForm" class="space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white p-6 rounded-lg shadow">
+                        <div>
+                            <label for="date" class="block text-sm font-medium text-gray-700">Fecha</label>
+                            <input
+                                id="date"
+                                v-model="form.date"
+                                type="date"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.date" class="mt-2 text-sm text-red-600">{{ form.errors.date }}</p>
                         </div>
 
-                        <!-- Enlace de descarga si no es imagen -->
-                        <div v-else-if="expense.file && typeof expense.file === 'string'" class="mb-2">
-                            <a :href="getFileUrl(expense.file)" target="_blank" class="text-blue-600 underline">
-                                Ver archivo actual
-                            </a>
+                        <div>
+                            <label for="name" class="block text-sm font-medium text-gray-700">Nombre del gasto</label>
+                            <input
+                                id="name"
+                                v-model="form.name"
+                                type="text"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
                         </div>
 
-                        <!-- Input para subir archivo -->
-                        <input id="file" type="file" @change="handleFileChange" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                        <div>
+                            <label for="category_id" class="block text-sm font-medium text-gray-700">Categoría</label>
+                            <select
+                                id="category_id"
+                                v-model="form.expense_category_id"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            >
+                                <option v-for="category in categories" :key="category.id" :value="category.id">
+                                    {{ category.name }}
+                                </option>
+                            </select>
+                            <p v-if="form.errors.expense_category_id" class="mt-2 text-sm text-red-600">{{ form.errors.expense_category_id }}</p>
+                        </div>
+
+                        <div>
+                            <label for="payment_method_id" class="block text-sm font-medium text-gray-700">Método de pago</label>
+                            <select
+                                id="payment_method_id"
+                                v-model="form.payment_method_id"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            >
+                                <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">
+                                    {{ paymentMethod.name }}
+                                </option>
+                            </select>
+                            <p v-if="form.errors.payment_method_id" class="mt-2 text-sm text-red-600">{{ form.errors.payment_method_id }}</p>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="description" class="block text-sm font-medium text-gray-700">Descripción</label>
+                            <textarea
+                                id="description"
+                                v-model="form.description"
+                                rows="3"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            ></textarea>
+                            <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
+                        </div>
+
+                        <div>
+                            <label for="amount" class="block text-sm font-medium text-gray-700">Importe sin IVA</label>
+                            <input
+                                id="amount"
+                                v-model.number="form.amount"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.amount" class="mt-2 text-sm text-red-600">{{ form.errors.amount }}</p>
+                        </div>
+
+                        <div>
+                            <label for="iva" class="block text-sm font-medium text-gray-700">IVA (%)</label>
+                            <input
+                                id="iva"
+                                v-model.number="form.iva"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.iva" class="mt-2 text-sm text-red-600">{{ form.errors.iva }}</p>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="file" class="block text-sm font-medium text-gray-700">Archivo adjunto</label>
+                            <div class="flex items-center gap-4">
+                                <input
+                                    id="file"
+                                    type="file"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                                    @change="handleFileChange"
+                                />
+                                <template v-if="currentFileUrl">
+                                    <a :href="currentFileUrl" target="_blank" class="text-sm text-blue-700 hover:underline">Ver archivo actual</a>
+                                </template>
+                            </div>
+                            <p v-if="form.errors.file" class="mt-2 text-sm text-red-600">{{ form.errors.file }}</p>
+                        </div>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="iva" class="block text-gray-700">IVA</label>
-                        <input v-model="expense.iva" id="iva" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">Importe base</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ Number(form.amount || 0).toFixed(2) }} €</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">IVA estimado</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ taxAmount.toFixed(2) }} €</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                            <p class="text-sm text-gray-500">Total previsto</p>
+                            <p class="text-xl font-semibold text-gray-800">{{ totalAmount.toFixed(2) }} €</p>
+                        </div>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="amount" class="block text-gray-700">Monto</label>
-                        <input v-model="expense.amount" id="amount" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                    <div class="flex items-center justify-between">
+                        <Link :href="route('expenses.show', expense.id)" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                        <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                            <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                            Guardar cambios
+                        </button>
                     </div>
-
-                    <div class="mb-4">
-                        <label for="payment_method_id" class="block text-gray-700">Método de Pago</label>
-                        <select v-model="expense.payment_method_id" id="payment_method_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">{{
-                                    paymentMethod.name
-                                }}</option>
-                        </select>
-                    </div>
-
-                </div>
-
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Cambios">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                </form>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref, onMounted} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { computed } from 'vue';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
 const props = defineProps({
     categories: Array,
@@ -98,57 +150,39 @@ const props = defineProps({
     expense: Object,
 });
 
-const expense = ref({
-    name: '',
-    description: '',
-    amount: 0,
-    iva: 21,
-    date: new Date().toISOString().split('T')[0],
-    payment_method_id: null,
-    expense_category_id: null,
+const form = useForm({
+    name: props.expense?.name ?? '',
+    description: props.expense?.description ?? '',
+    amount: props.expense?.amount ?? 0,
+    iva: props.expense?.iva ?? 0,
+    date: props.expense?.date ?? new Date().toISOString().split('T')[0],
+    payment_method_id: props.expense?.payment_method_id ?? '',
+    expense_category_id: props.expense?.expense_category_id ?? '',
     file: null,
 });
 
-// Cargar datos existentes del gasto al montar el componente
-onMounted(() => {
-    expense.value = { ...props.expense }; // Asignar los datos actuales al formulario
+const currentFileUrl = computed(() => {
+    if (!props.expense?.file) {
+        return null;
+    }
+    return `/storage/${props.expense.file}`;
 });
 
-const getFileUrl = (filePath) => {
-    return `/storage/${filePath.replace('public/', '')}`;
-};
+const taxAmount = computed(() => {
+    const amount = Number(form.amount) || 0;
+    const iva = Number(form.iva) || 0;
+    return amount * iva / 100;
+});
 
-const isImage = (file) => {
-    return file instanceof File && file.type.startsWith('image');
-};
+const totalAmount = computed(() => (Number(form.amount) || 0) + taxAmount.value);
 
-// Manejar el cambio de archivo
 const handleFileChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-        expense.value.file = file; // Guardar el archivo en expense.file
-        console.log('Archivo seleccionado:', file);
-    } else {
-        console.log('No se ha seleccionado ningún archivo');
-    }
+    form.file = event.target.files[0];
 };
 
-const submitForm = async () => {
-    const formData = new FormData();
-
-    for (const [key, value] of Object.entries(expense.value)) {
-        if (value !== null && value !== undefined) {
-            if (key === 'file' && typeof value === 'string') {
-                continue; // No enviar la ruta del archivo actual
-            }
-            formData.append(key, value instanceof File ? value : String(value));
-        }
-    }
-
-    // Enviar datos con Inertia
-    Inertia.post(route('expenses.update2', props.expense.id), formData, {
-        forceFormData: true, // Esto es clave para que Inertia envíe FormData correctamente
+const submitForm = () => {
+    form.post(route('expenses.update2', props.expense.id), {
+        forceFormData: true,
     });
 };
-
 </script>

--- a/resources/js/Pages/Expenses/Report.vue
+++ b/resources/js/Pages/Expenses/Report.vue
@@ -1,151 +1,177 @@
 <template>
     <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Reportes de Contabilidad</h1>
-            <div class="mb-4">
-                <label for="start_date" class="block text-gray-700">Fecha de Inicio</label>
-                <input v-model="filter.start_date" type="date" id="start_date" @change="fetchFilteredData"
-                       class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-            </div>
-            <div class="mb-4">
-                <label for="end_date" class="block text-gray-700">Fecha de Fin</label>
-                <input v-model="filter.end_date" type="date" id="end_date" @change="fetchFilteredData"
-                       class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-            </div>
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-6xl space-y-8">
+                <div>
+                    <h1 class="text-3xl font-semibold text-gray-800">Reportes de contabilidad</h1>
+                    <p class="text-sm text-gray-500">Filtra la información para analizar el desempeño económico de la empresa.</p>
+                </div>
 
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Gastos</h2>
-            <table class="min-w-full bg-white border border-gray-300 mb-8">
-                <thead>
-                <tr>
-                    <th class="py-2 px-4 border-b">Fecha</th>
-                    <th class="py-2 px-4 border-b">Nombre</th>
-                    <th class="py-2 px-4 border-b">Descripción</th>
-                    <th class="py-2 px-4 border-b">Monto</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr v-for="expense in filteredExpenses" :key="expense.id">
-                    <td class="py-2 px-4 border-b">{{ expense.date }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.name }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.description }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.amount }}</td>
-                </tr>
-                <tr v-if="filteredExpenses.length === 0">
-                    <td colspan="4" class="py-2 px-4 border-b text-center">No hay gastos en este rango de fechas.</td>
-                </tr>
-                </tbody>
-            </table>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 bg-white p-6 rounded-lg shadow">
+                    <div>
+                        <label for="start_date" class="block text-sm font-medium text-gray-700">Fecha de inicio</label>
+                        <input
+                            v-model="filter.start_date"
+                            type="date"
+                            id="start_date"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        >
+                    </div>
+                    <div>
+                        <label for="end_date" class="block text-sm font-medium text-gray-700">Fecha de fin</label>
+                        <input
+                            v-model="filter.end_date"
+                            type="date"
+                            id="end_date"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        >
+                    </div>
+                    <div class="md:col-span-2 flex gap-3">
+                        <button @click="clearFilters" type="button" class="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800">
+                            Limpiar filtros
+                        </button>
+                        <button @click="printReport" type="button" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                            <PrintIcon class="mr-2 h-5 w-5 fill-gray-50" />
+                            Imprimir reporte
+                        </button>
+                    </div>
+                </div>
 
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Ingresos</h2>
-            <table class="min-w-full bg-white border border-gray-300 mb-8">
-                <thead>
-                <tr>
-                    <th class="py-2 px-4 border-b">Fecha</th>
-                    <th class="py-2 px-4 border-b">Nombre</th>
-                    <th class="py-2 px-4 border-b">Cliente</th>
-                    <th class="py-2 px-4 border-b">Monto</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr v-for="income in filteredIncomes" :key="income.id">
-                    <td class="py-2 px-4 border-b">{{ income.date }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.name }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.source }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.total_amount }}</td>
-                </tr>
-                <tr v-if="filteredIncomes.length === 0">
-                    <td colspan="4" class="py-2 px-4 border-b text-center">No hay ingresos en este rango de fechas.</td>
-                </tr>
-                </tbody>
-            </table>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div class="rounded-lg bg-white p-4 shadow border border-gray-200">
+                        <p class="text-sm text-gray-500">Ingresos filtrados</p>
+                        <p class="text-2xl font-semibold text-emerald-600">{{ totalIncomes.toFixed(2) }} €</p>
+                    </div>
+                    <div class="rounded-lg bg-white p-4 shadow border border-gray-200">
+                        <p class="text-sm text-gray-500">Gastos filtrados</p>
+                        <p class="text-2xl font-semibold text-rose-600">{{ totalExpenses.toFixed(2) }} €</p>
+                    </div>
+                    <div class="rounded-lg bg-white p-4 shadow border border-gray-200">
+                        <p class="text-sm text-gray-500">Resultado neto</p>
+                        <p :class="['text-2xl font-semibold', netBenefit >= 0 ? 'text-blue-700' : 'text-red-600']">{{ netBenefit.toFixed(2) }} €</p>
+                    </div>
+                </div>
 
-            <!-- Sección de comparativa de beneficios -->
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Comparativa de Beneficios</h2>
-            <div class="bg-white border border-gray-300 p-4 mb-8">
-                <p><strong>Beneficio Bruto:</strong> {{ grossBenefit }}</p>
-                <p><strong>Monto de IVA:</strong> {{ ivaAmount }}</p>
-                <p><strong>Beneficio Neto:</strong> {{ netBenefit }}</p>
-            </div>
+                <section class="bg-white rounded-lg shadow overflow-hidden">
+                    <header class="px-6 py-4 border-b border-gray-200">
+                        <h2 class="text-xl font-semibold text-gray-700">Detalle de gastos</h2>
+                    </header>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nombre</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Descripción</th>
+                                    <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Monto</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                <tr v-for="expense in filteredExpenses" :key="expense.id" class="hover:bg-gray-50">
+                                    <td class="px-4 py-2 text-sm text-gray-700">{{ expense.date }}</td>
+                                    <td class="px-4 py-2 text-sm text-gray-700">{{ expense.name }}</td>
+                                    <td class="px-4 py-2 text-sm text-gray-600">{{ expense.description || 'Sin descripción' }}</td>
+                                    <td class="px-4 py-2 text-sm text-right text-gray-800">{{ Number(expense.amount).toFixed(2) }} €</td>
+                                </tr>
+                                <tr v-if="filteredExpenses.length === 0">
+                                    <td colspan="4" class="px-4 py-4 text-center text-sm text-gray-500">No hay gastos en este rango de fechas.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
 
-            <div class="mt-8 flex justify-between items-center">
-                <button @click="printReport" class="bg-blue-900 p-2 rounded-full" title="Imprimir Reporte">
-                    <PrintIcon class="w-6 h-6 fill-gray-50 stroke-0 stroke-gray-50"/>
-                </button>
+                <section class="bg-white rounded-lg shadow overflow-hidden">
+                    <header class="px-6 py-4 border-b border-gray-200">
+                        <h2 class="text-xl font-semibold text-gray-700">Detalle de ingresos</h2>
+                    </header>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nombre</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Origen</th>
+                                    <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                <tr v-for="income in filteredIncomes" :key="income.id" class="hover:bg-gray-50">
+                                    <td class="px-4 py-2 text-sm text-gray-700">{{ income.date }}</td>
+                                    <td class="px-4 py-2 text-sm text-gray-700">{{ income.name }}</td>
+                                    <td class="px-4 py-2 text-sm text-gray-600">{{ income.source }}</td>
+                                    <td class="px-4 py-2 text-sm text-right text-gray-800">{{ Number(income.total_amount).toFixed(2) }} €</td>
+                                </tr>
+                                <tr v-if="filteredIncomes.length === 0">
+                                    <td colspan="4" class="px-4 py-4 text-center text-sm text-gray-500">No hay ingresos en este rango de fechas.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
             </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref, computed} from 'vue';
+import { computed, reactive } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import PrintIcon from "@/Components/Icons/PrintIcon.vue";
+import PrintIcon from '@/Components/Icons/PrintIcon.vue';
 
 const props = defineProps({
     expenses: Array,
-    incomes: Array, // Cambié invoices a incomes
+    incomes: Array,
     clients: Array,
 });
 
-const filter = ref({
+const filter = reactive({
     start_date: '',
     end_date: '',
 });
 
-// Computed properties para filtrar los gastos y los ingresos
 const filteredExpenses = computed(() => {
-    if (!filter.value.start_date && !filter.value.end_date) {
-        return props.expenses; // Sin filtro, devuelve todos los gastos
+    if (!filter.start_date && !filter.end_date) {
+        return props.expenses;
     }
-    return props.expenses.filter(expense => {
-        const expenseDate = new Date(expense.date);
-        const startDate = new Date(filter.value.start_date);
-        const endDate = new Date(filter.value.end_date);
-        return (
-            (filter.value.start_date ? expenseDate >= startDate : true) &&
-            (filter.value.end_date ? expenseDate <= endDate : true)
-        );
-    });
+    return props.expenses.filter((expense) => isWithinRange(expense.date));
 });
 
 const filteredIncomes = computed(() => {
-    if (!filter.value.start_date && !filter.value.end_date) {
-        return props.incomes; // Sin filtro, devuelve todos los ingresos
+    if (!filter.start_date && !filter.end_date) {
+        return props.incomes;
     }
-    return props.incomes.filter(income => {
-        const incomeDate = new Date(income.date);
-        const startDate = new Date(filter.value.start_date);
-        const endDate = new Date(filter.value.end_date);
-        return (
-            (filter.value.start_date ? incomeDate >= startDate : true) &&
-            (filter.value.end_date ? incomeDate <= endDate : true)
-        );
-    });
+    return props.incomes.filter((income) => isWithinRange(income.date));
 });
 
-// Cálculos de beneficios
-const grossBenefit = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount, 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount, 0);
-    return totalIncomes - totalExpenses; // Beneficio bruto
-});
+const totalExpenses = computed(() => filteredExpenses.value.reduce((total, expense) => total + Number(expense.amount || 0), 0));
+const totalIncomes = computed(() => filteredIncomes.value.reduce((total, income) => total + Number(income.total_amount || 0), 0));
+const netBenefit = computed(() => totalIncomes.value - totalExpenses.value);
 
-const ivaAmount = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount * (expense.iva / 100), 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount * (income.tax_rate / 100), 0);
-    return totalIncomes - totalExpenses; // Monto de IVA
-});
+const isWithinRange = (dateString) => {
+    const date = new Date(dateString);
+    const start = filter.start_date ? new Date(filter.start_date) : null;
+    const end = filter.end_date ? new Date(filter.end_date) : null;
 
-const netBenefit = computed(() => {
-    return grossBenefit.value - ivaAmount.value; // Beneficio neto
-});
+    if (start && date < start) {
+        return false;
+    }
+    if (end && date > end) {
+        return false;
+    }
+    return true;
+};
 
-// Método para imprimir el reporte
+const clearFilters = () => {
+    filter.start_date = '';
+    filter.end_date = '';
+};
+
 const printReport = () => {
     const url = route('expenses.reportsPrint', {
-        start_date: filter.value.start_date,
-        end_date: filter.value.end_date,
+        start_date: filter.start_date,
+        end_date: filter.end_date,
     });
-    window.open(url, '_blank'); // Abrir la vista de impresión en una nueva pestaña
+    window.open(url, '_blank');
 };
 </script>

--- a/resources/js/Pages/Expenses/Show.vue
+++ b/resources/js/Pages/Expenses/Show.vue
@@ -1,57 +1,100 @@
 <template>
     <AppLayout>
-        <div class="items-center justify-start bg-white min-h-screen w-full flex flex-col">
-            <div class="container mt-10 p-6 bg-white rounded-lg ">
-                <h1 class="text-2xl text-blue-500 font-bold mb-6">Detalles del Gasto</h1>
-
-                <!-- Información del gasto -->
-                <div class="grid grid-cols-2 gap-4">
+        <div class="items-center justify-start bg-gray-50 min-h-screen w-full flex flex-col">
+            <div class="container mt-10 p-6 bg-white rounded-lg shadow max-w-5xl">
+                <div class="flex items-center justify-between mb-6">
                     <div>
-                        <p><strong>Nombre:</strong> {{ expense.name }}</p>
-                        <p><strong>Descripción:</strong> {{ expense.description }}</p>
-                        <p><strong>Fecha:</strong> {{ expense.date }}</p>
-                        <template v-for="paymentMethod in paymentMethods" :key="paymentMethod.id">
-                            <p v-if="paymentMethod.id === expense.payment_method_id"><strong>Método de Pago:</strong> {{ paymentMethod.name }}</p>
-                        </template>
-                        <template v-for="category in categories" :key="category.id">
-                            <p v-if="category.id === expense.expense_category_id"><strong>Categoría:</strong> {{ category.name }}</p>
-                        </template>
-
+                        <h1 class="text-3xl text-gray-800 font-semibold">Detalles del gasto</h1>
+                        <p class="text-sm text-gray-500">Consulta la información y los importes asociados a este gasto.</p>
                     </div>
-                    <div>
-                        <p><strong>Total:</strong> {{ expense.amount }}</p>
-                        <p><strong>IVA (%):</strong> {{ expense.iva }}</p>
-                        <p><strong>Monto IVA:</strong> {{ (expense.amount * (expense.iva / 100)).toFixed(2) }}</p>
+                    <div class="flex gap-2">
+                        <Link :href="route('expenses.edit', expense.id)" title="Editar Gasto" class="rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200">
+                            <EditIcon class="w-5 h-5" />
+                        </Link>
+                        <button @click="confirmDelete" title="Eliminar Gasto" class="rounded-full bg-red-100 p-2 text-red-600 hover:bg-red-200">
+                            <DeleteIcon class="w-5 h-5" />
+                        </button>
                     </div>
                 </div>
 
-                <!-- Archivo adjunto -->
-                <div class="mt-6">
-                    <p v-if="expense.file"><strong>Archivo Adjunto:</strong> <a :href="'/storage/'+expense.file" target="_blank" class="text-blue-600 hover:underline">Ver Archivo</a></p>
-                    <p v-else><strong>No hay archivo adjunto.</strong></p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <section class="space-y-3">
+                        <h2 class="text-lg font-semibold text-gray-700">Información general</h2>
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <dl class="space-y-2 text-sm text-gray-600">
+                                <div class="flex justify-between">
+                                    <dt class="font-medium text-gray-500">Nombre</dt>
+                                    <dd class="text-gray-800">{{ expense.name }}</dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt class="font-medium text-gray-500">Fecha</dt>
+                                    <dd class="text-gray-800">{{ expense.date }}</dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt class="font-medium text-gray-500">Método de pago</dt>
+                                    <dd class="text-gray-800">{{ paymentMethodName }}</dd>
+                                </div>
+                                <div class="flex justify-between">
+                                    <dt class="font-medium text-gray-500">Categoría</dt>
+                                    <dd class="text-gray-800">{{ categoryName }}</dd>
+                                </div>
+                            </dl>
+                        </div>
+
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <h3 class="text-sm font-semibold text-gray-600 mb-2">Descripción</h3>
+                            <p class="text-sm text-gray-700 whitespace-pre-line">{{ expense.description || 'Sin descripción' }}</p>
+                        </div>
+                    </section>
+
+                    <section class="space-y-3">
+                        <h2 class="text-lg font-semibold text-gray-700">Resumen económico</h2>
+                        <div class="rounded-lg border border-gray-200 p-4 space-y-2">
+                            <div class="flex justify-between text-sm text-gray-600">
+                                <span class="font-medium text-gray-500">Importe base</span>
+                                <span class="text-gray-800">{{ Number(expense.amount).toFixed(2) }} €</span>
+                            </div>
+                            <div class="flex justify-between text-sm text-gray-600">
+                                <span class="font-medium text-gray-500">IVA aplicado</span>
+                                <span class="text-gray-800">{{ expense.iva }} %</span>
+                            </div>
+                            <div class="flex justify-between text-sm text-gray-600">
+                                <span class="font-medium text-gray-500">Monto IVA</span>
+                                <span class="text-gray-800">{{ ivaAmount.toFixed(2) }} €</span>
+                            </div>
+                            <div class="flex justify-between text-base font-semibold text-gray-700">
+                                <span>Total con impuestos</span>
+                                <span>{{ totalAmount.toFixed(2) }} €</span>
+                            </div>
+                        </div>
+
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <h3 class="text-sm font-semibold text-gray-600 mb-2">Archivo adjunto</h3>
+                            <template v-if="expense.file">
+                                <a :href="`/storage/${expense.file}`" target="_blank" class="text-blue-700 text-sm hover:underline">
+                                    Ver archivo
+                                </a>
+                            </template>
+                            <p v-else class="text-sm text-gray-500">No se adjuntó ningún archivo.</p>
+                        </div>
+                    </section>
                 </div>
 
-                <!-- Botones de acciones con íconos -->
-                <div class="mt-6 flex justify-start space-x-4">
-                    <NavLink :href="route('expenses.edit', expense.id)" title="Editar Gasto">
-                        <EditIcon class="w-6 h-6 text-gray-600" />
-                    </NavLink>
-                    <button @click="confirmDelete" title="Eliminar Gasto">
-                        <DeleteIcon class="w-6 h-6 text-gray-600" />
-                    </button>
+                <div class="mt-8">
+                    <Link :href="route('expenses.index')" class="text-sm font-medium text-blue-700 hover:underline">Volver al listado de gastos</Link>
                 </div>
-
             </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import EditIcon from "@/Components/Icons/EditIcon.vue";
-import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
-import NavLink from "@/Components/NavLink.vue";
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 
 const props = defineProps({
     expense: Object,
@@ -59,16 +102,22 @@ const props = defineProps({
     categories: Array,
 });
 
+const ivaAmount = computed(() => Number(props.expense.amount || 0) * (Number(props.expense.iva || 0) / 100));
+const totalAmount = computed(() => Number(props.expense.amount || 0) + ivaAmount.value);
 
-// Confirmación y eliminación del gasto
+const paymentMethodName = computed(() => {
+    const method = props.paymentMethods.find((item) => item.id === props.expense.payment_method_id);
+    return method ? method.name : 'Sin método asignado';
+});
+
+const categoryName = computed(() => {
+    const category = props.categories.find((item) => item.id === props.expense.expense_category_id);
+    return category ? category.name : 'Sin categoría';
+});
+
 const confirmDelete = () => {
-    if (confirm("¿Estás seguro de que quieres eliminar este gasto?")) {
+    if (confirm('¿Estás seguro de que quieres eliminar este gasto?')) {
         Inertia.delete(route('expenses.destroy', props.expense.id));
     }
 };
 </script>
-
-<style scoped>
-/* Estilos adicionales pueden ser añadidos aquí */
-</style>
-

--- a/resources/js/Pages/Incomes/Create.vue
+++ b/resources/js/Pages/Incomes/Create.vue
@@ -1,97 +1,128 @@
 <template>
     <AppLayout>
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow">
-        <h1 class="text-2xl font-bold mb-6">Crear Ingreso</h1>
+        <div class="container mx-auto max-w-4xl bg-gray-50 min-h-screen p-6">
+            <h1 class="text-3xl font-semibold text-gray-800 mb-6">Registrar nuevo ingreso</h1>
 
-        <form @submit.prevent="submit">
-            <div class="grid grid-cols-1 gap-4">
-                <div>
-                    <label for="name" class="block font-medium text-gray-700">Nombre</label>
-                    <input
-                        id="name"
-                        v-model="form.name"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.name" class="text-sm text-red-500">{{ form.errors.name }}</span>
+            <form @submit.prevent="submit" class="space-y-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white p-6 rounded-lg shadow">
+                    <div>
+                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre</label>
+                        <input
+                            id="name"
+                            v-model="form.name"
+                            type="text"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            placeholder="Identificador del ingreso"
+                        />
+                        <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
+                    </div>
+
+                    <div>
+                        <label for="source" class="block text-sm font-medium text-gray-700">Origen</label>
+                        <input
+                            id="source"
+                            v-model="form.source"
+                            type="text"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            placeholder="Cliente o canal de venta"
+                        />
+                        <p v-if="form.errors.source" class="mt-2 text-sm text-red-600">{{ form.errors.source }}</p>
+                    </div>
+
+                    <div>
+                        <label for="tax_base" class="block text-sm font-medium text-gray-700">Base imponible</label>
+                        <input
+                            id="tax_base"
+                            v-model.number="form.tax_base"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            placeholder="0.00"
+                        />
+                        <p v-if="form.errors.tax_base" class="mt-2 text-sm text-red-600">{{ form.errors.tax_base }}</p>
+                    </div>
+
+                    <div>
+                        <label for="tax_rate" class="block text-sm font-medium text-gray-700">IVA (%)</label>
+                        <input
+                            id="tax_rate"
+                            v-model.number="form.tax_rate"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            placeholder="21"
+                        />
+                        <p v-if="form.errors.tax_rate" class="mt-2 text-sm text-red-600">{{ form.errors.tax_rate }}</p>
+                    </div>
+
+                    <div>
+                        <label for="date" class="block text-sm font-medium text-gray-700">Fecha</label>
+                        <input
+                            id="date"
+                            v-model="form.date"
+                            type="date"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.date" class="mt-2 text-sm text-red-600">{{ form.errors.date }}</p>
+                    </div>
                 </div>
 
-                <div>
-                    <label for="source" class="block font-medium text-gray-700">Origen</label>
-                    <input
-                        id="source"
-                        v-model="form.source"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.source" class="text-sm text-red-500">{{ form.errors.source }}</span>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                        <p class="text-sm text-gray-500">Monto de IVA</p>
+                        <p class="text-2xl font-semibold text-gray-800">{{ taxAmount.toFixed(2) }} €</p>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                        <p class="text-sm text-gray-500">Total con impuestos</p>
+                        <p class="text-2xl font-semibold text-gray-800">{{ totalAmount.toFixed(2) }} €</p>
+                    </div>
                 </div>
 
-                <div>
-                    <label for="tax_base" class="block font-medium text-gray-700">Base Imponible</label>
-                    <input
-                        id="tax_base"
-                        v-model="form.tax_base"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_base" class="text-sm text-red-500">{{ form.errors.tax_base }}</span>
+                <div class="flex items-center justify-between">
+                    <Link :href="route('incomes.index')" class="text-sm font-medium text-gray-600 hover:text-gray-800">
+                        Cancelar y volver
+                    </Link>
+                    <button
+                        type="submit"
+                        class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700 focus:outline-none"
+                    >
+                        <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                        Guardar ingreso
+                    </button>
                 </div>
-
-                <div>
-                    <label for="tax_rate" class="block font-medium text-gray-700">IVA (%)</label>
-                    <input
-                        id="tax_rate"
-                        v-model="form.tax_rate"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_rate" class="text-sm text-red-500">{{ form.errors.tax_rate }}</span>
-                </div>
-
-                <div>
-                    <label for="date" class="block font-medium text-gray-700">Fecha</label>
-                    <input
-                        id="date"
-                        v-model="form.date"
-                        type="date"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.date" class="text-sm text-red-500">{{ form.errors.date }}</span>
-                </div>
-
-            </div>
-
-            <button
-                type="submit"
-                class="mt-6 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
-            >
-                Guardar
-            </button>
-        </form>
-    </div>
+            </form>
+        </div>
     </AppLayout>
 </template>
 
 <script setup>
-import { useForm } from '@inertiajs/vue3';
-import { defineProps } from 'vue';
+import { computed } from 'vue';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-const props = defineProps({
-    companies: Array,
-});
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
 const form = useForm({
     name: '',
     source: '',
-    tax_base: '',
-    tax_rate: '',
-    date: '',
+    tax_base: 0,
+    tax_rate: 21,
+    date: new Date().toISOString().split('T')[0],
+});
+
+const taxAmount = computed(() => {
+    const base = Number(form.tax_base) || 0;
+    const rate = Number(form.tax_rate) || 0;
+    return base * rate / 100;
+});
+
+const totalAmount = computed(() => {
+    const base = Number(form.tax_base) || 0;
+    return base + taxAmount.value;
 });
 
 const submit = () => {
-    form.post('/incomes');
+    form.post(route('incomes.store'));
 };
 </script>

--- a/resources/js/Pages/Incomes/Edit.vue
+++ b/resources/js/Pages/Incomes/Edit.vue
@@ -1,91 +1,128 @@
 <template>
     <AppLayout>
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow">
-        <h1 class="text-2xl font-bold mb-6">Editar Ingreso</h1>
+        <div class="container mx-auto max-w-4xl bg-gray-50 min-h-screen p-6">
+            <h1 class="text-3xl font-semibold text-gray-800 mb-6">Editar ingreso</h1>
 
-        <form @submit.prevent="submit">
-            <div class="grid grid-cols-1 gap-4">
-                <div>
-                    <label for="name" class="block font-medium text-gray-700">Nombre</label>
-                    <input
-                        id="name"
-                        v-model="form.name"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.name" class="text-sm text-red-500">{{ form.errors.name }}</span>
+            <form @submit.prevent="submit" class="space-y-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white p-6 rounded-lg shadow">
+                    <div>
+                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre</label>
+                        <input
+                            id="name"
+                            v-model="form.name"
+                            type="text"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
+                    </div>
+
+                    <div>
+                        <label for="source" class="block text-sm font-medium text-gray-700">Origen</label>
+                        <input
+                            id="source"
+                            v-model="form.source"
+                            type="text"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.source" class="mt-2 text-sm text-red-600">{{ form.errors.source }}</p>
+                    </div>
+
+                    <div>
+                        <label for="tax_base" class="block text-sm font-medium text-gray-700">Base imponible</label>
+                        <input
+                            id="tax_base"
+                            v-model.number="form.tax_base"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.tax_base" class="mt-2 text-sm text-red-600">{{ form.errors.tax_base }}</p>
+                    </div>
+
+                    <div>
+                        <label for="tax_rate" class="block text-sm font-medium text-gray-700">IVA (%)</label>
+                        <input
+                            id="tax_rate"
+                            v-model.number="form.tax_rate"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.tax_rate" class="mt-2 text-sm text-red-600">{{ form.errors.tax_rate }}</p>
+                    </div>
+
+                    <div>
+                        <label for="date" class="block text-sm font-medium text-gray-700">Fecha</label>
+                        <input
+                            id="date"
+                            v-model="form.date"
+                            type="date"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        />
+                        <p v-if="form.errors.date" class="mt-2 text-sm text-red-600">{{ form.errors.date }}</p>
+                    </div>
                 </div>
 
-                <div>
-                    <label for="source" class="block font-medium text-gray-700">Origen</label>
-                    <input
-                        id="source"
-                        v-model="form.source"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.source" class="text-sm text-red-500">{{ form.errors.source }}</span>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                        <p class="text-sm text-gray-500">Monto de IVA</p>
+                        <p class="text-2xl font-semibold text-gray-800">{{ taxAmount.toFixed(2) }} €</p>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 bg-white p-4 shadow">
+                        <p class="text-sm text-gray-500">Total con impuestos</p>
+                        <p class="text-2xl font-semibold text-gray-800">{{ totalAmount.toFixed(2) }} €</p>
+                    </div>
                 </div>
 
-                <div>
-                    <label for="tax_base" class="block font-medium text-gray-700">Base Imponible</label>
-                    <input
-                        id="tax_base"
-                        v-model="form.tax_base"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_base" class="text-sm text-red-500">{{ form.errors.tax_base }}</span>
+                <div class="flex items-center justify-between">
+                    <Link :href="route('incomes.index')" class="text-sm font-medium text-gray-600 hover:text-gray-800">
+                        Cancelar y volver
+                    </Link>
+                    <button
+                        type="submit"
+                        class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700 focus:outline-none"
+                    >
+                        <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                        Actualizar ingreso
+                    </button>
                 </div>
-
-                <div>
-                    <label for="tax_rate" class="block font-medium text-gray-700">IVA (%)</label>
-                    <input
-                        id="tax_rate"
-                        v-model="form.tax_rate"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_rate" class="text-sm text-red-500">{{ form.errors.tax_rate }}</span>
-                </div>
-
-                <div>
-                    <label for="date" class="block font-medium text-gray-700">Fecha</label>
-                    <input
-                        id="date"
-                        v-model="form.date"
-                        type="date"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.date" class="text-sm text-red-500">{{ form.errors.date }}</span>
-                </div>
-            </div>
-
-            <button
-                type="submit"
-                class="mt-6 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
-            >
-                Actualizar
-            </button>
-        </form>
-    </div>
+            </form>
+        </div>
     </AppLayout>
 </template>
 
 <script setup>
-import { useForm } from '@inertiajs/vue3';
-import { defineProps } from 'vue';
+import { computed } from 'vue';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
+
 const props = defineProps({
     income: Object,
-    companies: Array,
 });
 
-const form = useForm({ ...props.income });
+const form = useForm({
+    name: props.income?.name ?? '',
+    source: props.income?.source ?? '',
+    tax_base: props.income?.tax_base ?? 0,
+    tax_rate: props.income?.tax_rate ?? 0,
+    date: props.income?.date ?? new Date().toISOString().split('T')[0],
+});
+
+const taxAmount = computed(() => {
+    const base = Number(form.tax_base) || 0;
+    const rate = Number(form.tax_rate) || 0;
+    return base * rate / 100;
+});
+
+const totalAmount = computed(() => {
+    const base = Number(form.tax_base) || 0;
+    return base + taxAmount.value;
+});
 
 const submit = () => {
-    form.put(`/incomes/${props.income.id}`);
+    form.put(route('incomes.update', props.income.id));
 };
 </script>

--- a/resources/js/Pages/Incomes/Index.vue
+++ b/resources/js/Pages/Incomes/Index.vue
@@ -43,6 +43,13 @@
                 </td>
                 <td class="px-4 py-2">{{ income.date }}</td>
                 <td class="px-4 py-2 text-center flex justify-center space-x-2">
+                    <Link
+                        :href="route('incomes.show', income.id)"
+                        class="text-blue-500 hover:text-blue-700"
+                        title="Ver"
+                    >
+                        <InfoIcon class="stroke-gray-600 w-5" />
+                    </Link>
                     <a
                         :href="route('incomes.edit', income.id)"
                         class="text-blue-500 hover:text-blue-700"
@@ -66,9 +73,10 @@
 </template>
 
 <script setup>
-import { router } from '@inertiajs/vue3';
+import { Link, router } from '@inertiajs/vue3';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+import InfoIcon from '@/Components/Icons/InfoIcon.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 const props = defineProps({
     incomes: Array, // Lista de ingresos enviada desde el controlador

--- a/resources/js/Pages/Incomes/Show.vue
+++ b/resources/js/Pages/Incomes/Show.vue
@@ -1,0 +1,101 @@
+<template>
+    <AppLayout>
+        <div class="container mx-auto max-w-4xl bg-gray-50 min-h-screen p-6">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <h1 class="text-3xl font-semibold text-gray-800">Detalle del ingreso</h1>
+                    <p class="text-sm text-gray-500">Revisa la información registrada de este movimiento.</p>
+                </div>
+                <div class="flex items-center gap-2">
+                    <Link :href="route('incomes.edit', income.id)" class="rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200" title="Editar ingreso">
+                        <EditIcon class="h-5 w-5" />
+                    </Link>
+                    <button @click="destroy" class="rounded-full bg-red-100 p-2 text-red-600 hover:bg-red-200" title="Eliminar ingreso">
+                        <DeleteIcon class="h-5 w-5" />
+                    </button>
+                </div>
+            </div>
+
+            <div class="space-y-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="rounded-lg bg-white p-6 shadow">
+                        <h2 class="text-lg font-semibold text-gray-700 mb-4">Información general</h2>
+                        <dl class="space-y-3 text-sm text-gray-600">
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Nombre</dt>
+                                <dd class="text-gray-800">{{ income.name }}</dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Origen</dt>
+                                <dd class="text-gray-800">{{ income.source }}</dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Fecha</dt>
+                                <dd class="text-gray-800">{{ income.date }}</dd>
+                            </div>
+                            <div class="flex justify-between" v-if="income.company">
+                                <dt class="font-medium text-gray-500">Empresa</dt>
+                                <dd class="text-gray-800">{{ income.company.name }}</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="rounded-lg bg-white p-6 shadow">
+                        <h2 class="text-lg font-semibold text-gray-700 mb-4">Resumen económico</h2>
+                        <dl class="space-y-3 text-sm text-gray-600">
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Base imponible</dt>
+                                <dd class="text-gray-800">{{ Number(income.tax_base).toFixed(2) }} €</dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">IVA aplicado</dt>
+                                <dd class="text-gray-800">{{ income.tax_rate }} %</dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Monto IVA</dt>
+                                <dd class="text-gray-800">{{ taxAmount.toFixed(2) }} €</dd>
+                            </div>
+                            <div class="flex justify-between">
+                                <dt class="font-medium text-gray-500">Total con impuestos</dt>
+                                <dd class="text-gray-800 font-semibold">{{ totalAmount.toFixed(2) }} €</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+
+                <div class="flex justify-start">
+                    <Link :href="route('incomes.index')" class="text-sm font-medium text-blue-700 hover:underline">Volver al listado</Link>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+
+const props = defineProps({
+    income: Object,
+});
+
+const income = props.income;
+
+const taxAmount = computed(() => {
+    const base = Number(income.tax_base) || 0;
+    const rate = Number(income.tax_rate) || 0;
+    return base * rate / 100;
+});
+
+const totalAmount = computed(() => Number(income.tax_base || 0) + taxAmount.value);
+
+const destroy = () => {
+    if (confirm('¿Quieres eliminar este ingreso?')) {
+        Inertia.delete(route('incomes.destroy', income.id));
+    }
+};
+</script>

--- a/resources/js/Pages/PaymentMethods/Create.vue
+++ b/resources/js/Pages/PaymentMethods/Create.vue
@@ -1,45 +1,58 @@
 <template>
     <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Crear Método de Pago</h1>
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Método</label>
-                        <input v-model="method.name" id="name" type="text" placeholder="Nombre del Método"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-4xl">
+                <h1 class="text-3xl font-semibold mb-6 text-gray-800">Registrar método de pago</h1>
+
+                <form @submit.prevent="submitForm" class="space-y-6 bg-white p-6 rounded-lg shadow">
+                    <div>
+                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre del método</label>
+                        <input
+                            v-model="form.name"
+                            id="name"
+                            type="text"
+                            placeholder="Ej. Transferencia bancaria"
+                            class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        >
+                        <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="method.description" id="description" rows="4"
-                                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del método de pago"></textarea>
+                    <div>
+                        <label for="description" class="block text-sm font-medium text-gray-700">Descripción</label>
+                        <textarea
+                            v-model="form.description"
+                            id="description"
+                            rows="4"
+                            class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            placeholder="Describe cómo se utiliza este método de pago"
+                        ></textarea>
+                        <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
                     </div>
-                </div>
 
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Método">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                    <div class="flex items-center justify-between">
+                        <Link :href="route('paymentMethods.index')" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                        <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                            <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                            Guardar método
+                        </button>
+                    </div>
+                </form>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
-const method = ref({
+const form = useForm({
     name: '',
     description: '',
 });
 
 const submitForm = () => {
-    Inertia.post(route('paymentMethods.store'), method.value);
+    form.post(route('paymentMethods.store'));
 };
 </script>

--- a/resources/js/Pages/PaymentMethods/Edit.vue
+++ b/resources/js/Pages/PaymentMethods/Edit.vue
@@ -1,54 +1,60 @@
 <template>
     <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Editar Método de Pago</h1>
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Método</label>
-                        <input v-model="method.name" id="name" type="text" placeholder="Nombre del Método"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-4xl">
+                <h1 class="text-3xl font-semibold mb-6 text-gray-800">Editar método de pago</h1>
+
+                <form @submit.prevent="submitForm" class="space-y-6 bg-white p-6 rounded-lg shadow">
+                    <div>
+                        <label for="name" class="block text-sm font-medium text-gray-700">Nombre del método</label>
+                        <input
+                            v-model="form.name"
+                            id="name"
+                            type="text"
+                            class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        >
+                        <p v-if="form.errors.name" class="mt-2 text-sm text-red-600">{{ form.errors.name }}</p>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="method.description" id="description" rows="4"
-                                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del método de pago"></textarea>
+                    <div>
+                        <label for="description" class="block text-sm font-medium text-gray-700">Descripción</label>
+                        <textarea
+                            v-model="form.description"
+                            id="description"
+                            rows="4"
+                            class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        ></textarea>
+                        <p v-if="form.errors.description" class="mt-2 text-sm text-red-600">{{ form.errors.description }}</p>
                     </div>
-                </div>
 
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Cambios">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                    <div class="flex items-center justify-between">
+                        <Link :href="route('paymentMethods.show', method.id)" class="text-sm font-medium text-gray-600 hover:text-gray-800">Cancelar y volver</Link>
+                        <button type="submit" class="inline-flex items-center rounded-full bg-blue-900 px-4 py-2 text-white shadow hover:bg-blue-700">
+                            <SaveIcon class="mr-2 h-5 w-5 stroke-gray-100" />
+                            Guardar cambios
+                        </button>
+                    </div>
+                </form>
+            </div>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref, onMounted} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { Link, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import SaveIcon from '@/Components/Icons/SaveIcon.vue';
 
-// Obtener el método existente desde los props
 const props = defineProps({
     method: Object,
 });
-const method = ref({
-    name: props.method.name,
-    description: props.method.description,
-});
 
-// Cargar los datos del método al montar el componente
-onMounted(() => {
-    method.value = props.method;
+const form = useForm({
+    name: props.method?.name ?? '',
+    description: props.method?.description ?? '',
 });
 
 const submitForm = () => {
-    Inertia.put(route('paymentMethods.update', props.method.id), method.value);
+    form.put(route('paymentMethods.update', props.method.id));
 };
 </script>

--- a/resources/js/Pages/PaymentMethods/Show.vue
+++ b/resources/js/Pages/PaymentMethods/Show.vue
@@ -1,0 +1,67 @@
+<template>
+    <AppLayout>
+        <div class="p-6 w-full bg-gray-50 min-h-screen">
+            <div class="mx-auto max-w-4xl bg-white rounded-lg shadow p-6 space-y-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h1 class="text-3xl font-semibold text-gray-800">Detalle del método de pago</h1>
+                        <p class="text-sm text-gray-500">Información y descripción del método seleccionado.</p>
+                    </div>
+                    <div class="flex gap-2">
+                        <Link :href="route('paymentMethods.edit', paymentMethod.id)" class="rounded-full bg-blue-100 p-2 text-blue-700 hover:bg-blue-200" title="Editar">
+                            <EditIcon class="h-5 w-5" />
+                        </Link>
+                        <button @click="destroy" class="rounded-full bg-red-100 p-2 text-red-600 hover:bg-red-200" title="Eliminar">
+                            <DeleteIcon class="h-5 w-5" />
+                        </button>
+                    </div>
+                </div>
+
+                <div class="space-y-4 text-sm text-gray-700">
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-600">Nombre</h2>
+                        <p class="text-gray-900">{{ paymentMethod.name }}</p>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-600">Descripción</h2>
+                        <p class="text-gray-900 whitespace-pre-line">{{ paymentMethod.description || 'Sin descripción disponible.' }}</p>
+                    </div>
+                    <div v-if="paymentMethod.company" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <h2 class="text-lg font-semibold text-gray-600">Empresa</h2>
+                            <p class="text-gray-900">{{ paymentMethod.company.name }}</p>
+                        </div>
+                        <div>
+                            <h2 class="text-lg font-semibold text-gray-600">CIF</h2>
+                            <p class="text-gray-900">{{ paymentMethod.company.cif }}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <Link :href="route('paymentMethods.index')" class="text-sm font-medium text-blue-700 hover:underline">Volver al listado</Link>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { Inertia } from '@inertiajs/inertia';
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
+
+const props = defineProps({
+    paymentMethod: Object,
+});
+
+const paymentMethod = props.paymentMethod;
+
+const destroy = () => {
+    if (confirm('¿Deseas eliminar este método de pago?')) {
+        Inertia.delete(route('paymentMethods.destroy', paymentMethod.id));
+    }
+};
+</script>

--- a/routes/web/Contabilidad.php
+++ b/routes/web/Contabilidad.php
@@ -48,6 +48,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/incomes/{income}/edit', [IncomeController::class, 'edit'])->name('incomes.edit');
     Route::put('/incomes/{income}', [IncomeController::class, 'update'])->name('incomes.update');
 
+    // Mostrar ingreso
+    Route::get('/incomes/{income}', [IncomeController::class, 'show'])->name('incomes.show');
+
     // Eliminar ingreso
     Route::delete('/incomes/{income}', [IncomeController::class, 'destroy'])->name('incomes.destroy');
 });


### PR DESCRIPTION
## Summary
- modernize income creation and editing with inline totals and add a detailed show page with navigation from the index
- refresh expense workflows, including create/edit/show forms with validation feedback and a richer reporting dashboard
- translate and redesign category and payment method forms, add dedicated detail pages, and wire controllers/routes for the new views

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*


------
https://chatgpt.com/codex/tasks/task_e_68df86818a808323bc92cb0c9e06607d