### PR TITLE
Refine accounting finance CRUD screens

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -61,11 +61,13 @@ class CategoryController extends Controller
         return Inertia::location(route('categories.index'));
     }
 
-    //show
-
-    public function show()
+    public function show(Category $category)
     {
+        $category->load(['company'])->loadCount('products');
 
+        return Inertia::render('Categories/Show', [
+            'category' => $category,
+        ]);
     }
 
     public function destroy(Category $category)

--- a/app/Http/Controllers/PaymentMethodController.php
+++ b/app/Http/Controllers/PaymentMethodController.php
@@ -37,15 +37,18 @@ class PaymentMethodController extends Controller
 
     public function show(PaymentMethod $paymentMethod)
     {
+        $paymentMethod->load(['company'])->loadCount('expenses');
+
         return Inertia::render('PaymentMethods/Show', [
-            'paymentMethod' => $paymentMethod
+            'paymentMethod' => $paymentMethod,
         ]);
     }
 
     public function edit(PaymentMethod $paymentMethod)
     {
         return Inertia::render('PaymentMethods/Edit', [
-            'method' => $paymentMethod
+            'method' => $paymentMethod,
+            'expensesCount' => $paymentMethod->expenses()->count(),
         ]);
     }
 

--- a/resources/js/Pages/Categories/Create.vue
+++ b/resources/js/Pages/Categories/Create.vue
@@ -1,50 +1,78 @@
 <template>
-    <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Create Category</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" type="text" class="mt-1 block w-full border border-gray-300 p-2 rounded" placeholder="Category name">
-                <span v-if="errors.name" class="text-red-500">{{ errors.name }}</span>
-            </div>
+    <AppLayout title="Crear categoría">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Catálogo"
+                title="Nueva categoría contable"
+                description="Clasifica gastos o ingresos bajo etiquetas consistentes para facilitar la elaboración de informes."
+                :metrics-columns="3"
+            >
+                <template #metrics>
+                    <FinanceSummaryCard label="Nombre" :value="form.name || 'Sin definir'" :helper="`${form.name.length} caracteres`" />
+                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Texto preparado' : 'Añade una descripción'" />
+                    <FinanceSummaryCard label="Estado" value="Borrador" helper="Pendiente de guardar" />
+                </template>
+            </FinancePageHeader>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Description</label>
-                <textarea v-model="form.description" class="mt-1 block w-full border border-gray-300 p-2 rounded" placeholder="Category description"></textarea>
-                <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-            </div>
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Datos de la categoría</h2>
+                        <p class="mt-1 text-sm text-slate-500">Define un nombre representativo y una descripción clara para que el equipo contable identifique fácilmente la categoría.</p>
+                    </header>
 
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                <SaveIcon /> Save Category
-            </button>
-        </form>
-    </div>
+                    <form @submit.prevent="submit" class="grid grid-cols-1 gap-6">
+                        <div>
+                            <InputLabel for="name" value="Nombre" />
+                            <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="description" value="Descripción" />
+                            <TextareaInput id="description" v-model="form.description" rows="4" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.description" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center gap-3 pt-2">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar categoría
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('categories.index')"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y volver
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
+        </div>
     </AppLayout>
 </template>
 
