### PR TITLE
Add IVA percentage field to products

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -48,6 +48,7 @@ class ProductController extends Controller
             'category_id' => 'required',
             'description' => 'required',
             'price' => 'required|numeric',
+            'iva' => 'required|numeric|min:0|max:100',
             'supplier_id' => 'required',
             'cost_price' => 'required|numeric',
             'stock' => 'required_if:is_stackable,true',
@@ -92,9 +93,10 @@ class ProductController extends Controller
             'name' => 'required',
             'description' => 'required',
             'category_id' => 'required',
-            'price' => 'required',
+            'price' => 'required|numeric',
+            'iva' => 'required|numeric|min:0|max:100',
             'stock' => 'required_if:is_stackable,true',
-            'cost_price' => 'required',
+            'cost_price' => 'required|numeric',
             'supplier_id' => 'required',
             'is_stackable' => 'required'
         ]);

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -10,8 +10,19 @@ class Product extends Model
     use HasFactory;
 
     protected $fillable = [
-        'company_id', 'category_id', 'name', 'description', 'price', 'stock',
-        'supplier_id', 'cost_price', 'is_stackable', 'disabled', 'codebar', 'label_path'
+        'company_id',
+        'category_id',
+        'name',
+        'description',
+        'price',
+        'iva',
+        'stock',
+        'supplier_id',
+        'cost_price',
+        'is_stackable',
+        'disabled',
+        'codebar',
+        'label_path'
     ];
 
     public function company()

--- a/database/migrations/2025_05_06_000001_add_iva_to_products_table.php
+++ b/database/migrations/2025_05_06_000001_add_iva_to_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('iva', 5, 2)->default(21)->after('price');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('iva');
+        });
+    }
+};

--- a/resources/js/Pages/Products/Create.vue
+++ b/resources/js/Pages/Products/Create.vue
@@ -33,6 +33,7 @@ const form = useForm({
     supplier_id: '',
     description: '',
     price: '',
+    iva: 21,
     cost_price: '',
     stock: '',
     is_stackable: false,
@@ -183,6 +184,20 @@ const isInventoryManaged = computed(() => Boolean(form.is_stackable));
                                         class="mt-2 block w-full"
                                     />
                                     <InputError :message="form.errors.price" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="iva" value="IVA (%)" />
+                                    <TextInput
+                                        id="iva"
+                                        v-model="form.iva"
+                                        type="number"
+                                        min="0"
+                                        max="100"
+                                        step="0.01"
+                                        class="mt-2 block w-full"
+                                    />
+                                    <InputError :message="form.errors.iva" class="mt-2" />
                                 </div>
 
                                 <div v-if="isInventoryManaged" class="col-span-6 sm:col-span-3">

--- a/resources/js/Pages/Products/Edit.vue
+++ b/resources/js/Pages/Products/Edit.vue
@@ -36,6 +36,7 @@ const form = useForm({
     supplier_id: props.product.supplier_id ?? '',
     description: props.product.description ?? '',
     price: props.product.price ?? '',
+    iva: props.product.iva ?? 21,
     cost_price: props.product.cost_price ?? '',
     stock: props.product.stock ?? '',
     is_stackable: Boolean(props.product.is_stackable),
@@ -161,6 +162,20 @@ const formattedStock = computed(() => (isInventoryManaged.value ? form.stock || 
                                     <InputLabel for="price" value="Preu de venda" />
                                     <TextInput id="price" v-model="form.price" type="number" min="0" step="0.01" class="mt-2 block w-full" />
                                     <InputError :message="form.errors.price" class="mt-2" />
+                                </div>
+
+                                <div class="col-span-6 sm:col-span-3">
+                                    <InputLabel for="iva" value="IVA (%)" />
+                                    <TextInput
+                                        id="iva"
+                                        v-model="form.iva"
+                                        type="number"
+                                        min="0"
+                                        max="100"
+                                        step="0.01"
+                                        class="mt-2 block w-full"
+                                    />
+                                    <InputError :message="form.errors.iva" class="mt-2" />
                                 </div>
 
                                 <div v-if="isInventoryManaged" class="col-span-6 sm:col-span-3">

--- a/resources/views/pdfs/product_label.blade.php
+++ b/resources/views/pdfs/product_label.blade.php
@@ -50,6 +50,7 @@
     <h2>{{ $product->name }}</h2>
     <p>{{ $product->description }}</p>
     <p>Precio: {{ $product->price }}€</p>
+    <p>IVA: {{ $product->iva }}%</p>
     <p>Código: {{ $product->codebar }}</p>
     <div class="barcode">
         <img src="{{ 'storage/' . $barcodePath }}" alt="Código de Barras">


### PR DESCRIPTION
## Summary
- add an IVA percentage column to products and include it in the model fillable fields
- require IVA in product validations and expose the percentage in create/edit forms
- display the IVA value on generated product labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0a46641208323a17570d1eec3ae4a