### PR TITLE
Implement automatic numbering for invoices, budgets and parts

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -13,11 +13,13 @@ use App\Models\EmailConfiguration;
 use App\Models\Invoice;
 use App\Models\Product;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
+use App\Services\DocumentNumberGenerator;
 
 class BudgetController extends Controller
 {
@@ -39,11 +41,21 @@ class BudgetController extends Controller
             ->where('disabled', false)
             ->with('category')
             ->get();
+
+        $nextBudgetNumber = DocumentNumberGenerator::generate(
+            Budget::class,
+            'name',
+            'PR',
+            Auth::user()->company_id,
+            Carbon::now()
+        );
+
         return Inertia::render('Budgets/Create', [
             'clients' => $clients,
             'companies' => $companies,
             'products' => $products,
             'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
+            'nextBudgetNumber' => $nextBudgetNumber,
         ]);
 
 
@@ -59,12 +71,19 @@ class BudgetController extends Controller
                 'date' => 'required|date',
                 'base_imponible' => 'required|numeric|min:0',
                 'iva' => 'nullable|numeric',
-                'name' => 'required|string|max:255',
                 'state' => 'required|string|in:draft,approved,rejected',
             ]);
 
-            $data = $request->all();
+            $issueDate = Carbon::parse($request->input('date'));
+            $data = $request->except('name');
             $data['company_id'] = Auth::user()->company_id;
+            $data['name'] = DocumentNumberGenerator::generate(
+                Budget::class,
+                'name',
+                'PR',
+                Auth::user()->company_id,
+                $issueDate
+            );
 
             Budget::create($data);
 
@@ -82,7 +101,6 @@ class BudgetController extends Controller
         // Validar los datos del request
         $validated = $request->validate([
             'date' => 'required|date',
-            'name' => 'required|string',
             'base_imponible' => 'required|numeric',
             'state' => 'required|string',
             'client_id' => 'required|exists:clients,id',
@@ -98,8 +116,16 @@ class BudgetController extends Controller
         ]);
 
         // Crear el presupuesto
-        $data=$request->only('date','name','base_imponible','state','client_id','total','iva','monto_iva');
+        $issueDate = Carbon::parse($validated['date']);
+        $data=$request->only('date','base_imponible','state','client_id','total','iva','monto_iva');
         $data['company_id']=Auth::user()->company_id;
+        $data['name'] = DocumentNumberGenerator::generate(
+            Budget::class,
+            'name',
+            'PR',
+            Auth::user()->company_id,
+            $issueDate
+        );
         $budget = Budget::create($data);
 
         // Crear los ítems de presupuesto

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -14,6 +14,7 @@ use App\Models\InvoiceItem;
 use App\Models\Client;
 use App\Models\Company;
 use App\Models\Product;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -26,6 +27,8 @@ use phpseclib3\Crypt\RSA;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\PdfParser\StreamReader;
 use phpseclib3\Crypt\PublicKeyLoader;
+
+use App\Services\DocumentNumberGenerator;
 
 // Importa la clase RSA
 
@@ -50,11 +53,21 @@ class InvoiceController extends Controller
             ->where('disabled', false)
             ->with('category')
             ->get();
+
+        $nextInvoiceNumber = DocumentNumberGenerator::generate(
+            Invoice::class,
+            'name',
+            'FA',
+            Auth::user()->company_id,
+            Carbon::now()
+        );
+
         return Inertia::render('Invoices/Create', [
             'clients' => $clients,
             'companies' => $companies,
             'products' => $products,
             'categories' => Category::where('company_id', Auth::user()->company_id)->get(),
+            'nextInvoiceNumber' => $nextInvoiceNumber,
         ]);
     }
 
@@ -66,12 +79,19 @@ class InvoiceController extends Controller
                 'date' => 'required|date',
                 'base_imponible' => 'required|numeric|min:0',
                 'iva' => 'nullable|numeric',
-                'name' => 'required|string|max:255',
                 'state' => 'required|string|in:pagado,no_pagado',
             ]);
 