-<script>
-import { useForm } from '@inertiajs/inertia-vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+<script setup>
+import { computed } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
-export default {
-    components: {SaveIcon, AppLayout},
-    setup() {
-        const form = useForm({
-            name: '',
-            description: '',
-        });
+const form = useForm({
+    name: '',
+    description: '',
+});
 
-        const submit = () => {
-            form.post(route('categories.store'));
-        };
+const descriptionLength = computed(() => form.description?.length ?? 0);
 
-        return {
-            form,
-            submit,
-            errors: form.errors,
-        };
-    }
+const submit = () => {
+    form.post(route('categories.store'));
 };
 </script>

--- a/resources/js/Pages/Categories/Edit.vue
+++ b/resources/js/Pages/Categories/Edit.vue
@@ -1,53 +1,102 @@
 <template>
-    <AppLayout>
-    <div>
-        <h1 class="text-2xl font-bold mb-4">Edit Category</h1>
-        <form @submit.prevent="submit">
-            <div class="mb-4">
-                <label class="block text-gray-700">Name</label>
-                <input v-model="form.name" type="text" class="mt-1 block w-full border border-gray-300 p-2 rounded">
-                <span v-if="errors.name" class="text-red-500">{{ errors.name }}</span>
-            </div>
+    <AppLayout title="Editar categoría">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Catálogo"
+                :title="`Editar ${form.name || 'categoría'}`"
+                description="Mantén tus etiquetas contables coherentes para comparar periodos y realizar auditorías con facilidad."
+                :metrics-columns="3"
+            >
+                <template #metrics>
+                    <FinanceSummaryCard label="Nombre" :value="form.name || 'Sin definir'" :helper="`${form.name.length} caracteres`" />
+                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Actualizada' : 'Añade contexto'" />
+                    <FinanceSummaryCard label="Creación" :value="formatDate(category.created_at)" :helper="`Última actualización: ${formatDate(category.updated_at)}`" />
+                </template>
+            </FinancePageHeader>
 
-            <div class="mb-4">
-                <label class="block text-gray-700">Description</label>
-                <textarea v-model="form.description" class="mt-1 block w-full border border-gray-300 p-2 rounded"></textarea>
-                <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-            </div>
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Datos de la categoría</h2>
+                        <p class="mt-1 text-sm text-slate-500">Los cambios se verán reflejados en el resto de vistas contables que utilizan esta categoría.</p>
+                    </header>
 
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-                <SaveIcon /> Update
-            </button>
-        </form>
-    </div>
+                    <form @submit.prevent="submit" class="grid grid-cols-1 gap-6">
+                        <div>
+                            <InputLabel for="name" value="Nombre" />
+                            <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="description" value="Descripción" />
+                            <TextareaInput id="description" v-model="form.description" rows="4" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.description" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center gap-3 pt-2">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar cambios
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('categories.show', category.id)"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y ver ficha
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
+        </div>
     </AppLayout>
 </template>
 
-<script>
-import { useForm } from '@inertiajs/inertia-vue3';
-import AppLayout from "@/Layouts/AppLayout.vue";
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+<script setup>
+import { computed } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
-export default {
-    components: {SaveIcon, AppLayout},
-    props: {
-        category: Object
+const props = defineProps({
+    category: {
+        type: Object,
+        required: true,
     },
-    setup(props) {
-        const form = useForm({
-            name: props.category.name,
-            description: props.category.description,
-        });
+});
 
-        const submit = () => {
-            form.put(route('categories.update', props.category.id));
-        };
+const category = computed(() => props.category ?? {});
 
-        return {
-            form,
-            submit,
-            errors: form.errors,
-        };
+const form = useForm({
+    name: category.value.name || '',
+    description: category.value.description || '',
+});
+
+const descriptionLength = computed(() => form.description?.length ?? 0);
+
+const formatDate = (value) => {
+    if (!value) {
+        return '—';
     }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const submit = () => {
+    form.put(route('categories.update', category.value.id));
 };
 </script>

--- a/resources/js/Pages/Categories/Show.vue
+++ b/resources/js/Pages/Categories/Show.vue
@@ -1,0 +1,95 @@
+<template>
+    <AppLayout>
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Categoría"
+                :title="category.name"
+                description="Consulta la información clave de la categoría y su uso dentro del catálogo contable."
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('categories.edit', category.id)"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Editar
+                    </NavLink>
+                    <NavLink
+                        :href="route('categories.index')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Volver al listado
+                    </NavLink>
+                </template>
+                <template #metrics>
+                    <FinanceSummaryCard label="Productos asociados" :value="productsCount" :helper="productsCount === 1 ? 'Producto' : 'Productos'" />
+                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Contenido disponible' : 'Sin descripción'" />
+                    <FinanceSummaryCard label="Creación" :value="formatDate(category.created_at)" :helper="`Actualizada: ${formatDate(category.updated_at)}`" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Descripción</h2>
+                        <p class="text-sm text-slate-500">Texto utilizado en informes y paneles para explicar el alcance de la categoría.</p>
+                    </header>
+                    <p class="mt-4 whitespace-pre-line text-slate-700">{{ category.description || 'Esta categoría todavía no tiene descripción.' }}</p>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Metadatos</h2>
+                        <p class="text-sm text-slate-500">Información adicional sobre la empresa asociada y los identificadores internos.</p>
+                    </header>
+                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Empresa</dt>
+                            <dd class="mt-2">{{ companyName }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</dt>
+                            <dd class="mt-2">{{ category.id }}</dd>
+                        </div>
+                    </dl>
+                </section>
+            </main>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import NavLink from '@/Components/NavLink.vue';
+
+const props = defineProps({
+    category: {
+        type: Object,
+        required: true,
+    },
+});
+
+const category = computed(() => props.category ?? {});
+
+const descriptionLength = computed(() => category.value.description?.length ?? 0);
+const productsCount = computed(() => category.value.products_count ?? 0);
+const companyName = computed(() => category.value.company?.name || 'Sin empresa asociada');
+
+const formatDate = (value) => {
+    if (!value) {
+        return '—';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+</script>

--- a/resources/js/Pages/Expenses/Create.vue
+++ b/resources/js/Pages/Expenses/Create.vue
@@ -1,122 +1,233 @@
 <template>
-    <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Crear Gasto</h1>
+    <AppLayout title="Registrar gasto">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Contabilidad"
+                title="Registrar nuevo gasto"
+                description="Introduce el gasto con el mismo diseño que el resto del módulo y obtén el cálculo automático de impuestos."
+                :metrics-columns="3"
+            >
+                <template #metrics>
+                    <FinanceSummaryCard
+                        label="Base imponible"
+                        :value="formatCurrency(form.amount)"
+                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
+                    />
+                    <FinanceSummaryCard
+                        label="IVA estimado"
+                        :value="formatCurrency(taxAmount)"
+                        :helper="`${form.iva || 0}% aplicado`"
+                    />
+                    <FinanceSummaryCard
+                        label="Total previsto"
+                        :value="formatCurrency(totalAmount)"
+                        :helper="form.payment_method_id ? paymentMethodName : 'Método pendiente'"
+                    />
+                </template>
+            </FinancePageHeader>
 
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="date" class="block text-gray-700">Fecha</label>
-                        <input v-model="expense.date" id="date" type="date"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+            <main class="max-w-5xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Detalles del gasto</h2>
+                        <p class="mt-1 text-sm text-slate-500">
+                            Organiza la información en bloques claros: importe, clasificación y documentación adjunta.
+                        </p>
+                    </header>
 
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Gasto</label>
-                        <input v-model="expense.name" id="name" type="text" placeholder="Nombre del Gasto"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                    <form @submit.prevent="submitForm" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                        <div>
+                            <InputLabel for="date" value="Fecha" />
+                            <TextInput id="date" v-model="form.date" type="date" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.date" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="category_id" class="block text-gray-700">Categoría</label>
-                        <select v-model="expense.expense_category_id" id="category_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="category in categories" :key="category.id" :value="category.id">{{
-                                    category.name
-                                }}</option>
-                        </select>
-                    </div>
+                        <div>
+                            <InputLabel for="name" value="Nombre del gasto" />
+                            <TextInput
+                                id="name"
+                                v-model="form.name"
+                                type="text"
+                                class="mt-2 block w-full"
+                                placeholder="Ej. Hosting anual"
+                            />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="expense.description" id="description" rows="4"
-                                  class="mt-1 block w-full h-11 border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del gasto"></textarea>
-                    </div>
+                        <div>
+                            <InputLabel for="expense_category_id" value="Categoría" />
+                            <SelectInput id="expense_category_id" v-model="form.expense_category_id" class="mt-2 block w-full">
+                                <option value="">Selecciona una categoría</option>
+                                <option v-for="category in categories" :key="category.id" :value="category.id">
+                                    {{ category.name }}
+                                </option>
+                            </SelectInput>
+                            <InputError :message="form.errors.expense_category_id" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="file" class="block text-gray-700">Archivo</label>
-                        <input id="file" type="file"  @change="handleFileChange"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" >
-                    </div>
+                        <div>
+                            <InputLabel for="payment_method_id" value="Método de pago" />
+                            <SelectInput id="payment_method_id" v-model="form.payment_method_id" class="mt-2 block w-full">
+                                <option value="">Selecciona un método</option>
+                                <option v-for="method in paymentMethods" :key="method.id" :value="method.id">
+                                    {{ method.name }}
+                                </option>
+                            </SelectInput>
+                            <InputError :message="form.errors.payment_method_id" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="iva" class="block text-gray-700">IVA</label>
-                        <input v-model="expense.iva" id="iva" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                        <div>
+                            <InputLabel for="amount" value="Base imponible" />
+                            <TextInput
+                                id="amount"
+                                v-model="form.amount"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.amount" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="amount" class="block text-gray-700">Monto</label>
-                        <input v-model="expense.amount" id="amount" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                        <div>
+                            <InputLabel for="iva" value="IVA (%)" />
+                            <TextInput
+                                id="iva"
+                                v-model="form.iva"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.iva" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="payment_method_id" class="block text-gray-700">Método de Pago</label>
-                        <select v-model="expense.payment_method_id" id="payment_method_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">{{
-                                    paymentMethod.name
-                                }}</option>
-                        </select>
-                    </div>
+                        <div class="sm:col-span-2">
+                            <InputLabel for="description" value="Descripción" />
+                            <TextareaInput
+                                id="description"
+                                v-model="form.description"
+                                rows="3"
+                                class="mt-2 block w-full"
+                                placeholder="Describe el gasto para futuras auditorías"
+                            />
+                            <InputError :message="form.errors.description" class="mt-2" />
+                        </div>
 
-                </div>
+                        <div class="sm:col-span-2">
+                            <InputLabel for="file" value="Documento adjunto" />
+                            <input
+                                id="file"
+                                type="file"
+                                class="mt-2 block w-full rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-slate-600 file:mr-4 file:rounded-md file:border-0 file:bg-emerald-100 file:px-4 file:py-2 file:text-emerald-700 hover:border-emerald-300"
+                                @change="handleFileChange"
+                            />
+                            <p v-if="fileName" class="mt-2 text-sm text-slate-500">Archivo seleccionado: {{ fileName }}</p>
+                            <InputError :message="form.errors.file" class="mt-2" />
+                        </div>
 
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Gasto">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                        <div class="sm:col-span-2 flex items-center gap-3 pt-4">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar gasto
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('expenses.index')"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y volver
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { computed, ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
 const props = defineProps({
-    categories: Array,
-    paymentMethods: Array,
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+    paymentMethods: {
+        type: Array,
+        default: () => [],
+    },
 });
 
-const expense = ref({
+const form = useForm({
     name: '',
     description: '',
-    amount: 0,
+    amount: '',
     iva: 21,
-    date: new Date().toISOString().split('T')[0], // Fecha actual
+    date: new Date().toISOString().split('T')[0],
     payment_method_id: '',
     expense_category_id: '',
     file: null,
 });
 
-// Manejar el cambio de archivo
+const fileName = ref('');
+
+const numeric = (value) => Number(value || 0);
+
+const taxAmount = computed(() => numeric(form.amount) * numeric(form.iva) / 100);
+const totalAmount = computed(() => numeric(form.amount) + taxAmount.value);
+
+const paymentMethodName = computed(() => {
+    const method = props.paymentMethods.find((item) => item.id === form.payment_method_id);
+    return method?.name || '';
+});
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(numeric(value));
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
 const handleFileChange = (event) => {
-    expense.value.file = event.target.files[0]; // Guardar el archivo en expense.file
+    const [file] = event.target.files;
+    form.file = file || null;
+    fileName.value = file ? file.name : '';
 };
 
 const submitForm = () => {
-    const formData = new FormData(); // Crear un FormData para la carga del archivo
-
-    // Agregar todos los campos al FormData excepto el archivo si está vacío
-    Object.entries(expense.value).forEach(([key, value]) => {
-        if (key !== 'file' || value) { // Solo añadir el archivo si existe
-            formData.append(key, value);
-        }
-    });
-
-    // Enviar la solicitud
-    Inertia.post(route('expenses.store'), formData, {
-        headers: {
-            'Content-Type': 'multipart/form-data', // Especificar el tipo de contenido
+    form.post(route('expenses.store'), {
+        forceFormData: true,
+        onSuccess: () => {
+            form.reset();
+            fileName.value = '';
         },
     });
 };
-
 </script>

--- a/resources/js/Pages/Expenses/Edit.vue
+++ b/resources/js/Pages/Expenses/Edit.vue
@@ -1,154 +1,225 @@
 <template>
-    <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Editar Gasto</h1>
-            <form @submit.prevent="submitForm" enctype="multipart/form-data">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="date" class="block text-gray-700">Fecha</label>
-                        <input v-model="expense.date" id="date" type="date"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+    <AppLayout title="Editar gasto">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Contabilidad"
+                :title="`Editar ${form.name || 'gasto'}`"
+                description="Actualiza los datos del gasto con una interfaz alineada al resto de la suite contable."
+                :metrics-columns="3"
+            >
+                <template #metrics>
+                    <FinanceSummaryCard
+                        label="Base imponible"
+                        :value="formatCurrency(form.amount)"
+                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
+                    />
+                    <FinanceSummaryCard
+                        label="IVA recalculado"
+                        :value="formatCurrency(taxAmount)"
+                        :helper="`${form.iva || 0}% aplicado`"
+                    />
+                    <FinanceSummaryCard
+                        label="Total actualizado"
+                        :value="formatCurrency(totalAmount)"
+                        :helper="form.payment_method_id ? paymentMethodName : 'Método pendiente'"
+                    />
+                </template>
+            </FinancePageHeader>
 
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Gasto</label>
-                        <input v-model="expense.name" id="name" type="text" placeholder="Nombre del Gasto"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+            <main class="max-w-5xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Detalles del gasto</h2>
+                        <p class="mt-1 text-sm text-slate-500">
+                            Los cambios se reflejarán en informes, dashboards y en la ficha del gasto inmediatamente.
+                        </p>
+                    </header>
 
-                    <div class="mb-4">
-                        <label for="category_id" class="block text-gray-700">Categoría</label>
-                        <select v-model="expense.expense_category_id" id="category_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="category in categories" :key="category.id" :value="category.id">{{
-                                    category.name
-                                }}</option>
-                        </select>
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="expense.description" id="description" rows="4"
-                                  class="mt-1 block w-full h-11 border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del gasto"></textarea>
-                    </div>
-
-                    <div class="mb-4">
-                        <label for="file" class="block text-gray-700">Archivo</label>
-
-                        <!-- Vista previa si el archivo es una imagen -->
-                        <div v-if="expense.file && isImage(expense.file)" class="mb-2">
-                            <img :src="getFileUrl(expense.file)" alt="Archivo adjunto" class="w-40 h-auto rounded shadow">
+                    <form @submit.prevent="submitForm" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                        <div>
+                            <InputLabel for="date" value="Fecha" />
+                            <TextInput id="date" v-model="form.date" type="date" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.date" class="mt-2" />
                         </div>
 
-                        <!-- Enlace de descarga si no es imagen -->
-                        <div v-else-if="expense.file && typeof expense.file === 'string'" class="mb-2">
-                            <a :href="getFileUrl(expense.file)" target="_blank" class="text-blue-600 underline">
-                                Ver archivo actual
-                            </a>
+                        <div>
+                            <InputLabel for="name" value="Nombre del gasto" />
+                            <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.name" class="mt-2" />
                         </div>
 
-                        <!-- Input para subir archivo -->
-                        <input id="file" type="file" @change="handleFileChange" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                        <div>
+                            <InputLabel for="expense_category_id" value="Categoría" />
+                            <SelectInput id="expense_category_id" v-model="form.expense_category_id" class="mt-2 block w-full">
+                                <option value="">Selecciona una categoría</option>
+                                <option v-for="category in categories" :key="category.id" :value="category.id">
+                                    {{ category.name }}
+                                </option>
+                            </SelectInput>
+                            <InputError :message="form.errors.expense_category_id" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="iva" class="block text-gray-700">IVA</label>
-                        <input v-model="expense.iva" id="iva" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                        <div>
+                            <InputLabel for="payment_method_id" value="Método de pago" />
+                            <SelectInput id="payment_method_id" v-model="form.payment_method_id" class="mt-2 block w-full">
+                                <option value="">Selecciona un método</option>
+                                <option v-for="method in paymentMethods" :key="method.id" :value="method.id">
+                                    {{ method.name }}
+                                </option>
+                            </SelectInput>
+                            <InputError :message="form.errors.payment_method_id" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="amount" class="block text-gray-700">Monto</label>
-                        <input v-model="expense.amount" id="amount" type="number" step="0.01"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+                        <div>
+                            <InputLabel for="amount" value="Base imponible" />
+                            <TextInput id="amount" v-model="form.amount" type="number" step="0.01" min="0" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.amount" class="mt-2" />
+                        </div>
 
-                    <div class="mb-4">
-                        <label for="payment_method_id" class="block text-gray-700">Método de Pago</label>
-                        <select v-model="expense.payment_method_id" id="payment_method_id"
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                            <option v-for="paymentMethod in paymentMethods" :key="paymentMethod.id" :value="paymentMethod.id">{{
-                                    paymentMethod.name
-                                }}</option>
-                        </select>
-                    </div>
+                        <div>
+                            <InputLabel for="iva" value="IVA (%)" />
+                            <TextInput id="iva" v-model="form.iva" type="number" step="0.01" min="0" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.iva" class="mt-2" />
+                        </div>
 
-                </div>
+                        <div class="sm:col-span-2">
+                            <InputLabel for="description" value="Descripción" />
+                            <TextareaInput id="description" v-model="form.description" rows="3" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.description" class="mt-2" />
+                        </div>
 
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Cambios">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                        <div class="sm:col-span-2 space-y-3">
+                            <InputLabel for="file" value="Documento adjunto" />
+                            <div v-if="currentFileUrl" class="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+                                <span class="font-medium text-slate-700">Archivo actual:</span>
+                                <a :href="currentFileUrl" target="_blank" class="text-emerald-600 hover:text-emerald-800">Ver documento</a>
+                            </div>
+                            <input
+                                id="file"
+                                type="file"
+                                class="mt-2 block w-full rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-slate-600 file:mr-4 file:rounded-md file:border-0 file:bg-emerald-100 file:px-4 file:py-2 file:text-emerald-700 hover:border-emerald-300"
+                                @change="handleFileChange"
+                            />
+                            <p v-if="fileName" class="text-sm text-slate-500">Nuevo archivo: {{ fileName }}</p>
+                            <InputError :message="form.errors.file" class="mt-2" />
+                        </div>
+
+                        <div class="sm:col-span-2 flex items-center gap-3 pt-4">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar cambios
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('expenses.show', expense.id)"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y ver ficha
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref, onMounted} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { computed, ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import SelectInput from '@/Components/SelectInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
 const props = defineProps({
-    categories: Array,
-    paymentMethods: Array,
-    expense: Object,
+    categories: {
+        type: Array,
+        default: () => [],
+    },
+    paymentMethods: {
+        type: Array,
+        default: () => [],
+    },
+    expense: {
+        type: Object,
+        required: true,
+    },
 });
 
-const expense = ref({
-    name: '',
-    description: '',
-    amount: 0,
-    iva: 21,
-    date: new Date().toISOString().split('T')[0],
-    payment_method_id: null,
-    expense_category_id: null,
+const form = useForm({
+    name: props.expense.name || '',
+    description: props.expense.description || '',
+    amount: props.expense.amount ?? '',
+    iva: props.expense.iva ?? 21,
+    date: props.expense.date || new Date().toISOString().split('T')[0],
+    payment_method_id: props.expense.payment_method_id ?? '',
+    expense_category_id: props.expense.expense_category_id ?? '',
     file: null,
 });
 
-// Cargar datos existentes del gasto al montar el componente
-onMounted(() => {
-    expense.value = { ...props.expense }; // Asignar los datos actuales al formulario
+const fileName = ref('');
+
+const numeric = (value) => Number(value || 0);
+
+const taxAmount = computed(() => numeric(form.amount) * numeric(form.iva) / 100);
+const totalAmount = computed(() => numeric(form.amount) + taxAmount.value);
+
+const paymentMethodName = computed(() => {
+    const method = props.paymentMethods.find((item) => item.id === form.payment_method_id);
+    return method?.name || '';
 });
 
-const getFileUrl = (filePath) => {
-    return `/storage/${filePath.replace('public/', '')}`;
+const currentFileUrl = computed(() => {
+    if (!props.expense.file) {
+        return '';
+    }
+    const path = props.expense.file.startsWith('public/')
+        ? props.expense.file.replace('public/', '')
+        : props.expense.file;
+    return `/storage/${path}`;
+});
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(numeric(value));
 };
 
-const isImage = (file) => {
-    return file instanceof File && file.type.startsWith('image');
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
 };
 
-// Manejar el cambio de archivo
 const handleFileChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-        expense.value.file = file; // Guardar el archivo en expense.file
-        console.log('Archivo seleccionado:', file);
-    } else {
-        console.log('No se ha seleccionado ningún archivo');
-    }
+    const [file] = event.target.files;
+    form.file = file || null;
+    fileName.value = file ? file.name : '';
 };
 
-const submitForm = async () => {
-    const formData = new FormData();
-
-    for (const [key, value] of Object.entries(expense.value)) {
-        if (value !== null && value !== undefined) {
-            if (key === 'file' && typeof value === 'string') {
-                continue; // No enviar la ruta del archivo actual
-            }
-            formData.append(key, value instanceof File ? value : String(value));
-        }
-    }
-
-    // Enviar datos con Inertia
-    Inertia.post(route('expenses.update2', props.expense.id), formData, {
-        forceFormData: true, // Esto es clave para que Inertia envíe FormData correctamente
+const submitForm = () => {
+    form.post(route('expenses.update2', props.expense.id), {
+        forceFormData: true,
+        onSuccess: () => {
+            fileName.value = '';
+            form.file = null;
+        },
     });
 };
-
 </script>

--- a/resources/js/Pages/Expenses/Report.vue
+++ b/resources/js/Pages/Expenses/Report.vue
@@ -1,90 +1,177 @@
 <template>
-    <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Reportes de Contabilidad</h1>
-            <div class="mb-4">
-                <label for="start_date" class="block text-gray-700">Fecha de Inicio</label>
-                <input v-model="filter.start_date" type="date" id="start_date" @change="fetchFilteredData"
-                       class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-            </div>
-            <div class="mb-4">
-                <label for="end_date" class="block text-gray-700">Fecha de Fin</label>
-                <input v-model="filter.end_date" type="date" id="end_date" @change="fetchFilteredData"
-                       class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-            </div>
+    <AppLayout title="Informes contables">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Análisis"
+                title="Informe contable"
+                description="Cruza ingresos y gastos con filtros temporales y obtén una visión clara de la salud financiera de la empresa."
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <PrimaryButton type="button" @click="printReport">
+                        Imprimir informe
+                    </PrimaryButton>
+                </template>
+                <template #metrics>
+                    <FinanceSummaryCard label="Ingresos filtrados" :value="formatCurrency(totalIncomes)" :helper="`${filteredIncomes.length} registros`" />
+                    <FinanceSummaryCard label="Gastos filtrados" :value="formatCurrency(totalExpenses)" :helper="`${filteredExpenses.length} registros`" />
+                    <FinanceSummaryCard :label="netBalanceLabel" :value="formatCurrency(netBalance)" :helper="ivaHelper" />
+                </template>
+            </FinancePageHeader>
 
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Gastos</h2>
-            <table class="min-w-full bg-white border border-gray-300 mb-8">
-                <thead>
-                <tr>
-                    <th class="py-2 px-4 border-b">Fecha</th>
-                    <th class="py-2 px-4 border-b">Nombre</th>
-                    <th class="py-2 px-4 border-b">Descripción</th>
-                    <th class="py-2 px-4 border-b">Monto</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr v-for="expense in filteredExpenses" :key="expense.id">
-                    <td class="py-2 px-4 border-b">{{ expense.date }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.name }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.description }}</td>
-                    <td class="py-2 px-4 border-b">{{ expense.amount }}</td>
-                </tr>
-                <tr v-if="filteredExpenses.length === 0">
-                    <td colspan="4" class="py-2 px-4 border-b text-center">No hay gastos en este rango de fechas.</td>
-                </tr>
-                </tbody>
-            </table>
+            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-6 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Filtros temporales</h2>
+                        <p class="mt-1 text-sm text-slate-500">Selecciona un periodo para recalcular automáticamente todos los indicadores y tablas.</p>
+                    </header>
+                    <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+                        <div class="md:col-span-1">
+                            <InputLabel for="start_date" value="Fecha de inicio" />
+                            <TextInput id="start_date" v-model="filter.start_date" type="date" class="mt-2 block w-full" />
+                        </div>
+                        <div class="md:col-span-1">
+                            <InputLabel for="end_date" value="Fecha de fin" />
+                            <TextInput id="end_date" v-model="filter.end_date" type="date" class="mt-2 block w-full" />
+                        </div>
+                        <div class="md:col-span-1 flex items-end">
+                            <SecondaryButton type="button" class="w-full justify-center" @click="resetFilters">
+                                Limpiar filtros
+                            </SecondaryButton>
+                        </div>
+                    </div>
+                    <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                        <div class="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">Ingresos netos</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(totalIncomes - totalIncomeTaxes) }}</p>
+                            <p class="mt-2 text-xs text-emerald-800/70">Importe sin impuestos.</p>
+                        </div>
+                        <div class="rounded-2xl border border-rose-100 bg-rose-50 p-4 text-rose-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">Gastos totales</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(totalExpenses + totalExpenseTaxes) }}</p>
+                            <p class="mt-2 text-xs text-rose-800/70">Incluye base imponible e IVA.</p>
+                        </div>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-slate-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">Resultado neto</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(netBalance) }}</p>
+                            <p class="mt-2 text-xs text-slate-500">Beneficio tras impuestos.</p>
+                        </div>
+                    </div>
+                </section>
 
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Ingresos</h2>
-            <table class="min-w-full bg-white border border-gray-300 mb-8">
-                <thead>
-                <tr>
-                    <th class="py-2 px-4 border-b">Fecha</th>
-                    <th class="py-2 px-4 border-b">Nombre</th>
-                    <th class="py-2 px-4 border-b">Cliente</th>
-                    <th class="py-2 px-4 border-b">Monto</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr v-for="income in filteredIncomes" :key="income.id">
-                    <td class="py-2 px-4 border-b">{{ income.date }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.name }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.source }}</td>
-                    <td class="py-2 px-4 border-b">{{ income.total_amount }}</td>
-                </tr>
-                <tr v-if="filteredIncomes.length === 0">
-                    <td colspan="4" class="py-2 px-4 border-b text-center">No hay ingresos en este rango de fechas.</td>
-                </tr>
-                </tbody>
-            </table>
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Gastos</h2>
+                            <p class="text-sm text-slate-500">Detalle de gastos filtrados por fecha con su base imponible e impuestos asociados.</p>
+                        </div>
+                        <span class="text-sm text-slate-500">{{ filteredExpenses.length }} registros</span>
+                    </header>
+                    <div class="mt-6 overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Fecha</th>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Descripción</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Base imponible</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr v-for="expense in filteredExpenses" :key="expense.id" class="bg-white/60">
+                                    <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ expense.name }}</td>
+                                    <td class="px-4 py-3">{{ expense.description || '—' }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount + expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                </tr>
+                                <tr v-if="filteredExpenses.length === 0">
+                                    <td colspan="6" class="px-4 py-4 text-center text-slate-400">No hay gastos en este rango de fechas.</td>
+                                </tr>
+                            </tbody>
+                            <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <td colspan="3" class="px-4 py-3">Totales</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenses) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenseTaxes) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenses + totalExpenseTaxes) }}</td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </section>
 
-            <!-- Sección de comparativa de beneficios -->
-            <h2 class="text-2xl font-semibold mt-8 mb-4">Comparativa de Beneficios</h2>
-            <div class="bg-white border border-gray-300 p-4 mb-8">
-                <p><strong>Beneficio Bruto:</strong> {{ grossBenefit }}</p>
-                <p><strong>Monto de IVA:</strong> {{ ivaAmount }}</p>
-                <p><strong>Beneficio Neto:</strong> {{ netBenefit }}</p>
-            </div>
-
-            <div class="mt-8 flex justify-between items-center">
-                <button @click="printReport" class="bg-blue-900 p-2 rounded-full" title="Imprimir Reporte">
-                    <PrintIcon class="w-6 h-6 fill-gray-50 stroke-0 stroke-gray-50"/>
-                </button>
-            </div>
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-800">Ingresos</h2>
+                            <p class="text-sm text-slate-500">Incluye nombre, origen y cantidades con impuestos para facilitar la conciliación.</p>
+                        </div>
+                        <span class="text-sm text-slate-500">{{ filteredIncomes.length }} registros</span>
+                    </header>
+                    <div class="mt-6 overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Fecha</th>
+                                    <th scope="col" class="px-4 py-3">Nombre</th>
+                                    <th scope="col" class="px-4 py-3">Origen</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Base imponible</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr v-for="income in filteredIncomes" :key="income.id" class="bg-white/60">
+                                    <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(income.date) }}</td>
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ income.name }}</td>
+                                    <td class="px-4 py-3">{{ income.source || '—' }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(income.tax_base ?? 0) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)) }}</td>
+                                </tr>
+                                <tr v-if="filteredIncomes.length === 0">
+                                    <td colspan="6" class="px-4 py-4 text-center text-slate-400">No hay ingresos en este rango de fechas.</td>
+                                </tr>
+                            </tbody>
+                            <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <td colspan="3" class="px-4 py-3">Totales</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomeBase) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomeTaxes) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomes) }}</td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref, computed} from 'vue';
+import { computed, ref } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import PrintIcon from "@/Components/Icons/PrintIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
 
 const props = defineProps({
-    expenses: Array,
-    incomes: Array, // Cambié invoices a incomes
-    clients: Array,
+    expenses: {
+        type: Array,
+        default: () => [],
+    },
+    incomes: {
+        type: Array,
+        default: () => [],
+    },
 });
 
 const filter = ref({
@@ -92,60 +179,95 @@ const filter = ref({
     end_date: '',
 });
 
-// Computed properties para filtrar los gastos y los ingresos
+const parseDate = (value) => {
+    if (!value) {
+        return null;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+};
+
 const filteredExpenses = computed(() => {
     if (!filter.value.start_date && !filter.value.end_date) {
-        return props.expenses; // Sin filtro, devuelve todos los gastos
+        return props.expenses;
     }
-    return props.expenses.filter(expense => {
-        const expenseDate = new Date(expense.date);
-        const startDate = new Date(filter.value.start_date);
-        const endDate = new Date(filter.value.end_date);
-        return (
-            (filter.value.start_date ? expenseDate >= startDate : true) &&
-            (filter.value.end_date ? expenseDate <= endDate : true)
-        );
+    const start = parseDate(filter.value.start_date);
+    const end = parseDate(filter.value.end_date);
+    return props.expenses.filter((expense) => {
+        const date = parseDate(expense.date);
+        if (!date) {
+            return false;
+        }
+        const afterStart = start ? date >= start : true;
+        const beforeEnd = end ? date <= end : true;
+        return afterStart && beforeEnd;
     });
 });
 
 const filteredIncomes = computed(() => {
     if (!filter.value.start_date && !filter.value.end_date) {
-        return props.incomes; // Sin filtro, devuelve todos los ingresos
+        return props.incomes;
     }
-    return props.incomes.filter(income => {
-        const incomeDate = new Date(income.date);
-        const startDate = new Date(filter.value.start_date);
-        const endDate = new Date(filter.value.end_date);
-        return (
-            (filter.value.start_date ? incomeDate >= startDate : true) &&
-            (filter.value.end_date ? incomeDate <= endDate : true)
-        );
+    const start = parseDate(filter.value.start_date);
+    const end = parseDate(filter.value.end_date);
+    return props.incomes.filter((income) => {
+        const date = parseDate(income.date);
+        if (!date) {
+            return false;
+        }
+        const afterStart = start ? date >= start : true;
+        const beforeEnd = end ? date <= end : true;
+        return afterStart && beforeEnd;
     });
 });
 
-// Cálculos de beneficios
-const grossBenefit = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount, 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount, 0);
-    return totalIncomes - totalExpenses; // Beneficio bruto
-});
+const sumBy = (collection, callback) => {
+    return collection.reduce((total, item) => total + Number(callback(item) || 0), 0);
+};
 
-const ivaAmount = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount * (expense.iva / 100), 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount * (income.tax_rate / 100), 0);
-    return totalIncomes - totalExpenses; // Monto de IVA
-});
+const totalExpenses = computed(() => sumBy(filteredExpenses.value, (expense) => expense.amount));
+const totalExpenseTaxes = computed(() => sumBy(filteredExpenses.value, (expense) => expense.amount * (expense.iva ?? 0) / 100));
+const totalIncomes = computed(() => sumBy(filteredIncomes.value, (income) => income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)));
+const totalIncomeBase = computed(() => sumBy(filteredIncomes.value, (income) => income.tax_base ?? 0));
+const totalIncomeTaxes = computed(() => sumBy(filteredIncomes.value, (income) => income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100));
 
