### PR TITLE
Add VAT breakdown display across finance documents

### DIFF
--- a/app/Services/DocumentTotalsCalculator.php
+++ b/app/Services/DocumentTotalsCalculator.php
@@ -10,12 +10,19 @@ class DocumentTotalsCalculator
      * Each item must contain quantity, unit_price, optional discount and iva rate.
      *
      * @param  array<int, array<string, mixed>>  $items
-     * @return array{base: float, tax: float, total: float, effectiveRate: float}
+     * @return array{
+     *     base: float,
+     *     tax: float,
+     *     total: float,
+     *     effectiveRate: float,
+     *     taxBreakdown: array<int, array{rate: float, base: float, tax: float}>
+     * }
      */
     public static function calculate(array $items): array
     {
         $base = 0.0;
         $tax = 0.0;
+        $breakdown = [];
 
         foreach ($items as $item) {
             $quantity = self::toFloat($item['quantity'] ?? 0);
@@ -33,6 +40,21 @@ class DocumentTotalsCalculator
 
             $base += $lineBase;
             $tax += $lineTax;
+
+            if ($lineBase > 0 || $lineTax > 0) {
+                $rateKey = number_format($ivaRate, 2, '.', '');
+
+                if (! isset($breakdown[$rateKey])) {
+                    $breakdown[$rateKey] = [
+                        'rate' => round($ivaRate, 2),
+                        'base' => 0.0,
+                        'tax' => 0.0,
+                    ];
+                }
+
+                $breakdown[$rateKey]['base'] += $lineBase;
+                $breakdown[$rateKey]['tax'] += $lineTax;
+            }
         }
 
         $base = round($base, 2);
@@ -40,11 +62,22 @@ class DocumentTotalsCalculator
         $total = round($base + $tax, 2);
         $effectiveRate = $base > 0 ? round(($tax / $base) * 100, 2) : 0.0;
 
+        ksort($breakdown, SORT_NUMERIC);
+
+        $taxBreakdown = array_map(function (array $entry) {
+            return [
+                'rate' => $entry['rate'],
+                'base' => round($entry['base'], 2),
+                'tax' => round($entry['tax'], 2),
+            ];
+        }, array_values($breakdown));
+
         return [
             'base' => $base,
             'tax' => $tax,
             'total' => $total,
             'effectiveRate' => $effectiveRate,
+            'taxBreakdown' => $taxBreakdown,
         ];
     }
 

--- a/resources/js/Pages/Budgets/Create.vue
+++ b/resources/js/Pages/Budgets/Create.vue
@@ -113,6 +113,35 @@
                                 <TextInput :value="formatCurrency(budget.total)" disabled class="mt-2 block w-full text-slate-600" />
                             </div>
                         </div>