-            $data = $request->all();
+            $issueDate = Carbon::parse($request->input('date'));
+            $data = $request->except('name');
             $data['company_id'] = Auth::user()->company_id;
+            $data['name'] = DocumentNumberGenerator::generate(
+                Invoice::class,
+                'name',
+                'FA',
+                Auth::user()->company_id,
+                $issueDate
+            );
 
             Invoice::create($data);
 
@@ -86,7 +106,6 @@ class InvoiceController extends Controller
 
         $validated = $request->validate([
             'date' => 'required|date',
-            'name' => 'required|string',
             'base_imponible' => 'required|numeric',
             'state' => 'required|string',
             'client_id' => 'required|exists:clients,id',
@@ -101,8 +120,16 @@ class InvoiceController extends Controller
             'invoiceItems.*.total' => 'required|numeric',
         ]);
 
-        $data = $request->only('date', 'name', 'base_imponible', 'state', 'client_id', 'total', 'iva', 'monto_iva');
+        $issueDate = Carbon::parse($validated['date']);
+        $data = $request->only('date', 'base_imponible', 'state', 'client_id', 'total', 'iva', 'monto_iva');
         $data['company_id'] = Auth::user()->company_id;
+        $data['name'] = DocumentNumberGenerator::generate(
+            Invoice::class,
+            'name',
+            'FA',
+            Auth::user()->company_id,
+            $issueDate
+        );
         $invoice = Invoice::create($data);
 
         foreach ($validated['invoiceItems'] as $item) {
@@ -242,16 +269,23 @@ class InvoiceController extends Controller
             $budget['state'] = 'accepted';
             $budget->save();
             // Crear la factura con los datos del presupuesto
+            $issueDate = Carbon::now();
             $invoice = Invoice::create([
                 'company_id' => $budget->company_id,
                 'client_id' => $budget->client_id,
-                'date' => now(), // O puedes usar $budget->date si quieres mantener la misma fecha
+                'date' => $issueDate,
                 'total' => $budget->total,
                 'state' => 'pending',
                 'monto_iva' => $budget->monto_iva,
                 'base_imponible' => $budget->base_imponible,
                 'iva' => $budget->iva,
-                'name' => $budget->name,
+                'name' => DocumentNumberGenerator::generate(
+                    Invoice::class,
+                    'name',
+                    'FA',
+                    $budget->company_id,
+                    $issueDate
+                ),
             ]);
 
             // Copiar los ítems del presupuesto a los ítems de la factura
@@ -282,8 +316,15 @@ class InvoiceController extends Controller
     public function copy(Invoice $invoice)
     {
         //crear nueva factura a partir de la que recivimos
+        $copyDate = Carbon::parse($invoice->date);
         $newInvoice= Invoice::create([
-                'name'=>$invoice->name."(copy)",
+                'name' => DocumentNumberGenerator::generate(
+                    Invoice::class,
+                    'name',
+                    'FA',
+                    $invoice->company_id,
+                    $copyDate
+                ),
                 'client_id'=>$invoice->client_id,
                 'date'=>$invoice->date,
                 'base_imponible'=>$invoice->base_imponible,

--- a/app/Http/Controllers/PartController.php
+++ b/app/Http/Controllers/PartController.php
@@ -9,6 +9,8 @@ use App\Models\InvoiceItem;
 use App\Models\Part;
 use App\Models\PartItem;
 use App\Models\Product;
+use App\Services\DocumentNumberGenerator;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -24,9 +26,18 @@ class PartController extends Controller
 
         $clients = Client::where('company_id', Auth::user()->company_id)->get();
 
+        $nextInvoiceNumber = DocumentNumberGenerator::generate(
+            Invoice::class,
+            'name',
+            'FA',
+            Auth::user()->company_id,
+            Carbon::now()
+        );
+
         return Inertia::render('Parts/Index', [
             'parts' => $parts,
             'clients' => $clients,
+            'nextInvoiceNumber' => $nextInvoiceNumber,
         ]);
     }
 
@@ -38,16 +49,25 @@ class PartController extends Controller
             ->with('category')
             ->get();
 
+        $nextPartReference = DocumentNumberGenerator::generate(
+            Part::class,
+            'reference',
+            'AB',
+            Auth::user()->company_id,
+            Carbon::now()
+        );
+
         return Inertia::render('Parts/Create', [
             'clients' => $clients,
             'products' => $products,
+            'nextPartReference' => $nextPartReference,
         ]);
     }
 
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'reference' => 'required|string|max:255',
+            'reference' => 'nullable|string|max:255',
             'date' => 'required|date',
             'client_id' => 'required|exists:clients,id',
             'notes' => 'nullable|string',
@@ -70,10 +90,17 @@ class PartController extends Controller
             return back()->withErrors(['items' => 'Se han seleccionado productos no disponibles.']);
         }
 
+        $issueDate = Carbon::parse($validated['date']);
         $part = Part::create([
             'company_id' => Auth::user()->company_id,
             'client_id' => $client->id,
-            'reference' => $validated['reference'],
+            'reference' => DocumentNumberGenerator::generate(
+                Part::class,
+                'reference',
+                'AB',
+                Auth::user()->company_id,
+                $issueDate
+            ),
             'date' => $validated['date'],
             'status' => 'pending',
             'total' => 0,
@@ -121,7 +148,6 @@ class PartController extends Controller
         $validated = $request->validate([
             'parts' => 'required|array|min:1',
             'parts.*' => 'exists:parts,id',
-            'invoice.name' => 'required|string|max:255',
             'invoice.date' => 'required|date',
             'invoice.state' => 'required|in:pending,paid,cancelled',
             'invoice.iva' => 'required|numeric|min:0',
@@ -150,11 +176,18 @@ class PartController extends Controller
         $montoIva = round($baseImponible * ($ivaRate / 100), 2);
         $total = round($baseImponible + $montoIva, 2);
 
+        $invoiceDate = Carbon::parse($validated['invoice']['date']);
         $invoice = Invoice::create([
             'company_id' => Auth::user()->company_id,
             'client_id' => $clientIds->first(),
             'date' => $validated['invoice']['date'],
-            'name' => $validated['invoice']['name'],
+            'name' => DocumentNumberGenerator::generate(
+                Invoice::class,
+                'name',
+                'FA',
+                Auth::user()->company_id,
+                $invoiceDate
+            ),
             'base_imponible' => $baseImponible,
             'iva' => $ivaRate,
             'monto_iva' => $montoIva,

--- a/app/Services/DocumentNumberGenerator.php
+++ b/app/Services/DocumentNumberGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+
+class DocumentNumberGenerator
+{
+    /**
+     * Generate the next document number for the given model.
+     */
+    public static function generate(string $modelClass, string $numberColumn, string $prefix, int $companyId, Carbon $date): string
+    {
+        $year = $date->year;
+        $pattern = sprintf('%s-%d-', $prefix, $year);
+
+        $latestDocument = $modelClass::where('company_id', $companyId)
+            ->whereYear('date', $year)
+            ->where($numberColumn, 'like', $pattern . '%')
+            ->orderBy($numberColumn, 'desc')
+            ->first();
+
+        $nextSequence = 1;
+
+        if ($latestDocument) {
+            $currentValue = $latestDocument->{$numberColumn};
+
+            if (preg_match('/(\d+)$/', $currentValue, $matches)) {
+                $nextSequence = (int) $matches[1] + 1;
+            }
+        }
+
+        return sprintf('%s-%d-%04d', $prefix, $year, $nextSequence);
+    }
+}

--- a/resources/js/Pages/Budgets/Create.vue
+++ b/resources/js/Pages/Budgets/Create.vue
@@ -60,15 +60,13 @@
                                 <TextInput id="budget-date" v-model="budget.date" type="date" class="mt-2 block w-full" />
                             </div>
                             <div class="space-y-2">
-                                <InputLabel for="budget-name" value="Nombre interno" />
-                                <TextInput
-                                    id="budget-name"
-                                    v-model="budget.name"
-                                    type="text"
-                                    class="mt-2 block w-full"
-                                    placeholder="Propuesta comercial"
-                                    autocomplete="off"
-                                />
+                                <InputLabel value="Número de pressupost" />
+                                <div class="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700">
+                                    {{ budgetNumberPreview }}
+                                </div>
+                                <p class="text-xs text-slate-500">
+                                    S'assigna automàticament mantenint la numeració correlativa per any fiscal.
+                                </p>
                             </div>
                             <div class="space-y-2">
                                 <InputLabel for="client-search" value="Buscar cliente" />
@@ -331,11 +329,15 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+    nextBudgetNumber: {
+        type: String,
+        default: '',
+    },
 });
 
 const budget = ref({
     date: new Date().toISOString().split('T')[0],
-    name: '',
+    name: props.nextBudgetNumber || '',
     state: 'in_process',
     client_id: '',
     total: 0,
@@ -369,6 +371,18 @@ const filteredProducts = computed(() => {
             : true;
         return matchesName && matchesCategory;
     });
+});
+
+const budgetNumberPreview = computed(() => {
+    if (budget.value.name) {
+        return budget.value.name;
+    }
+
+    if (props.nextBudgetNumber) {
+        return props.nextBudgetNumber;
+    }
+
+    return 'Es generarà automàticament en guardar';
 });
 
 const formatCurrency = (value) =>

--- a/resources/js/Pages/Invoices/Create.vue
+++ b/resources/js/Pages/Invoices/Create.vue
@@ -65,15 +65,13 @@
                                 />
                             </div>
                             <div class="space-y-2">
-                                <InputLabel for="invoice-name" value="Nombre interno" />
-                                <TextInput
-                                    id="invoice-name"
-                                    v-model="invoice.name"
-                                    type="text"
-                                    class="mt-2 block w-full"
-                                    placeholder="Factura proforma abril"
-                                    autocomplete="off"
-                                />
+                                <InputLabel value="Número de factura" />
+                                <div class="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700">
+                                    {{ invoiceNumberPreview }}
+                                </div>
+                                <p class="text-xs text-slate-500">
+                                    El codi es genera de manera automàtica i correlativa segons l'any de la data seleccionada.
+                                </p>
                             </div>
                             <div class="space-y-2">
                                 <InputLabel for="client-search" value="Buscar cliente" />
@@ -366,11 +364,15 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+    nextInvoiceNumber: {
+        type: String,
+        default: '',
+    },
 });
 
 const invoice = ref({
     date: new Date().toISOString().split('T')[0],
-    name: '',
+    name: props.nextInvoiceNumber || '',
     state: 'pending',
     client_id: '',
     total: 0,
@@ -404,6 +406,18 @@ const filteredProducts = computed(() => {
             : true;
         return matchesName && matchesCategory;
     });
+});
+
+const invoiceNumberPreview = computed(() => {
+    if (invoice.value.name) {
+        return invoice.value.name;
+    }
+
+    if (props.nextInvoiceNumber) {
+        return props.nextInvoiceNumber;
+    }
+
+    return 'Es generarà automàticament en guardar';
 });
 
 const formatCurrency = (value) =>

--- a/resources/js/Pages/Parts/Create.vue
+++ b/resources/js/Pages/Parts/Create.vue
@@ -23,14 +23,13 @@
 
                         <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
                             <div class="space-y-2">
-                                <InputLabel for="part-reference" value="Referència" />
-                                <TextInput
-                                    id="part-reference"
-                                    v-model="form.reference"
-                                    type="text"
-                                    class="mt-2 block w-full"
-                                    placeholder="Parte instal·lació març"
-                                />
+                                <InputLabel value="Número de parte" />
+                                <div class="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700">
+                                    {{ partReferencePreview }}
+                                </div>
+                                <p class="text-xs text-slate-500">
+                                    Assignem el codi automàticament seguint la seqüència correlativa anual.
+                                </p>
                                 <InputError :message="form.errors.reference" />
                             </div>
                             <div class="space-y-2">
@@ -254,10 +253,11 @@ import AddProductIcon from '@/Components/Icons/AddProductIcon.vue';
 const props = defineProps({
     clients: { type: Array, default: () => [] },
     products: { type: Array, default: () => [] },
+    nextPartReference: { type: String, default: '' },
 });
 
 const form = useForm({
-    reference: '',
+    reference: props.nextPartReference || '',
     date: new Date().toISOString().split('T')[0],
     client_id: '',
     notes: '',
@@ -282,6 +282,18 @@ const availableCategories = computed(() => {
         .filter((category) => Boolean(category));
 
     return Array.from(new Set(categories)).sort((a, b) => a.localeCompare(b, 'ca')); // alphabetical order
+});
+
+const partReferencePreview = computed(() => {
+    if (form.reference) {
+        return form.reference;
+    }
+
+    if (props.nextPartReference) {
+        return props.nextPartReference;
+    }
+
+    return 'Es generarà automàticament en guardar';
 });
 
 const filteredProducts = computed(() => {

--- a/resources/js/Pages/Parts/Index.vue
+++ b/resources/js/Pages/Parts/Index.vue
@@ -208,8 +208,13 @@
                     </div>
                     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <div class="space-y-2">
-                            <InputLabel value="Nom intern" />
-                            <TextInput v-model="invoiceForm.name" type="text" class="mt-1 block w-full" placeholder="Factura mensual" />
+                            <InputLabel value="Número de factura" />
+                            <div class="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700">
+                                {{ invoiceNumberPreview }}
+                            </div>
+                            <p class="text-xs text-slate-500">
+                                El sistema generarà el codi correlatiu segons l'any de la data indicada.
+                            </p>
                         </div>
                         <div class="space-y-2">
                             <InputLabel value="Data" />
@@ -268,6 +273,7 @@ import PrimaryButton from '@/Components/PrimaryButton.vue';
 const props = defineProps({
     parts: { type: Array, default: () => [] },
     clients: { type: Array, default: () => [] },
+    nextInvoiceNumber: { type: String, default: '' },
 });
 
 const filters = reactive({
@@ -280,10 +286,22 @@ const filters = reactive({
 const selectedParts = ref([]);
 const invoiceModalOpen = ref(false);
 const invoiceForm = reactive({
-    name: '',
+    name: props.nextInvoiceNumber || '',
     date: new Date().toISOString().split('T')[0],
     state: 'pending',
     iva: 21,
+});
+
+const invoiceNumberPreview = computed(() => {
+    if (invoiceForm.name) {
+        return invoiceForm.name;
+    }
+
+    if (props.nextInvoiceNumber) {
+        return props.nextInvoiceNumber;
+    }
+
+    return 'Es generarà automàticament en guardar';
 });
 
 const formatCurrency = (value) =>
@@ -369,12 +387,12 @@ const openInvoiceModal = () => {
 
     invoiceModalOpen.value = true;
     if (!invoiceForm.name) {
-        invoiceForm.name = `Factura ${new Date().toLocaleDateString('ca-ES')}`;
+        invoiceForm.name = props.nextInvoiceNumber || '';
     }
 };
 
 const resetInvoiceForm = () => {
-    invoiceForm.name = '';
+    invoiceForm.name = props.nextInvoiceNumber || '';
     invoiceForm.date = new Date().toISOString().split('T')[0];
     invoiceForm.state = 'pending';
     invoiceForm.iva = 21;


### PR DESCRIPTION
## Summary
- add a reusable DocumentNumberGenerator service to build sequential document codes by year and company
- update invoice, budget and part creation (including conversions and copies) to assign automatic identifiers and surface previews in the UI
- adjust the Vue forms so the generated numbers are shown as read-only guidance instead of editable inputs

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68f093d1d688832388e72532d8bb9a0e