-const netBenefit = computed(() => {
-    return grossBenefit.value - ivaAmount.value; // Beneficio neto
-});
+const netBalance = computed(() => totalIncomes.value - (totalExpenses.value + totalExpenseTaxes.value));
+const netBalanceLabel = computed(() => (netBalance.value >= 0 ? 'Beneficio neto' : 'Pérdida neta'));
+const ivaHelper = computed(() => `IVA: ${formatCurrency(totalIncomeTaxes.value - totalExpenseTaxes.value)}`);
 
-// Método para imprimir el reporte
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const resetFilters = () => {
+    filter.value.start_date = '';
+    filter.value.end_date = '';
+};
+
 const printReport = () => {
     const url = route('expenses.reportsPrint', {
         start_date: filter.value.start_date,
         end_date: filter.value.end_date,
     });
-    window.open(url, '_blank'); // Abrir la vista de impresión en una nueva pestaña
+    window.open(url, '_blank');
 };
 </script>

--- a/resources/js/Pages/Incomes/Create.vue
+++ b/resources/js/Pages/Incomes/Create.vue
@@ -1,97 +1,168 @@
 <template>
-    <AppLayout>
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow">
-        <h1 class="text-2xl font-bold mb-6">Crear Ingreso</h1>
-
-        <form @submit.prevent="submit">
-            <div class="grid grid-cols-1 gap-4">
-                <div>
-                    <label for="name" class="block font-medium text-gray-700">Nombre</label>
-                    <input
-                        id="name"
-                        v-model="form.name"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.name" class="text-sm text-red-500">{{ form.errors.name }}</span>
-                </div>
-
-                <div>
-                    <label for="source" class="block font-medium text-gray-700">Origen</label>
-                    <input
-                        id="source"
-                        v-model="form.source"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.source" class="text-sm text-red-500">{{ form.errors.source }}</span>
-                </div>
-
-                <div>
-                    <label for="tax_base" class="block font-medium text-gray-700">Base Imponible</label>
-                    <input
-                        id="tax_base"
-                        v-model="form.tax_base"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_base" class="text-sm text-red-500">{{ form.errors.tax_base }}</span>
-                </div>
-
-                <div>
-                    <label for="tax_rate" class="block font-medium text-gray-700">IVA (%)</label>
-                    <input
-                        id="tax_rate"
-                        v-model="form.tax_rate"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_rate" class="text-sm text-red-500">{{ form.errors.tax_rate }}</span>
-                </div>
-
-                <div>
-                    <label for="date" class="block font-medium text-gray-700">Fecha</label>
-                    <input
-                        id="date"
-                        v-model="form.date"
-                        type="date"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.date" class="text-sm text-red-500">{{ form.errors.date }}</span>
-                </div>
-
-            </div>
-
-            <button
-                type="submit"
-                class="mt-6 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+    <AppLayout title="Registrar ingreso">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Contabilidad"
+                title="Registrar nuevo ingreso"
+                description="Completa la información clave del ingreso para que el dashboard financiero pueda calcular los indicadores al instante."
+                :metrics-columns="3"
             >
