### PR TITLE
Adjust inventory gradient colors

### DIFF
--- a/resources/js/Components/Inventory/inventoryTheme.js
+++ b/resources/js/Components/Inventory/inventoryTheme.js
@@ -1,6 +1,6 @@
 export const inventoryPalette = {
     background: 'bg-slate-950',
-    gradient: 'from-yellow-400 via-yellow-600 to-black',
+    gradient: 'from-amber-500 via-orange-600 to-slate-950',
     surface: 'bg-white',
     surfaceMuted: 'bg-white/80 backdrop-blur',
     border: 'border-amber-500/20',


### PR DESCRIPTION
## Summary
- update the inventory palette gradient to use an amber to slate blend so the almacén hero no longer renders as white

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df890c75948323a2610a459e6c22cd