### PR TITLE
Ensure form input text is dark

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,6 +6,17 @@
     display: none;
 }
 
+@layer base {
+    input,
+    select,
+    textarea,
+    .form-input,
+    .form-select,
+    .form-textarea {
+        @apply text-slate-900;
+    }
+}
+
 .icon-accent {
     color: inherit;
 }


### PR DESCRIPTION
## Summary
- ensure all input, select, and textarea elements inherit a dark text color for improved readability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c783ff0883238fa3f33153eb2acc