-                Guardar
-            </button>
-        </form>
-    </div>
+                <template #metrics>
+                    <FinanceSummaryCard
+                        label="Base imponible"
+                        :value="formatCurrency(form.tax_base)"
+                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
+                    />
+                    <FinanceSummaryCard
+                        label="IVA estimado"
+                        :value="formatCurrency(taxAmount)"
+                        :helper="`${form.tax_rate || 0}% aplicado`"
+                    />
+                    <FinanceSummaryCard
+                        label="Total previsto"
+                        :value="formatCurrency(totalAmount)"
+                        :helper="form.source ? `Origen: ${form.source}` : 'Origen pendiente'"
+                    />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Datos del ingreso</h2>
+                        <p class="mt-1 text-sm text-slate-500">
+                            Estos campos alimentan los cálculos de impuestos y totales. Revisa especialmente el tipo impositivo y la fecha de registro.
+                        </p>
+                    </header>
+
+                    <form @submit.prevent="submit" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                        <div class="sm:col-span-2">
+                            <InputLabel for="name" value="Nombre del ingreso" />
+                            <TextInput
+                                id="name"
+                                v-model="form.name"
+                                type="text"
+                                class="mt-2 block w-full"
+                                autocomplete="off"
+                                placeholder="Ej. Suscripción premium"
+                            />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
+
+                        <div class="sm:col-span-2">
+                            <InputLabel for="source" value="Origen o cliente" />
+                            <TextInput
+                                id="source"
+                                v-model="form.source"
+                                type="text"
+                                class="mt-2 block w-full"
+                                placeholder="Ej. Factura 2024-015"
+                            />
+                            <InputError :message="form.errors.source" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="tax_base" value="Base imponible" />
+                            <TextInput
+                                id="tax_base"
+                                v-model="form.tax_base"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.tax_base" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="tax_rate" value="IVA (%)" />
+                            <TextInput
+                                id="tax_rate"
+                                v-model="form.tax_rate"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.tax_rate" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="date" value="Fecha de registro" />
+                            <TextInput id="date" v-model="form.date" type="date" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.date" class="mt-2" />
+                        </div>
+
+                        <div class="sm:col-span-2 flex items-center gap-3 pt-4">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar ingreso
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('incomes.index')"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y volver
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
+        </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useForm } from '@inertiajs/vue3';
-import { defineProps } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-const props = defineProps({
-    companies: Array,
-});
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
 const form = useForm({
     name: '',
     source: '',
     tax_base: '',
-    tax_rate: '',
-    date: '',
+    tax_rate: 21,
+    date: new Date().toISOString().split('T')[0],
 });
 
