### PR TITLE
Fix edit pages when related props are missing

### DIFF
--- a/resources/js/Pages/Budgets/Edit.vue
+++ b/resources/js/Pages/Budgets/Edit.vue
@@ -317,11 +317,35 @@ import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
 const props = defineProps({
-    budget: Object,
-    budgetItems: Array,
-    products: Array,
-    clients: Array,
-    categories: Array,
+    budget: {
+        type: Object,
+        default: () => ({
+            client_id: null,
+            date: '',
+            name: '',
+            state: 'in_process',
+            base_imponible: 0,
+            iva: 0,
+            monto_iva: 0,
+            total: 0,
+        }),
+    },
+    budgetItems: {
+        type: Array,
+        default: () => [],
+    },
+    products: {
+        type: Array,
+        default: () => [],
+    },
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
 });
 
 const form = ref({

--- a/resources/js/Pages/Invoices/Edit.vue
+++ b/resources/js/Pages/Invoices/Edit.vue
@@ -317,11 +317,35 @@ import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import MenuCategoryIcon from '@/Components/Icons/MenuCategoryIcon.vue';
 
 const props = defineProps({
-    invoice: Object,
-    invoiceItems: Array,
-    products: Array,
-    clients: Array,
-    categories: Array,
+    invoice: {
+        type: Object,
+        default: () => ({
+            client_id: null,
+            date: '',
+            name: '',
+            state: 'pending',
+            base_imponible: 0,
+            iva: 0,
+            monto_iva: 0,
+            total: 0,
+        }),
+    },
+    invoiceItems: {
+        type: Array,
+        default: () => [],
+    },
+    products: {
+        type: Array,
+        default: () => [],
+    },
+    clients: {
+        type: Array,
+        default: () => [],
+    },
+    categories: {
+        type: Array,
+        default: () => [],
+    },
 });
 
 const form = ref({


### PR DESCRIPTION
## Summary
- provide default values for invoice and budget edit props to avoid runtime errors
- ensure computed helpers always operate on arrays even when the backend omits related data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efbf250b5483239dcfc06d404d3951