### PR TITLE
Restyle PDF document templates

### DIFF
--- a/resources/views/pdfs/budget.blade.php
+++ b/resources/views/pdfs/budget.blade.php
@@ -14,67 +14,106 @@
         body {
             font-family: 'DejaVu Sans', Arial, sans-serif;
             font-size: 10px;
-            color: #333;
-            background-color: #fff;
-            margin: 20px;
+            color: #2f3542;
+            background-color: #f5f6fa;
+            margin: 24px;
         }
 
         header, footer {
             text-align: center;
-            margin-bottom: 20px;
+            margin-bottom: 24px;
+        }
+
+        h1, h2, h3, p {
+            margin: 4px 0;
         }
 
         .container {
             width: 100%;
             max-width: 850px;
             margin: 0 auto;
+            background: #ffffff;
+            padding: 24px;
+            border-radius: 12px;
+            box-shadow: 0 6px 24px rgba(15, 31, 53, 0.08);
         }
 
-        .details, .items, .totals {
-            margin-bottom: 20px;
+        .details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 16px;
+            margin-bottom: 24px;
         }
 
-        h1, h2, h3, p {
-            margin: 5px 0;
+        .items, .totals {
+            margin-bottom: 24px;
         }
 
         .panel {
-            margin-bottom: 20px;
-            background: #ffffff;
-            border: 1px solid #ddd;
-            padding: 10px;
-            border-radius: 5px;
+            border: 1px solid #e5e9f2;
+            border-left: 4px solid #2563eb;
+            padding: 16px;
+            border-radius: 10px;
+            background: #fff;
         }
 
         .panel-heading {
-            font-weight: bold;
-            margin-bottom: 10px;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: #1f2937;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 9px;
         }
 
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 10px;
+            margin-top: 12px;
         }
 
         th, td {
-            border: 1px solid #ddd;
-            padding: 8px;
-            text-align: center;
+            padding: 10px 12px;
+            border-bottom: 1px solid #e5e9f2;
+            text-align: left;
         }
 
         th {
-            background: #3498db;
-            color: #fff;
+            font-weight: 600;
+            font-size: 9px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: #2563eb;
+            background: transparent;
+        }
+
+        .items tbody tr:last-child td {
+            border-bottom: none;
         }
 
         .totals {
-            float: right;
-            width: 50%;
+            max-width: 320px;
+            margin-left: auto;
         }
 