+const numeric = (value) => Number(value || 0);
+
+const taxAmount = computed(() => {
+    return numeric(form.tax_base) * numeric(form.tax_rate) / 100;
+});
+
+const totalAmount = computed(() => numeric(form.tax_base) + taxAmount.value);
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(numeric(value));
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
 const submit = () => {
-    form.post('/incomes');
+    form.post(route('incomes.store'));
 };
 </script>

--- a/resources/js/Pages/Incomes/Edit.vue
+++ b/resources/js/Pages/Incomes/Edit.vue
@@ -1,91 +1,170 @@
 <template>
-    <AppLayout>
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow">
-        <h1 class="text-2xl font-bold mb-6">Editar Ingreso</h1>
-
-        <form @submit.prevent="submit">
-            <div class="grid grid-cols-1 gap-4">
-                <div>
-                    <label for="name" class="block font-medium text-gray-700">Nombre</label>
-                    <input
-                        id="name"
-                        v-model="form.name"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.name" class="text-sm text-red-500">{{ form.errors.name }}</span>
-                </div>
-
-                <div>
-                    <label for="source" class="block font-medium text-gray-700">Origen</label>
-                    <input
-                        id="source"
-                        v-model="form.source"
-                        type="text"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.source" class="text-sm text-red-500">{{ form.errors.source }}</span>
-                </div>
-
-                <div>
-                    <label for="tax_base" class="block font-medium text-gray-700">Base Imponible</label>
-                    <input
-                        id="tax_base"
-                        v-model="form.tax_base"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_base" class="text-sm text-red-500">{{ form.errors.tax_base }}</span>
-                </div>
-
-                <div>
-                    <label for="tax_rate" class="block font-medium text-gray-700">IVA (%)</label>
-                    <input
-                        id="tax_rate"
-                        v-model="form.tax_rate"
-                        type="number"
-                        step="0.01"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.tax_rate" class="text-sm text-red-500">{{ form.errors.tax_rate }}</span>
-                </div>
-
-                <div>
-                    <label for="date" class="block font-medium text-gray-700">Fecha</label>
-                    <input
-                        id="date"
-                        v-model="form.date"
-                        type="date"
-                        class="w-full border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <span v-if="form.errors.date" class="text-sm text-red-500">{{ form.errors.date }}</span>
-                </div>
-            </div>
-
-            <button
-                type="submit"
-                class="mt-6 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+    <AppLayout title="Editar ingreso">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Contabilidad"
+                :title="`Editar ${form.name || 'ingreso'}`"
+                description="Ajusta cualquier dato del ingreso para mantener consistentes los indicadores contables y la trazabilidad histórica."
+                :metrics-columns="3"
             >
