### PR TITLE
Fix namespace declarations in part migrations

### DIFF
--- a/database/migrations/2024_08_07_200000_create_parts_table.php
+++ b/database/migrations/2024_08_07_200000_create_parts_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2024_08_07_200100_create_part_items_table.php
+++ b/database/migrations/2024_08_07_200100_create_part_items_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {


### PR DESCRIPTION
## Summary
- replace escaped namespace separators in the parts migrations so the PHP parser recognizes the use statements

## Testing
- php -l database/migrations/2024_08_07_200000_create_parts_table.php
- php -l database/migrations/2024_08_07_200100_create_part_items_table.php

------
https://chatgpt.com/codex/tasks/task_e_68efe2ae07048323aeadee3581708d21