### PR TITLE
Fix product category relationship

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -26,7 +26,7 @@ class Product extends Model
 
     public function category()
     {
-        return $this->belongsToMany(Category::class);
+        return $this->belongsTo(Category::class);
     }
 
     public function invoiceItems()


### PR DESCRIPTION
## Summary
- update the Product model to reference its category with a belongsTo relationship instead of belongsToMany
- prevent Laravel from expecting a missing pivot table when eager loading product categories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efc087e3cc8323bcf462b75deb7a44