-                Actualizar
-            </button>
-        </form>
-    </div>
+                <template #metrics>
+                    <FinanceSummaryCard
+                        label="Base imponible"
+                        :value="formatCurrency(form.tax_base)"
+                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
+                    />
+                    <FinanceSummaryCard
+                        label="IVA recalculado"
+                        :value="formatCurrency(taxAmount)"
+                        :helper="`${form.tax_rate || 0}% aplicado`"
+                    />
+                    <FinanceSummaryCard
+                        label="Total actualizado"
+                        :value="formatCurrency(totalAmount)"
+                        :helper="form.source ? `Origen: ${form.source}` : 'Origen pendiente'"
+                    />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Información del ingreso</h2>
+                        <p class="mt-1 text-sm text-slate-500">
+                            Los cambios se reflejan automáticamente en el dashboard financiero y en los informes impresos.
+                        </p>
+                    </header>
+
+                    <form @submit.prevent="submit" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                        <div class="sm:col-span-2">
+                            <InputLabel for="name" value="Nombre del ingreso" />
+                            <TextInput
+                                id="name"
+                                v-model="form.name"
+                                type="text"
+                                class="mt-2 block w-full"
+                                autocomplete="off"
+                            />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
+
+                        <div class="sm:col-span-2">
+                            <InputLabel for="source" value="Origen o cliente" />
+                            <TextInput
+                                id="source"
+                                v-model="form.source"
+                                type="text"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.source" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="tax_base" value="Base imponible" />
+                            <TextInput
+                                id="tax_base"
+                                v-model="form.tax_base"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.tax_base" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="tax_rate" value="IVA (%)" />
+                            <TextInput
+                                id="tax_rate"
+                                v-model="form.tax_rate"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                class="mt-2 block w-full"
+                            />
+                            <InputError :message="form.errors.tax_rate" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="date" value="Fecha de registro" />
+                            <TextInput id="date" v-model="form.date" type="date" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.date" class="mt-2" />
+                        </div>
+
+                        <div class="sm:col-span-2 flex items-center gap-3 pt-4">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar cambios
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('incomes.index')"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y volver
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
+        </div>
     </AppLayout>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useForm } from '@inertiajs/vue3';
