### PR TITLE
Adjust sidebar alignment and icon sizing

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -27,7 +27,7 @@
             </nav>
 
             <div class="flex-1 w-full pb-12 pt-8">
-                <div class="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 lg:flex-row">
+                <div class="flex w-full max-w-7xl flex-col gap-8 px-4 lg:flex-row lg:items-start lg:px-0">
                     <aside class="w-full lg:w-72">
                         <div class="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl shadow-2xl shadow-blue-500/20">
                             <div class="space-y-6">
@@ -41,8 +41,8 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">General</p>
                                         <NewNavLink :href="route('dashboard')" :active="route().current('dashboard')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuHomeIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuHomeIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Inici</p>
@@ -56,26 +56,26 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Facturació</p>
                                         <NewNavLink :href="route('dashboard.billing')" :active="route().current('dashboard.billing')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuBillingIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuBillingIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Facturació</p>
                                                     <p class="text-xs text-blue-100/70">Gestió de pressupostos i factures</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isBillingPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('invoices.index')" :active="route().current('invoices.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuInvoiceIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuInvoiceIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Factures</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('budgets.index')" :active="route().current('budgets.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuBudgetIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuBudgetIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Pressupostos</span>
                                                 </span>
                                             </NewNavLink>
@@ -86,38 +86,38 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Magatzem</p>
                                         <NewNavLink :href="route('dashboard.products')" :active="route().current('dashboard.products')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuInventoryIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuInventoryIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Almacén</p>
                                                     <p class="text-xs text-blue-100/70">Control d'estoc i categories</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isProductsPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('products.index')" :active="route().current('products.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuProductIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuProductIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Productes</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('suppliers.index')" :active="route().current('suppliers.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuClientsIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuClientsIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Proveïdors</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('stockEntries.index')" :active="route().current('stockEntries.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <AddProductIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <AddProductIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Entrades de stock</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('categories.index')" :active="route().current('categories.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuCategoryIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuCategoryIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Categories</span>
                                                 </span>
                                             </NewNavLink>
@@ -128,8 +128,8 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Clients</p>
                                         <NewNavLink :href="route('dashboard.clients')" :active="route().current('dashboard.clients')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuClientsIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuClientsIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Clients</p>
@@ -143,44 +143,44 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Finances</p>
                                         <NewNavLink :href="route('dashboard.accounting')" :active="route().current('dashboard.accounting')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuAccountingIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuAccountingIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Comptabilitat</p>
                                                     <p class="text-xs text-blue-100/70">Informes i seguiment econòmic</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isAccountingPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('expenses.report')" :active="route().current('expenses.report')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuReportIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuReportIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Informes</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('incomes.index')" :active="route().current('incomes.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <IncomeIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <IncomeIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Ingressos</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('expenses.index')" :active="route().current('expenses.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuExpenseIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuExpenseIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Despeses</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('expenseCategories.index')" :active="route().current('expenseCategories.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuCategoryIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuCategoryIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Categories</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('paymentMethods.index')" :active="route().current('paymentMethods.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuPaymentIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuPaymentIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Mètodes de pagament</span>
                                                 </span>
                                             </NewNavLink>
@@ -191,32 +191,32 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">TPV</p>
                                         <NewNavLink :href="route('dashboard.tpv')" :active="route().current('dashboard.tpv')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <PayIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <PayIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">TPV</p>
                                                     <p class="text-xs text-blue-100/70">Cobraments i punts de venda</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isTpvPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('tikets.create')" :active="route().current('tikets.create')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuPaymentIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuPaymentIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Nova venda</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('tikets.index')" :active="route().current('tikets.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuInvoiceIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuInvoiceIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Tickets</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('tikets.productReport')" :active="route().current('tikets.productReport')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuReportIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuReportIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Informe de productes</span>
                                                 </span>
                                             </NewNavLink>
@@ -227,56 +227,56 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Persones</p>
                                         <NewNavLink :href="route('dashboard.rrhh')" :active="route().current('dashboard.rrhh')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuRRHHIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuRRHHIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">RRHH</p>
                                                     <p class="text-xs text-blue-100/70">Equip, fitxatges i formació</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isRRHHPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('employees.index')" :active="route().current('employees.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuClientsIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuClientsIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Empleats</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('departments.index')" :active="route().current('departments.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuCategoryIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuCategoryIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Departaments</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('payrolls.index')" :active="route().current('payrolls.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuInvoiceIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuInvoiceIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Nòmines</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('attendances.index')" :active="route().current('attendances.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuAccountingIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuAccountingIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Control horari</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('performance-reviews.index')" :active="route().current('performance-reviews.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuReportIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuReportIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Desempeño</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('leaves.index')" :active="route().current('leaves.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuExpenseIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuExpenseIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Vacances i absències</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('trainings.index')" :active="route().current('trainings.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <AddProductIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <AddProductIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Formacions</span>
                                                 </span>
                                             </NewNavLink>
@@ -287,26 +287,26 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">CRM</p>
                                         <NewNavLink :href="route('dashboard.crm')" :active="route().current('dashboard.crm')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuCRMIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuCRMIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">CRM</p>
                                                     <p class="text-xs text-blue-100/70">Oportunitats i seguiment comercial</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isCrmPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('leads.index')" :active="route().current('leads.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuClientsIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuClientsIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Leads</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('opportunities.index')" :active="route().current('opportunities.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuCategoryIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuCategoryIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Oportunitats</span>
                                                 </span>
                                             </NewNavLink>
@@ -317,32 +317,32 @@
                                         <p class="text-xs uppercase tracking-[0.35em] text-blue-200/60">Administració</p>
                                         <NewNavLink :href="route('dashboard.admin')" :active="route().current('dashboard.admin')">
                                             <div class="flex items-center gap-3">
-                                                <span class="icon-accent flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
-                                                    <MenuReportIcon class="h-5 w-5" />
+                                                <span class="icon-accent flex h-8 w-8 items-center justify-center rounded-xl bg-white/10 text-blue-200 transition group-hover:bg-white/20">
+                                                    <MenuReportIcon class="h-4 w-4" />
                                                 </span>
                                                 <div class="text-left">
                                                     <p class="text-sm font-semibold">Administració</p>
                                                     <p class="text-xs text-blue-100/70">Usuaris i rols del sistema</p>
                                                 </div>
                                             </div>
-                                            <DropdownIcon class="h-4 w-4 text-blue-100/70" />
+                                            <DropdownIcon class="h-3 w-3 text-blue-100/70" />
                                         </NewNavLink>
                                         <div v-if="isAdminPage" class="ml-4 space-y-2 border-l border-white/10 pl-4">
                                             <NewNavLink :href="route('users.index')" :active="route().current('users.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuClientsIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuClientsIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Usuaris</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('user_tasks.index')" :active="route().current('user_tasks.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuInvoiceIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuInvoiceIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Tasques</span>
                                                 </span>
                                             </NewNavLink>
                                             <NewNavLink :href="route('roles.index')" :active="route().current('roles.index')" variant="sub">
                                                 <span class="flex items-center gap-2 text-sm">
-                                                    <MenuCategoryIcon class="icon-accent h-4 w-4 text-blue-100" />
+                                                    <MenuCategoryIcon class="icon-accent h-3 w-3 text-blue-100" />
                                                     <span>Rols</span>
                                                 </span>
                                             </NewNavLink>


### PR DESCRIPTION
## Summary
- align the application layout sidebar flush with the left edge on large viewports by removing the centered container margin
- shrink the primary and sub-navigation icon sizes for a more compact menu appearance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa2db34948323a17a839036d759cd