-        .totals th, .totals td {
+        .totals table th {
+            color: #4b5563;
+            width: 55%;
+        }
+
+        .totals table td {
             text-align: right;
+            color: #111827;
+        }
+
+        .totals table tr:last-child th,
+        .totals table tr:last-child td {
+            border-bottom: none;
+        }
+
+        footer p {
+            color: #6b7280;
+            font-size: 9px;
         }
     </style>
 </head>

--- a/resources/views/pdfs/invoice.blade.php
+++ b/resources/views/pdfs/invoice.blade.php
@@ -14,67 +14,106 @@
         body {
             font-family: 'DejaVu Sans', Arial, sans-serif;
             font-size: 10px;
-            color: #333;
-            background-color: #fff;
-            margin: 20px;
+            color: #2f3542;
+            background-color: #f5f6fa;
+            margin: 24px;
         }
 
         header, footer {
             text-align: center;
-            margin-bottom: 20px;
+            margin-bottom: 24px;
+        }
+
+        h1, h2, h3, p {
+            margin: 4px 0;
         }
 
         .container {
             width: 100%;
             max-width: 850px;
             margin: 0 auto;
+            background: #ffffff;
+            padding: 24px;
+            border-radius: 12px;
+            box-shadow: 0 6px 24px rgba(15, 31, 53, 0.08);
         }
 
-        .details, .items, .totals {
-            margin-bottom: 20px;
+        .details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 16px;
+            margin-bottom: 24px;
         }
 
-        h1, h2, h3, p {
-            margin: 5px 0;
+        .items, .totals {
+            margin-bottom: 24px;
         }
 
         .panel {
-            margin-bottom: 20px;
-            background: #ffffff;
-            border: 1px solid #ddd;
-            padding: 10px;
-            border-radius: 5px;
+            border: 1px solid #e5e9f2;
+            border-left: 4px solid #2563eb;
+            padding: 16px;
+            border-radius: 10px;
+            background: #fff;
         }
 
         .panel-heading {
-            font-weight: bold;
-            margin-bottom: 10px;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: #1f2937;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 9px;
         }
 
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 10px;
+            margin-top: 12px;
         }
 
         th, td {
-            border: 1px solid #ddd;
-            padding: 8px;
-            text-align: center;
+            padding: 10px 12px;
+            border-bottom: 1px solid #e5e9f2;
+            text-align: left;
         }
 
         th {
-            background: #3498db;
-            color: #fff;
+            font-weight: 600;
+            font-size: 9px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: #2563eb;
+            background: transparent;
+        }
+
+        .items tbody tr:last-child td {
+            border-bottom: none;
         }
 
         .totals {
-            float: right;
-            width: 50%;
+            max-width: 320px;
+            margin-left: auto;
         }
 
-        .totals th, .totals td {
+        .totals table th {
+            color: #4b5563;
+            width: 55%;
+        }
+
+        .totals table td {
             text-align: right;
+            color: #111827;
+        }
+
+        .totals table tr:last-child th,
+        .totals table tr:last-child td {
+            border-bottom: none;
+        }
+
+        footer p {
+            color: #6b7280;
+            font-size: 9px;
         }
     </style>
 </head>

--- a/resources/views/pdfs/payroll.blade.php
+++ b/resources/views/pdfs/payroll.blade.php
@@ -6,56 +6,68 @@
     <title>Nómina #{{ $payroll->id }}</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'DejaVu Sans', Arial, sans-serif;
             margin: 0;
-            padding: 0;
-            background-color: #f4f4f9;
-            color: #333;
+            padding: 24px;
+            background-color: #f5f6fa;
+            color: #2f3542;
         }
         .container {
             width: 90%;
-            margin: 20px auto;
+            margin: 0 auto;
             background: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            padding: 32px;
+            border-radius: 12px;
+            box-shadow: 0 6px 24px rgba(15, 31, 53, 0.08);
         }
         .header, .footer {
             text-align: center;
-            margin: 20px 0;
+            margin: 24px 0;
         }
         .header h1 {
             margin: 0;
-            color: #0044cc;
+            color: #1f2937;
+            font-size: 20px;
+            letter-spacing: 0.04em;
         }
         .header p {
-            margin: 5px 0;
+            margin: 4px 0;
+            color: #6b7280;
         }
         .section-title {
-            background-color: #0044cc;
-            color: #fff;
-            padding: 10px;
-            margin-top: 20px;
-            border-radius: 4px;
-            font-size: 18px;
+            margin-top: 24px;
+            padding-left: 12px;
+            border-left: 4px solid #2563eb;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #1f2937;
         }
         table {
             width: 100%;
             border-collapse: collapse;
-            margin: 20px 0;
+            margin: 16px 0 0;
         }
         table th, table td {
-            border: 1px solid #ddd;
-            padding: 10px;
+            border-bottom: 1px solid #e5e9f2;
+            padding: 10px 12px;
             text-align: left;
         }
         table th {
-            background-color: #f4f4f9;
-            font-weight: bold;
+            font-weight: 600;
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: #2563eb;
+            background: transparent;
+        }
+        table tr:last-child td {
+            border-bottom: none;
         }
         .footer p {
-            font-size: 14px;
-            color: #777;
+            font-size: 10px;
+            color: #9ca3af;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- apply a clean minimal style to the invoice and budget PDF templates, including lighter typography and card layouts
- update payroll PDF layout to remove vertical table lines and align with the new minimalist aesthetic

## Testing
- not run (not required for CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f0c35675548323980f06558e27f4a2