-import { defineProps } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
+
 const props = defineProps({
-    income: Object,
-    companies: Array,
+    income: {
+        type: Object,
+        required: true,
+    },
 });
 
-const form = useForm({ ...props.income });
+const form = useForm({
+    name: props.income.name || '',
+    source: props.income.source || '',
+    tax_base: props.income.tax_base ?? '',
+    tax_rate: props.income.tax_rate ?? 21,
+    date: props.income.date || new Date().toISOString().split('T')[0],
+});
+
+const numeric = (value) => Number(value || 0);
+
+const taxAmount = computed(() => numeric(form.tax_base) * numeric(form.tax_rate) / 100);
+const totalAmount = computed(() => numeric(form.tax_base) + taxAmount.value);
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(numeric(value));
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
 
 const submit = () => {
-    form.put(`/incomes/${props.income.id}`);
+    form.put(route('incomes.update', props.income.id));
 };
 </script>

--- a/resources/js/Pages/Incomes/Show.vue
+++ b/resources/js/Pages/Incomes/Show.vue
@@ -1,0 +1,152 @@
+<template>
+    <AppLayout>
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Detalle de ingreso"
+                :title="income.name || 'Ingreso'"
+                :description="`Consulta el desglose fiscal y la procedencia de este ingreso para auditarlo o compartirlo con otros equipos.`"
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('incomes.edit', income.id)"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        <EditIcon class="h-4 w-4" />
+                        <span>Editar</span>
+                    </NavLink>
+                    <button
+                        type="button"
+                        @click="confirmDelete"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Eliminar
+                    </button>
+                    <button
+                        type="button"
+                        @click="printPage"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Imprimir ficha
+                    </button>
+                </template>
+
+                <template #metrics>
+                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(income.tax_base)" :helper="formatDate(income.date)" />
+                    <FinanceSummaryCard label="IVA" :value="formatCurrency(taxAmount)" :helper="`${income.tax_rate ?? 0}% aplicado`" />
+                    <FinanceSummaryCard label="Total" :value="formatCurrency(totalAmount)" :helper="companyName" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Información principal</h2>
+                        <p class="text-sm text-slate-500">Datos esenciales del ingreso con un formato alineado al resto del módulo contable.</p>
+                    </header>
+                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Origen</dt>
+                            <dd class="mt-2">{{ income.source || 'Sin especificar' }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</dt>
+                            <dd class="mt-2">{{ formatDate(income.date) }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Empresa</dt>
+                            <dd class="mt-2">{{ companyName }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador interno</dt>
+                            <dd class="mt-2">{{ income.id }}</dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Desglose fiscal</h2>
+                        <p class="text-sm text-slate-500">Visualiza rápidamente cómo se compone el importe final.</p>
+                    </header>
+                    <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                        <div class="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">Base imponible</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(income.tax_base) }}</p>
+                            <p class="mt-2 text-xs text-emerald-800/70">Importe sin impuestos.</p>
+                        </div>
+                        <div class="rounded-2xl border border-sky-100 bg-sky-50 p-4 text-sky-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">IVA</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(taxAmount) }}</p>
+                            <p class="mt-2 text-xs text-sky-800/70">Tipo aplicado: {{ income.tax_rate ?? 0 }}%.</p>
+                        </div>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-slate-700">
+                            <h3 class="text-xs font-semibold uppercase tracking-widest">Total</h3>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(totalAmount) }}</p>
+                            <p class="mt-2 text-xs text-slate-500">Resultado final registrado.</p>
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { Inertia } from '@inertiajs/inertia';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import NavLink from '@/Components/NavLink.vue';
+import EditIcon from '@/Components/Icons/EditIcon.vue';
+
+const props = defineProps({
+    income: {
+        type: Object,
+        required: true,
+    },
+});
+
+const income = computed(() => props.income ?? {});
+
+const numeric = (value) => Number(value || 0);
+
+const taxAmount = computed(() => numeric(income.value.tax_base) * numeric(income.value.tax_rate) / 100);
+const totalAmount = computed(() => numeric(income.value.tax_base) + taxAmount.value);
+
+const companyName = computed(() => income.value.company?.name || 'Sin empresa asociada');
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(numeric(value));
+};
+
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const printPage = () => {
+    window.print();
+};
+
+const confirmDelete = () => {
+    if (confirm('¿Seguro que deseas eliminar este ingreso? Esta acción no se puede deshacer.')) {
+        Inertia.delete(route('incomes.destroy', income.value.id));
+    }
+};
+</script>