+
+                        <div class="space-y-3">
+                            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                Desglose por tipo de IVA
+                            </h3>
+                            <div
+                                v-if="taxBreakdown.length"
+                                class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                            >
+                                <div
+                                    v-for="tier in taxBreakdown"
+                                    :key="tier.rate"
+                                    class="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4"
+                                >
+                                    <p class="text-sm font-semibold text-slate-800">
+                                        {{ formatPercentage(tier.rate) }}
+                                    </p>
+                                    <p class="mt-1 text-xs text-slate-500">
+                                        Base: {{ formatCurrency(tier.base) }}
+                                    </p>
+                                    <p class="text-xs text-slate-500">
+                                        IVA: {{ formatCurrency(tier.tax) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <p v-else class="text-xs text-slate-500">
+                                Agrega líneas al presupuesto para calcular el IVA por cada tipo aplicado.
+                            </p>
+                        </div>
                     </section>
 
                     <section class="space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
@@ -354,6 +383,7 @@ const searchTerm = ref('');
 const selectedCategory = ref('');
 const baseImponible = ref(0);
 const montoIva = ref(0);
+const taxBreakdown = ref([]);
 const clientSearchTerm = ref('');
 
 const totalClients = computed(() => props.clients.length);
@@ -402,18 +432,41 @@ const sanitizeNumber = (value) => Number(value) || 0;
 const calculateTotals = () => {
     let base = 0;
     let tax = 0;
+    const breakdown = {};
 
     budgetItems.value.forEach((item) => {
         const lineBase = sanitizeNumber(item.total);
         const iva = sanitizeNumber(item.iva);
 
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const lineTax = Number(((lineBase * iva) / 100).toFixed(2));
+        const rateKey = iva.toFixed(2);
+
         base += lineBase;
-        tax += (lineBase * iva) / 100;
+        tax += lineTax;
+
+        if (!breakdown[rateKey]) {
+            breakdown[rateKey] = { base: 0, tax: 0 };
+        }
+
+        breakdown[rateKey].base += lineBase;
+        breakdown[rateKey].tax += lineTax;
     });
 
     baseImponible.value = Number(base.toFixed(2));
     montoIva.value = Number(tax.toFixed(2));
     budget.value.total = Number((baseImponible.value + montoIva.value).toFixed(2));
+
+    taxBreakdown.value = Object.entries(breakdown)
+        .map(([rate, amounts]) => ({
+            rate: Number(rate),
+            base: Number(amounts.base.toFixed(2)),
+            tax: Number(amounts.tax.toFixed(2)),
+        }))
+        .sort((a, b) => a.rate - b.rate);
 };
 
 const effectiveIva = computed(() => {

--- a/resources/js/Pages/Budgets/Edit.vue
+++ b/resources/js/Pages/Budgets/Edit.vue
@@ -113,6 +113,35 @@
                                 <TextInput :value="formatCurrency(form.total)" disabled class="mt-2 block w-full text-slate-600" />
                             </div>
                         </div>
+
+                        <div class="space-y-3">
+                            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                Desglose por tipo de IVA
+                            </h3>
+                            <div
+                                v-if="taxBreakdown.length"
+                                class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                            >
+                                <div
+                                    v-for="tier in taxBreakdown"
+                                    :key="tier.rate"
+                                    class="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4"
+                                >
+                                    <p class="text-sm font-semibold text-slate-800">
+                                        {{ formatPercentage(tier.rate) }}
+                                    </p>
+                                    <p class="mt-1 text-xs text-slate-500">
+                                        Base: {{ formatCurrency(tier.base) }}
+                                    </p>
+                                    <p class="text-xs text-slate-500">
+                                        IVA: {{ formatCurrency(tier.tax) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <p v-else class="text-xs text-slate-500">
+                                Añade productos al presupuesto para visualizar el IVA agrupado por tipo.
+                            </p>
+                        </div>
                     </section>
 
                     <section class="space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
@@ -376,6 +405,7 @@ const showProductModal = ref(false);
 const searchTerm = ref('');
 const selectedCategory = ref('');
 const clientSearchTerm = ref('');
+const taxBreakdown = ref([]);
 
 const totalClients = computed(() => props.clients.length);
 const totalProducts = computed(() => props.products.length);
@@ -413,13 +443,28 @@ const sanitizeNumber = (value) => Number(value) || 0;
 const recalculateTotals = () => {
     let base = 0;
     let tax = 0;
+    const breakdown = {};
 
     form.value.items.forEach((item) => {
         const lineBase = sanitizeNumber(item.total);
         const iva = sanitizeNumber(item.iva);
 
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const lineTax = Number(((lineBase * iva) / 100).toFixed(2));
+        const rateKey = iva.toFixed(2);
+
         base += lineBase;
-        tax += (lineBase * iva) / 100;
+        tax += lineTax;
+
+        if (!breakdown[rateKey]) {
+            breakdown[rateKey] = { base: 0, tax: 0 };
+        }
+
+        breakdown[rateKey].base += lineBase;
+        breakdown[rateKey].tax += lineTax;
     });
 
     form.value.base_imponible = Number(base.toFixed(2));
@@ -428,6 +473,14 @@ const recalculateTotals = () => {
     form.value.iva = form.value.base_imponible === 0
         ? 0
         : Number(((form.value.monto_iva / form.value.base_imponible) * 100).toFixed(2));
+
+    taxBreakdown.value = Object.entries(breakdown)
+        .map(([rate, amounts]) => ({
+            rate: Number(rate),
+            base: Number(amounts.base.toFixed(2)),
+            tax: Number(amounts.tax.toFixed(2)),
+        }))
+        .sort((a, b) => a.rate - b.rate);
 };
 
 const effectiveIva = computed(() => form.value.iva || 0);

--- a/resources/js/Pages/Budgets/Print.vue
+++ b/resources/js/Pages/Budgets/Print.vue
@@ -61,10 +61,20 @@
 
         <!-- Budget Totals -->
         <div class="flex justify-end mt-8 text-gray-800">
-            <div class="text-right">
-                <p class="mb-2"><strong>Base Imponible:</strong> {{ budget.base_imponible }}€</p>
-                <p class="mb-2"><strong>IVA (21%):</strong> {{ budget.monto_iva }}€</p>
-                <p class="text-lg font-bold"><strong>Total:</strong> {{ budget.total }}€</p>
+            <div class="text-right space-y-2">
+                <p class="mb-2"><strong>Base Imponible:</strong> {{ formatEuro(budget.base_imponible) }}</p>
+                <div>
+                    <p class="text-sm font-semibold text-gray-700">IVA desglossat:</p>
+                    <ul v-if="taxBreakdown.length" class="mt-1 space-y-1 text-sm">
+                        <li v-for="tier in taxBreakdown" :key="tier.rate" class="leading-tight">
+                            <span class="font-semibold text-gray-800">{{ formatRate(tier.rate) }}</span>
+                            <span class="ml-2">{{ formatEuro(tier.tax) }}</span>
+                            <span class="block text-xs text-gray-500">Base: {{ formatEuro(tier.base) }}</span>
+                        </li>
+                    </ul>
+                    <p v-else class="text-xs text-gray-500">Sense IVA aplicat en aquest pressupost.</p>
+                </div>
+                <p class="text-lg font-bold"><strong>Total:</strong> {{ formatEuro(budget.total) }}</p>
             </div>
         </div>
 
@@ -99,6 +109,9 @@ const toNumber = (value, fallback = 0) => {
     return Number.isFinite(number) ? number : fallback;
 };
 
+const formatEuro = (value) => `${toNumber(value).toFixed(2)}€`;
+const formatRate = (value) => `${toNumber(value).toFixed(2)}%`;
+
 //reducir los decimales a dos de los precios de los productos y de los totales
 const budgetItems = props.budgetItems.map((item) => {
     return {
@@ -113,6 +126,33 @@ const budget = {
     monto_iva: toNumber(props.budget.monto_iva).toFixed(2),
     total: toNumber(props.budget.total).toFixed(2),
 };
+
+const buildTaxBreakdown = (items) => {
+    const map = new Map();
+
+    items.forEach((item) => {
+        const lineBase = toNumber(item.total);
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const rate = toNumber(item.iva);
+        const lineTax = +((lineBase * rate) / 100).toFixed(2);
+        const key = rate.toFixed(2);
+
+        if (!map.has(key)) {
+            map.set(key, { rate: Number(key), base: 0, tax: 0 });
+        }
+
+        const entry = map.get(key);
+        entry.base = +(entry.base + lineBase).toFixed(2);
+        entry.tax = +(entry.tax + lineTax).toFixed(2);
+    });
+
+    return Array.from(map.values()).sort((a, b) => a.rate - b.rate);
+};
+
+const taxBreakdown = buildTaxBreakdown(budgetItems);
 
 const printBudget = () => {
     const element = document.getElementById("invoice"); // Selecciona el contenidor del document

--- a/resources/js/Pages/Invoices/Create.vue
+++ b/resources/js/Pages/Invoices/Create.vue
@@ -132,6 +132,35 @@
                                 />
                             </div>
                         </div>
+
+                        <div class="space-y-3">
+                            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                Desglose por tipo de IVA
+                            </h3>
+                            <div
+                                v-if="taxBreakdown.length"
+                                class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                            >
+                                <div
+                                    v-for="tier in taxBreakdown"
+                                    :key="tier.rate"
+                                    class="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4"
+                                >
+                                    <p class="text-sm font-semibold text-slate-800">
+                                        {{ formatPercentage(tier.rate) }}
+                                    </p>
+                                    <p class="mt-1 text-xs text-slate-500">
+                                        Base: {{ formatCurrency(tier.base) }}
+                                    </p>
+                                    <p class="text-xs text-slate-500">
+                                        IVA: {{ formatCurrency(tier.tax) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <p v-else class="text-xs text-slate-500">
+                                Añade líneas con productos para calcular automáticamente el IVA por tramo.
+                            </p>
+                        </div>
                     </section>
 
                     <section class="space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
@@ -389,6 +418,7 @@ const searchTerm = ref('');
 const selectedCategory = ref('');
 const baseImponible = ref(0);
 const montoIva = ref(0);
+const taxBreakdown = ref([]);
 const clientSearchTerm = ref('');
 
 const totalClients = computed(() => props.clients.length);
@@ -437,18 +467,41 @@ const sanitizeNumber = (value) => Number(value) || 0;
 const recalculateTotals = () => {
     let base = 0;
     let tax = 0;
+    const breakdown = {};
 
     invoiceItems.value.forEach((item) => {
         const lineBase = sanitizeNumber(item.total);
         const iva = sanitizeNumber(item.iva);
 
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const lineTax = Number(((lineBase * iva) / 100).toFixed(2));
+        const rateKey = iva.toFixed(2);
+
         base += lineBase;
-        tax += (lineBase * iva) / 100;
+        tax += lineTax;
+
+        if (!breakdown[rateKey]) {
+            breakdown[rateKey] = { base: 0, tax: 0 };
+        }
+
+        breakdown[rateKey].base += lineBase;
+        breakdown[rateKey].tax += lineTax;
     });
 
     baseImponible.value = Number(base.toFixed(2));
     montoIva.value = Number(tax.toFixed(2));
     invoice.value.total = Number((baseImponible.value + montoIva.value).toFixed(2));
+
+    taxBreakdown.value = Object.entries(breakdown)
+        .map(([rate, amounts]) => ({
+            rate: Number(rate),
+            base: Number(amounts.base.toFixed(2)),
+            tax: Number(amounts.tax.toFixed(2)),
+        }))
+        .sort((a, b) => a.rate - b.rate);
 };
 
 const effectiveIva = computed(() => {

--- a/resources/js/Pages/Invoices/Edit.vue
+++ b/resources/js/Pages/Invoices/Edit.vue
@@ -113,6 +113,35 @@
                                 <TextInput :value="formatCurrency(form.total)" disabled class="mt-2 block w-full text-slate-600" />
                             </div>
                         </div>
+
+                        <div class="space-y-3">
+                            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                Desglose por tipo de IVA
+                            </h3>
+                            <div
+                                v-if="taxBreakdown.length"
+                                class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                            >
+                                <div
+                                    v-for="tier in taxBreakdown"
+                                    :key="tier.rate"
+                                    class="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4"
+                                >
+                                    <p class="text-sm font-semibold text-slate-800">
+                                        {{ formatPercentage(tier.rate) }}
+                                    </p>
+                                    <p class="mt-1 text-xs text-slate-500">
+                                        Base: {{ formatCurrency(tier.base) }}
+                                    </p>
+                                    <p class="text-xs text-slate-500">
+                                        IVA: {{ formatCurrency(tier.tax) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <p v-else class="text-xs text-slate-500">
+                                Añade conceptos con impuestos para consultar el desglose por tramo.
+                            </p>
+                        </div>
                     </section>
 
                     <section class="space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
@@ -376,6 +405,7 @@ const showProductModal = ref(false);
 const searchTerm = ref('');
 const selectedCategory = ref('');
 const clientSearchTerm = ref('');
+const taxBreakdown = ref([]);
 
 const totalClients = computed(() => props.clients.length);
 const totalProducts = computed(() => props.products.length);
@@ -413,13 +443,28 @@ const sanitizeNumber = (value) => Number(value) || 0;
 const recalculateTotals = () => {
     let base = 0;
     let tax = 0;
+    const breakdown = {};
 
     form.value.items.forEach((item) => {
         const lineBase = sanitizeNumber(item.total);
         const iva = sanitizeNumber(item.iva);
 
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const lineTax = Number(((lineBase * iva) / 100).toFixed(2));
+        const rateKey = iva.toFixed(2);
+
         base += lineBase;
-        tax += (lineBase * iva) / 100;
+        tax += lineTax;
+
+        if (!breakdown[rateKey]) {
+            breakdown[rateKey] = { base: 0, tax: 0 };
+        }
+
+        breakdown[rateKey].base += lineBase;
+        breakdown[rateKey].tax += lineTax;
     });
 
     form.value.base_imponible = Number(base.toFixed(2));
@@ -428,6 +473,14 @@ const recalculateTotals = () => {
     form.value.iva = form.value.base_imponible === 0
         ? 0
         : Number(((form.value.monto_iva / form.value.base_imponible) * 100).toFixed(2));
+
+    taxBreakdown.value = Object.entries(breakdown)
+        .map(([rate, amounts]) => ({
+            rate: Number(rate),
+            base: Number(amounts.base.toFixed(2)),
+            tax: Number(amounts.tax.toFixed(2)),
+        }))
+        .sort((a, b) => a.rate - b.rate);
 };
 
 const effectiveIva = computed(() => form.value.iva || 0);

--- a/resources/js/Pages/Invoices/Print.vue
+++ b/resources/js/Pages/Invoices/Print.vue
@@ -62,11 +62,21 @@
 
         <!-- Invoice Totals -->
         <div class="flex justify-end mt-8 text-gray-800">
-            <div class="text-right">
-                <p class="mb-2"><strong>Base Imponible:</strong> {{ invoice.base_imponible }}€</p>
-                <p class="mb-2"><strong>IVA (21%):</strong> {{ invoice.monto_iva }}€</p>
-                <p class="mb-2"><strong>Retenció IRPF (15%):</strong> −{{ retencionIrpf.toFixed(2) }}€</p>
-                <p class="text-lg font-bold mt-2"><strong>Total a pagar:</strong> {{ totalFinal.toFixed(2) }}€</p>
+            <div class="text-right space-y-2">
+                <p class="mb-2"><strong>Base Imponible:</strong> {{ formatEuro(invoice.base_imponible) }}</p>
+                <div>
+                    <p class="text-sm font-semibold text-gray-700">IVA desglossat:</p>
+                    <ul v-if="taxBreakdown.length" class="mt-1 space-y-1 text-sm">
+                        <li v-for="tier in taxBreakdown" :key="tier.rate" class="leading-tight">
+                            <span class="font-semibold text-gray-800">{{ formatRate(tier.rate) }}</span>
+                            <span class="ml-2">{{ formatEuro(tier.tax) }}</span>
+                            <span class="block text-xs text-gray-500">Base: {{ formatEuro(tier.base) }}</span>
+                        </li>
+                    </ul>
+                    <p v-else class="text-xs text-gray-500">Sense IVA aplicat a les línies actuals.</p>
+                </div>
+                <p class="mb-2"><strong>Retenció IRPF (15%):</strong> −{{ formatEuro(retencionIrpf) }}</p>
+                <p class="text-lg font-bold mt-2"><strong>Total a pagar:</strong> {{ formatEuro(totalFinal) }}</p>
             </div>
         </div>
 
@@ -101,6 +111,9 @@ const toNumber = (value, fallback = 0) => {
     return Number.isFinite(number) ? number : fallback;
 };
 
+const formatEuro = (value) => `${toNumber(value).toFixed(2)}€`;
+const formatRate = (value) => `${toNumber(value).toFixed(2)}%`;
+
 // Format price fields
 const invoiceItems = props.invoiceItems.map((item) => {
     return {
@@ -124,6 +137,33 @@ const invoice = {
     monto_iva: montoIva.toFixed(2),
     total: toNumber(props.invoice.total).toFixed(2),
 };
+
+const buildTaxBreakdown = (items) => {
+    const map = new Map();
+
+    items.forEach((item) => {
+        const lineBase = toNumber(item.total);
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const rate = toNumber(item.iva);
+        const lineTax = +((lineBase * rate) / 100).toFixed(2);
+        const key = rate.toFixed(2);
+
+        if (!map.has(key)) {
+            map.set(key, { rate: Number(key), base: 0, tax: 0 });
+        }
+
+        const entry = map.get(key);
+        entry.base = +(entry.base + lineBase).toFixed(2);
+        entry.tax = +(entry.tax + lineTax).toFixed(2);
+    });
+
+    return Array.from(map.values()).sort((a, b) => a.rate - b.rate);
+};
+
+const taxBreakdown = buildTaxBreakdown(invoiceItems);
 
 const printBudget = () => {
     const element = document.getElementById("invoice");

--- a/resources/js/Pages/Parts/Create.vue
+++ b/resources/js/Pages/Parts/Create.vue
@@ -63,6 +63,50 @@
                                 />
                             </div>
                         </div>
+
+                        <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+                            <div class="space-y-2">
+                                <InputLabel value="Base sense IVA" />
+                                <TextInput :value="formatCurrency(partTotal)" disabled class="mt-2 block w-full text-slate-600" />
+                            </div>
+                            <div class="space-y-2">
+                                <InputLabel value="IVA estimat" />
+                                <TextInput :value="formatCurrency(partTaxTotal)" disabled class="mt-2 block w-full text-slate-600" />
+                            </div>
+                            <div class="space-y-2">
+                                <InputLabel value="Total amb IVA" />
+                                <TextInput :value="formatCurrency(partTotalWithTax)" disabled class="mt-2 block w-full text-slate-600" />
+                            </div>
+                        </div>
+
+                        <div class="space-y-3">
+                            <h3 class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                Desglossament per tipus d'IVA
+                            </h3>
+                            <div
+                                v-if="ivaBreakdown.length"
+                                class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                            >
+                                <div
+                                    v-for="tier in ivaBreakdown"
+                                    :key="tier.rate"
+                                    class="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4"
+                                >
+                                    <p class="text-sm font-semibold text-slate-800">
+                                        {{ formatPercentage(tier.rate) }}
+                                    </p>
+                                    <p class="mt-1 text-xs text-slate-500">
+                                        Base: {{ formatCurrency(tier.base) }}
+                                    </p>
+                                    <p class="text-xs text-slate-500">
+                                        IVA: {{ formatCurrency(tier.tax) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <p v-else class="text-xs text-slate-500">
+                                Afegeix productes al parte per calcular automàticament els trams d'IVA aplicats.
+                            </p>
+                        </div>
                     </section>
 
                     <section class="space-y-6 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm">
@@ -274,7 +318,42 @@ const formatCurrency = (value) =>
         currency: 'EUR',
     }).format(Number(value) || 0);
 
+const formatPercentage = (value) => `${Number(value || 0).toFixed(2)}%`;
+
 const partTotal = computed(() => items.value.reduce((total, item) => total + Number(item.total || 0), 0));
+const ivaBreakdown = computed(() => {
+    const breakdown = {};
+
+    items.value.forEach((item) => {
+        const lineBase = Number(item.total) || 0;
+        if (lineBase <= 0) {
+            return;
+        }
+
+        const product = props.products.find((p) => p.id === item.product_id);
+        const ivaRate = Number.isFinite(Number(item.iva)) ? Number(item.iva) : Number(product?.iva ?? 0);
+        const lineTax = Number(((lineBase * ivaRate) / 100).toFixed(2));
+        const rateKey = ivaRate.toFixed(2);
+
+        if (!breakdown[rateKey]) {
+            breakdown[rateKey] = { base: 0, tax: 0 };
+        }
+
+        breakdown[rateKey].base += lineBase;
+        breakdown[rateKey].tax += lineTax;
+    });
+
+    return Object.entries(breakdown)
+        .map(([rate, amounts]) => ({
+            rate: Number(rate),
+            base: Number(amounts.base.toFixed(2)),
+            tax: Number(amounts.tax.toFixed(2)),
+        }))
+        .sort((a, b) => a.rate - b.rate);
+});
+
+const partTaxTotal = computed(() => ivaBreakdown.value.reduce((total, tier) => total + tier.tax, 0));
+const partTotalWithTax = computed(() => Number((partTotal.value + partTaxTotal.value).toFixed(2)));
 
 const availableCategories = computed(() => {
     const categories = props.products
@@ -362,6 +441,7 @@ const onProductSelected = (index) => {
     }
 
     item.unit_price = Number(product.price);
+    item.iva = sanitizeNumber(product.iva);
     if (!item.quantity || sanitizeNumber(item.quantity) < 1) {
         item.quantity = 1;
     }
@@ -389,6 +469,7 @@ const selectProduct = (product) => {
         quantity: 1,
         unit_price: Number(product.price) || 0,
         total: Number(product.price) || 0,
+        iva: sanitizeNumber(product.iva),
     });
 
     form.clearErrors('items');

--- a/resources/views/pdfs/budget.blade.php
+++ b/resources/views/pdfs/budget.blade.php
@@ -134,16 +134,66 @@
         </table>
     </div>
 
+    @php
+        $ivaBreakdown = [];
+
+        foreach ($budget->items as $item) {
+            $lineBase = round($item->total ?? 0, 2);
+
+            if ($lineBase <= 0) {
+                continue;
+            }
+
+            $rate = round($item->iva ?? $item->product->iva ?? 0, 2);
+            $lineTax = round(($lineBase * $rate) / 100, 2);
+            $rateKey = number_format($rate, 2, '.', '');
+
+            if (! isset($ivaBreakdown[$rateKey])) {
+                $ivaBreakdown[$rateKey] = [
+                    'rate' => $rate,
+                    'base' => 0.0,
+                    'tax' => 0.0,
+                ];
+            }
+
+            $ivaBreakdown[$rateKey]['base'] += $lineBase;
+            $ivaBreakdown[$rateKey]['tax'] += $lineTax;
+        }
+
+        ksort($ivaBreakdown, SORT_NUMERIC);
+
+        $ivaBreakdown = array_map(function ($tier) {
+            return [
+                'rate' => $tier['rate'],
+                'base' => round($tier['base'], 2),
+                'tax' => round($tier['tax'], 2),
+            ];
+        }, $ivaBreakdown);
+    @endphp
+
     <div class="totals">
         <table>
             <tr>
                 <th>Base Imponible:</th>
                 <td>${{ number_format($budget->base_imponible, 2) }}</td>
             </tr>
-            <tr>
-                <th>IVA (21%):</th>
-                <td>${{ number_format($budget->monto_iva, 2) }}</td>
-            </tr>
+            @forelse ($ivaBreakdown as $tier)
+                @php
+                    $formattedRate = rtrim(rtrim(number_format($tier['rate'], 2, ',', ''), '0'), ',');
+                @endphp
+                <tr>
+                    <th>IVA ({{ $formattedRate }}%):</th>
+                    <td>
+                        ${{ number_format($tier['tax'], 2) }}<br>
+                        <small>Base: ${{ number_format($tier['base'], 2) }}</small>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <th>IVA:</th>
+                    <td>$0.00</td>
+                </tr>
+            @endforelse
             <tr>
                 <th>Total:</th>
                 <td>${{ number_format($budget->total, 2) }}</td>

--- a/resources/views/pdfs/invoice.blade.php
+++ b/resources/views/pdfs/invoice.blade.php
@@ -135,8 +135,43 @@
     </div>
 
     @php
-        $irpf = $invoice->base_imponible * 0.15;
-        $total_final = $invoice->base_imponible + $invoice->monto_iva - $irpf;
+        $ivaBreakdown = [];
+
+        foreach ($invoice->items as $item) {
+            $lineBase = round($item->total ?? 0, 2);
+
+            if ($lineBase <= 0) {
+                continue;
+            }
+
+            $rate = round($item->iva ?? $item->product->iva ?? 0, 2);
+            $lineTax = round(($lineBase * $rate) / 100, 2);
+            $rateKey = number_format($rate, 2, '.', '');
+
+            if (! isset($ivaBreakdown[$rateKey])) {
+                $ivaBreakdown[$rateKey] = [
+                    'rate' => $rate,
+                    'base' => 0.0,
+                    'tax' => 0.0,
+                ];
+            }
+
+            $ivaBreakdown[$rateKey]['base'] += $lineBase;
+            $ivaBreakdown[$rateKey]['tax'] += $lineTax;
+        }
+
+        ksort($ivaBreakdown, SORT_NUMERIC);
+
+        $ivaBreakdown = array_map(function ($tier) {
+            return [
+                'rate' => $tier['rate'],
+                'base' => round($tier['base'], 2),
+                'tax' => round($tier['tax'], 2),
+            ];
+        }, $ivaBreakdown);
+
+        $irpf = round($invoice->base_imponible * 0.15, 2);
+        $total_final = round($invoice->base_imponible + $invoice->monto_iva - $irpf, 2);
     @endphp
 
     <div class="totals">
@@ -145,10 +180,23 @@
                 <th>Base Imponible:</th>
                 <td>${{ number_format($invoice->base_imponible, 2) }}</td>
             </tr>
-            <tr>
-                <th>IVA (21%):</th>
-                <td>${{ number_format($invoice->monto_iva, 2) }}</td>
-            </tr>
+            @forelse ($ivaBreakdown as $tier)
+                @php
+                    $formattedRate = rtrim(rtrim(number_format($tier['rate'], 2, ',', ''), '0'), ',');
+                @endphp
+                <tr>
+                    <th>IVA ({{ $formattedRate }}%):</th>
+                    <td>
+                        ${{ number_format($tier['tax'], 2) }}<br>
+                        <small>Base: ${{ number_format($tier['base'], 2) }}</small>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <th>IVA:</th>
+                    <td>$0.00</td>
+                </tr>
+            @endforelse
             <tr>
                 <th>Retención IRPF (15%):</th>
                 <td>− ${{ number_format($irpf, 2) }}</td>


### PR DESCRIPTION
## Summary
- extend the totals calculator to return grouped VAT breakdown information
- surface per-rate VAT breakdowns in invoice, budget, and part creation and edit screens, as well as the print views
- show the VAT breakdown by rate in the generated PDF templates for invoices and budgets

## Testing
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68f0bdffcd4483238cfe422aa6f77e2f