### PR TITLE
Fix numeric formatting in billing dashboard

### DIFF
--- a/resources/js/Pages/DashboardFacturacion.vue
+++ b/resources/js/Pages/DashboardFacturacion.vue
@@ -71,7 +71,7 @@
                                     <p class="font-semibold text-slate-700">{{ getClientName(budget.client_id) }}</p>
                                     <p class="text-xs text-slate-400">{{ formatDate(budget.date) }}</p>
                                 </div>
-                                <p class="font-semibold text-slate-800">€{{ (budget.total ?? 0).toFixed(2) }}</p>
+                                <p class="font-semibold text-slate-800">€{{ formatCurrency(budget.total) }}</p>
                             </li>
                             <li v-if="recentBudgets.length === 0" class="py-4 text-center text-slate-400">No hay presupuestos registrados.</li>
                         </ul>
@@ -101,7 +101,7 @@
                                     <p class="text-xs text-slate-400">{{ formatDate(invoice.date) }}</p>
                                 </div>
                                 <div class="text-right">
-                                    <p class="font-semibold text-slate-800">€{{ (invoice.total ?? 0).toFixed(2) }}</p>
+                                    <p class="font-semibold text-slate-800">€{{ formatCurrency(invoice.total) }}</p>
                                     <p class="text-xs text-slate-400 uppercase tracking-widest">{{ invoice.state ?? 'pending' }}</p>
                                 </div>
                             </li>
@@ -136,13 +136,24 @@ const props = defineProps({
     clients: Array,
 });
 
+const parseAmount = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const formatCurrency = (value) => parseAmount(value).toFixed(2);
+
 const totalBudgets = computed(() => props.budgets.length);
 const totalInvoices = computed(() => props.invoices.length);
 const totalClients = computed(() => props.clients.length);
-const totalIncome = computed(() => props.invoices.reduce((acc, invoice) => acc + (invoice.total ?? 0), 0).toFixed(2));
+const totalIncome = computed(() => props.invoices.reduce((acc, invoice) => acc + parseAmount(invoice.total), 0).toFixed(2));
 const outstandingAmount = computed(() => props.invoices
     .filter(invoice => invoice.state !== 'paid')
-    .reduce((acc, invoice) => acc + (invoice.total ?? 0), 0)
+    .reduce((acc, invoice) => acc + parseAmount(invoice.total), 0)
     .toFixed(2));
 const outstandingInvoices = computed(() => props.invoices.filter(invoice => invoice.state !== 'paid').length);
 const paidPercentage = computed(() => {
@@ -153,8 +164,8 @@ const paidPercentage = computed(() => {
     return Math.round((paid / props.invoices.length) * 100);
 });
 
-const averageBudget = computed(() => props.budgets.length ? (props.budgets.reduce((acc, budget) => acc + (budget.total ?? 0), 0) / props.budgets.length).toFixed(2) : '0.00');
-const averageInvoice = computed(() => props.invoices.length ? (props.invoices.reduce((acc, invoice) => acc + (invoice.total ?? 0), 0) / props.invoices.length).toFixed(2) : '0.00');
+const averageBudget = computed(() => props.budgets.length ? (props.budgets.reduce((acc, budget) => acc + parseAmount(budget.total), 0) / props.budgets.length).toFixed(2) : '0.00');
+const averageInvoice = computed(() => props.invoices.length ? (props.invoices.reduce((acc, invoice) => acc + parseAmount(invoice.total), 0) / props.invoices.length).toFixed(2) : '0.00');
 
 const recentBudgets = computed(() => [...props.budgets].sort((a, b) => new Date(b.date) - new Date(a.date)).slice(0, 5));
 const recentInvoices = computed(() => [...props.invoices].sort((a, b) => new Date(b.date) - new Date(a.date)).slice(0, 5));
@@ -171,7 +182,7 @@ const formatDate = (date) => {
 const budgetClientData = computed(() => {
     const clientTotals = props.budgets.reduce((acc, budget) => {
         if (!acc[budget.client_id]) acc[budget.client_id] = 0;
-        acc[budget.client_id] += budget.total ?? 0;
+        acc[budget.client_id] += parseAmount(budget.total);
         return acc;
     }, {});
 
@@ -191,7 +202,7 @@ const invoiceMonthlyData = computed(() => {
     const monthlyTotals = props.invoices.reduce((acc, invoice) => {
         if (!invoice.date) return acc;
         const month = new Date(invoice.date).toLocaleString('default', { month: 'short' });
-        acc[month] = (acc[month] || 0) + (invoice.total ?? 0);
+        acc[month] = (acc[month] || 0) + parseAmount(invoice.total);
         return acc;
     }, {});
 
@@ -243,13 +254,13 @@ const budgetVsInvoiceChart = computed(() => {
     props.budgets.forEach(budget => {
         if (!budget.date) return;
         const monthIndex = sortedMonths.indexOf(new Date(budget.date).getMonth());
-        budgetTotals[monthIndex] += budget.total ?? 0;
+        budgetTotals[monthIndex] += parseAmount(budget.total);
     });
 
     props.invoices.forEach(invoice => {
         if (!invoice.date) return;
         const monthIndex = sortedMonths.indexOf(new Date(invoice.date).getMonth());
-        invoiceTotals[monthIndex] += invoice.total ?? 0;
+        invoiceTotals[monthIndex] += parseAmount(invoice.total);
     });
 
     return {
@@ -276,7 +287,7 @@ const budgetVsInvoiceChart = computed(() => {
 const topClientName = computed(() => {
     const totals = props.invoices.reduce((acc, invoice) => {
         const clientId = invoice.client_id;
-        acc[clientId] = (acc[clientId] || 0) + (invoice.total ?? 0);
+        acc[clientId] = (acc[clientId] || 0) + parseAmount(invoice.total);
         return acc;
     }, {});
 


### PR DESCRIPTION
## Summary
- sanitize budget and invoice totals before performing dashboard aggregations
- centralize currency formatting to avoid runtime errors when totals arrive as strings

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*


------
https://chatgpt.com/codex/tasks/task_e_68efb6d30a6083239ad9688f5e1d8a81