### PR TITLE
Handle missing notification feature when creating clients

### DIFF
--- a/app/Http/Controllers/UserNotificationController.php
+++ b/app/Http/Controllers/UserNotificationController.php
@@ -51,6 +51,12 @@ class UserNotificationController extends Controller
 
         $feature = Feature::where('name', $type)->first();
 
+        if (! $feature) {
+            Log::warning('Feature not found for notification type: '.$type);
+
+            return;
+        }
+
         Log::info('Feature: '.$feature);
 
         $roles = $feature->roles;


### PR DESCRIPTION
## Summary
- prevent client creation from failing when the notification feature for the given type is missing
- log a warning instead of triggering an error so the request can complete normally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efaba032d483239e289c8a9e8d61ac