--- a/resources/js/Pages/PaymentMethods/Create.vue
+++ b/resources/js/Pages/PaymentMethods/Create.vue
@@ -1,45 +1,78 @@
 <template>
-    <AppLayout>
-        <div class="p-6 w-full bg-gray-50 min-h-screen shadow-md">
-            <h1 class="text-3xl font-bold mb-8">Crear Método de Pago</h1>
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="mb-4">
-                        <label for="name" class="block text-gray-700">Nombre del Método</label>
-                        <input v-model="method.name" id="name" type="text" placeholder="Nombre del Método"
-                               class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
-                    </div>
+    <AppLayout title="Crear método de pago">
+        <div class="min-h-screen bg-slate-950">
+            <FinancePageHeader
+                eyebrow="Pagos"
+                title="Nuevo método de pago"
+                description="Define cómo se registran los cobros para mantener alineados los informes financieros."
+                :metrics-columns="3"
+            >
+                <template #metrics>
+                    <FinanceSummaryCard label="Nombre" :value="form.name || 'Sin definir'" :helper="`${form.name.length} caracteres`" />
+                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Texto preparado' : 'Añade más contexto'" />
+                    <FinanceSummaryCard label="Estado" value="Activo" helper="Disponible tras guardar" />
+                </template>
+            </FinancePageHeader>
 
-                    <div class="mb-4">
-                        <label for="description" class="block text-gray-700">Descripción</label>
-                        <textarea v-model="method.description" id="description" rows="4"
-                                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
-                                  placeholder="Descripción del método de pago"></textarea>
-                    </div>
-                </div>
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="mb-8 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Datos del método</h2>
+                        <p class="mt-1 text-sm text-slate-500">Especifica cómo se denomina este método y, opcionalmente, describe cuándo debe utilizarse.</p>
+                    </header>
 
-                <div class="mt-8 flex justify-between items-center">
-                    <button type="submit" class="bg-blue-900 p-2 rounded-full" title="Guardar Método">
-                        <SaveIcon class="w-6 h-6 stroke-gray-50"/>
-                    </button>
-                </div>
-            </form>
+                    <form @submit.prevent="submitForm" class="grid grid-cols-1 gap-6">
+                        <div>
+                            <InputLabel for="name" value="Nombre" />
+                            <TextInput id="name" v-model="form.name" type="text" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.name" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <InputLabel for="description" value="Descripción" />
+                            <TextareaInput id="description" v-model="form.description" rows="4" class="mt-2 block w-full" />
+                            <InputError :message="form.errors.description" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center gap-3 pt-2">
+                            <PrimaryButton type="submit" :disabled="form.processing">
+                                Guardar método
+                            </PrimaryButton>
+                            <NavLink
+                                :href="route('paymentMethods.index')"
+                                class="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+                            >
+                                Cancelar y volver
+                            </NavLink>
+                        </div>
+                    </form>
+                </section>
+            </main>
         </div>
     </AppLayout>
 </template>
 
 <script setup>
-import {ref} from 'vue';
-import {Inertia} from '@inertiajs/inertia';
+import { computed } from 'vue';
+import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import SaveIcon from "@/Components/Icons/SaveIcon.vue";
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import TextareaInput from '@/Components/TextareaInput.vue';
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import NavLink from '@/Components/NavLink.vue';
 
-const method = ref({
+const form = useForm({
     name: '',
     description: '',
 });
 
+const descriptionLength = computed(() => form.description?.length ?? 0);
+
 const submitForm = () => {
-    Inertia.post(route('paymentMethods.store'), method.value);
+    form.post(route('paymentMethods.store'));
 };
 </script>

--- a/resources/js/Pages/PaymentMethods/Show.vue
+++ b/resources/js/Pages/PaymentMethods/Show.vue
@@ -1,0 +1,94 @@
+<template>
+    <AppLayout>
+        <div class="min-h-screen bg-slate-950 print:bg-white">
+            <FinancePageHeader
+                eyebrow="Método de pago"
+                :title="paymentMethod.name"
+                description="Comprueba el uso del método y su descripción para mantener coherentes los registros contables."
+                :metrics-columns="3"
+            >
+                <template #actions>
+                    <NavLink
+                        :href="route('paymentMethods.edit', paymentMethod.id)"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Editar
+                    </NavLink>
+                    <NavLink
+                        :href="route('paymentMethods.index')"
+                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                        Volver al listado
+                    </NavLink>
+                </template>
+                <template #metrics>
+                    <FinanceSummaryCard label="Movimientos" :value="paymentsCount" :helper="paymentsCount === 1 ? 'Gasto asociado' : 'Gastos asociados'" />
+                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Texto disponible' : 'Sin descripción'" />
+                    <FinanceSummaryCard label="Creación" :value="formatDate(paymentMethod.created_at)" :helper="`Actualizado: ${formatDate(paymentMethod.updated_at)}`" />
+                </template>
+            </FinancePageHeader>
+
+            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Descripción</h2>
+                        <p class="text-sm text-slate-500">Utiliza este texto para orientar a los equipos sobre cuándo aplicar el método.</p>
+                    </header>
+                    <p class="mt-4 whitespace-pre-line text-slate-700">{{ paymentMethod.description || 'Todavía no se ha añadido ninguna descripción.' }}</p>
+                </section>
+
+                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
+                    <header class="border-b border-slate-100 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Metadatos</h2>
+                        <p class="text-sm text-slate-500">Información adicional para auditorías: empresa, identificador y estado.</p>
+                    </header>
+                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Empresa</dt>
+                            <dd class="mt-2">{{ companyName }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</dt>
+                            <dd class="mt-2">{{ paymentMethod.id }}</dd>
+                        </div>
+                    </dl>
+                </section>
+            </main>
+        </div>
+    </AppLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
+import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import NavLink from '@/Components/NavLink.vue';
+
+const props = defineProps({
+    paymentMethod: {
+        type: Object,
+        required: true,
+    },
+});
+
+const paymentMethod = computed(() => props.paymentMethod ?? {});
+const paymentsCount = computed(() => paymentMethod.value.expenses_count ?? 0);
+const descriptionLength = computed(() => paymentMethod.value.description?.length ?? 0);
+const companyName = computed(() => paymentMethod.value.company?.name || 'Sin empresa asociada');
+
+const formatDate = (value) => {
+    if (!value) {
+        return '—';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+</script>

--- a/routes/web/Contabilidad.php
+++ b/routes/web/Contabilidad.php
@@ -44,6 +44,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/incomes/create', [IncomeController::class, 'create'])->name('incomes.create');
     Route::post('/incomes', [IncomeController::class, 'store'])->name('incomes.store');
 
+    // Ver ingreso
+    Route::get('/incomes/{income}', [IncomeController::class, 'show'])->name('incomes.show');
+
     // Editar ingreso
     Route::get('/incomes/{income}/edit', [IncomeController::class, 'edit'])->name('incomes.edit');
     Route::put('/incomes/{income}', [IncomeController::class, 'update'])->name('incomes.update');


### PR DESCRIPTION
## Summary
- redesign create and edit forms for incomes, expenses, categories and payment methods to match the updated accounting style
- add rich show pages for incomes, categories and payment methods and refresh the accounting report layout
- expose the income show route and load related data for category and payment method detail screens

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68df89714e3883239a2974ee114e1012