### PR TITLE
Fix product category filtering in budget and invoice modals

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -6,6 +6,7 @@ use App\Mail\BudgetMail;
 use App\Mail\InvoiceMail;
 use App\Models\Budget;
 use App\Models\BudgetItem;
+use App\Models\Category;
 use App\Models\Client;
 use App\Models\Company;
 use App\Models\EmailConfiguration;
@@ -34,11 +35,15 @@ class BudgetController extends Controller
     {
         $clients = Client::where('company_id', Auth::user()->company_id)->get();
         $companies = Company::all();
-        $products = Product::where('company_id', Auth::user()->company_id)->where('disabled', false)->get();
+        $products = Product::where('company_id', Auth::user()->company_id)
+            ->where('disabled', false)
+            ->with('category')
+            ->get();
         return Inertia::render('Budgets/Create', [
             'clients' => $clients,
             'companies' => $companies,
-            'products' => $products
+            'products' => $products,
+            'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
         ]);
 
 
@@ -125,8 +130,11 @@ class BudgetController extends Controller
         return Inertia::render('Budgets/Edit', [
             'budget' => $budget,
             'budgetItems' => $budgetItems,
-            'products' => Product::where('company_id', Auth::user()->company_id)->get(),
+            'products' => Product::where('company_id', Auth::user()->company_id)
+                ->with('category')
+                ->get(),
             'clients' => Client::where('company_id', Auth::user()->company_id)->get(),
+            'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
         ]);
     }
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Mail\InvoiceMail;
 use App\Models\Budget;
 use App\Models\BudgetItem;
+use App\Models\Category;
 use App\Models\CreditNote;
 use App\Models\EmailConfiguration;
 use App\Models\Income;
@@ -45,11 +46,15 @@ class InvoiceController extends Controller
     {
         $clients = Client::where('company_id', Auth::user()->company_id)->get();
         $companies = Company::all();
-        $products = Product::where('company_id', Auth::user()->company_id)->where('disabled', false)->get();
+        $products = Product::where('company_id', Auth::user()->company_id)
+            ->where('disabled', false)
+            ->with('category')
+            ->get();
         return Inertia::render('Invoices/Create', [
             'clients' => $clients,
             'companies' => $companies,
-            'products' => $products
+            'products' => $products,
+            'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
         ]);
     }
 
@@ -126,8 +131,11 @@ class InvoiceController extends Controller
         return Inertia::render('Invoices/Edit', [
             'invoice' => $invoice,
             'invoiceItems' => $invoiceItems,
-            'products' => Product::where('company_id', Auth::user()->company_id)->get(),
+            'products' => Product::where('company_id', Auth::user()->company_id)
+                ->with('category')
+                ->get(),
             'clients' => Client::where('company_id', Auth::user()->company_id)->get(),
+            'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
         ]);
     }
 


### PR DESCRIPTION
## Summary
- provide budget and invoice pages with the list of product categories for the selection modal
- eager-load each product's category so the modal filter can match by category name

## Testing
- php artisan test *(fails: missing `vendor/autoload.php` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68efbd9642d48323bbd44679cbbe8f76