### PR TITLE
Add PHP-based Verifactu certificate conversion helper

### DIFF
--- a/app/Services/Verifactu/CertificateConverter.php
+++ b/app/Services/Verifactu/CertificateConverter.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services\Verifactu;
+
+use App\Services\Verifactu\Exceptions\CertificateConversionException;
+
+class CertificateConverter
+{
+    /**
+     * Converts the provided PKCS#12 (PFX) certificate into a PEM file that contains
+     * the private key, the public certificate and any intermediate certificates.
+     *
+     * @param  string       $pfxPath         The absolute path to the PFX file that should be converted.
+     * @param  string       $password        The password used to protect the PFX bundle.
+     * @param  string|null  $destinationPath Optional destination. If null a temporary file is created.
+     *
+     * @return string The path to the generated PEM file.
+     */
+    public function convertPfxToPem(string $pfxPath, string $password, ?string $destinationPath = null): string
+    {
+        if (!extension_loaded('openssl')) {
+            throw new CertificateConversionException('The PHP OpenSSL extension is required to convert PKCS#12 certificates.');
+        }
+
+        if (!is_file($pfxPath) || !is_readable($pfxPath)) {
+            throw new CertificateConversionException(sprintf('The PFX file "%s" is not readable.', $pfxPath));
+        }
+
+        $pfxContent = file_get_contents($pfxPath);
+        if ($pfxContent === false) {
+            throw new CertificateConversionException(sprintf('Unable to read the PFX file "%s".', $pfxPath));
+        }
+
+        $certificates = [];
+        if (!openssl_pkcs12_read($pfxContent, $certificates, $password)) {
+            throw new CertificateConversionException('Unable to parse the PFX bundle. Please check the password or file integrity.');
+        }
+
+        $pemContent = $this->buildPemContent($certificates);
+
+        if ($destinationPath === null) {
+            $destinationPath = $this->createTemporaryPemPath();
+        }
+
+        if (file_put_contents($destinationPath, $pemContent) === false) {
+            throw new CertificateConversionException(sprintf('Unable to write the PEM file to "%s".', $destinationPath));
+        }
+
+        @chmod($destinationPath, 0600);
+
+        return $destinationPath;
+    }
+
+    /**
+     * @param  array<string, mixed>  $certificates
+     */
+    private function buildPemContent(array $certificates): string
+    {
+        $segments = [];
+
+        if (!empty($certificates['pkey'])) {
+            $segments[] = $this->normalizePemSegment($certificates['pkey']);
+        }
+
+        if (!empty($certificates['cert'])) {
+            $segments[] = $this->normalizePemSegment($certificates['cert']);
+        }
+
+        if (!empty($certificates['extracerts']) && is_array($certificates['extracerts'])) {
+            foreach ($certificates['extracerts'] as $extraCertificate) {
+                if (!empty($extraCertificate)) {
+                    $segments[] = $this->normalizePemSegment($extraCertificate);
+                }
+            }
+        }
+
+        if (empty($segments)) {
+            throw new CertificateConversionException('The PFX file did not contain any exportable certificates.');
+        }
+
+        return implode(PHP_EOL, $segments) . PHP_EOL;
+    }
+
+    private function normalizePemSegment(string $segment): string
+    {
+        $segment = trim($segment);
+
+        if ($segment === '') {
+            throw new CertificateConversionException('An empty certificate segment was encountered while building the PEM file.');
+        }
+
+        if (!str_contains($segment, '-----BEGIN')) {
+            $segment = "-----BEGIN CERTIFICATE-----\n" . chunk_split(base64_encode($segment), 64, "\n") . "-----END CERTIFICATE-----";
+        }
+
+        return $segment;
+    }
+
+    private function createTemporaryPemPath(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'vf_pem_');
+        if ($path === false) {
+            throw new CertificateConversionException('Unable to create a temporary PEM file.');
+        }
+
+        return $path;
+    }
+}

--- a/app/Services/Verifactu/Exceptions/CertificateConversionException.php
+++ b/app/Services/Verifactu/Exceptions/CertificateConversionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Services\Verifactu\Exceptions;
+
+use RuntimeException;
+
+class CertificateConversionException extends RuntimeException
+{
+}

--- a/tests/Unit/Verifactu/CertificateConverterTest.php
+++ b/tests/Unit/Verifactu/CertificateConverterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit\Verifactu;
+
+use App\Services\Verifactu\CertificateConverter;
+use OpenSSLAsymmetricKey;
+use OpenSSLCertificate;
+use PHPUnit\Framework\TestCase;
+
+class CertificateConverterTest extends TestCase
+{
+    public function testItConvertsPfxToPemWithoutExternalBinary(): void
+    {
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('The OpenSSL extension is required for this test.');
+        }
+
+        $pfxPassword = 'S3cretPass!';
+        $pfxPath = tempnam(sys_get_temp_dir(), 'vf_pfx_');
+        $pemPath = tempnam(sys_get_temp_dir(), 'vf_pem_');
+
+        try {
+            [$certificate, $privateKey] = $this->generateSelfSignedCertificate();
+
+            $exported = openssl_pkcs12_export($certificate, $pfxBundle, $privateKey, $pfxPassword);
+            $this->assertTrue($exported, 'Failed to export the PKCS#12 bundle.');
+
+            $writeResult = file_put_contents($pfxPath, $pfxBundle);
+            $this->assertIsInt($writeResult);
+
+            $converter = new CertificateConverter();
+            $resultPath = $converter->convertPfxToPem($pfxPath, $pfxPassword, $pemPath);
+
+            $this->assertFileExists($resultPath);
+            $pemContent = file_get_contents($resultPath);
+            $this->assertNotFalse($pemContent);
+            $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $pemContent);
+            $this->assertStringContainsString('-----BEGIN CERTIFICATE-----', $pemContent);
+        } finally {
+            @unlink($pfxPath);
+            @unlink($pemPath);
+        }
+    }
+
+    /**
+     * @return array{0: OpenSSLCertificate|resource|string, 1: OpenSSLAsymmetricKey|resource}
+     */
+    private function generateSelfSignedCertificate(): array
+    {
+        $distinguishedName = [
+            'countryName' => 'ES',
+            'stateOrProvinceName' => 'Barcelona',
+            'localityName' => 'Barcelona',
+            'organizationName' => 'Jesty Test Suite',
+            'organizationalUnitName' => 'QA',
+            'commonName' => 'jesty.test',
+            'emailAddress' => 'qa@jesty.test',
+        ];
+
+        $privateKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        $this->assertTrue(is_resource($privateKey) || $privateKey instanceof OpenSSLAsymmetricKey);
+
+        $csr = openssl_csr_new($distinguishedName, $privateKey, ['digest_alg' => 'sha256']);
+        $this->assertNotFalse($csr);
+
+        $certificate = openssl_csr_sign($csr, null, $privateKey, 365, ['digest_alg' => 'sha256']);
+        $this->assertNotFalse($certificate);
+
+        return [$certificate, $privateKey];
+    }
+}


### PR DESCRIPTION
## Summary
- add a Verifactu certificate converter service that relies on PHP's OpenSSL extension instead of hard-coded system binaries
- introduce a dedicated CertificateConversionException for clearer error reporting during certificate preparation
- cover the converter with a unit test that ensures PFX bundles are converted to PEM files without shelling out to external tools

## Testing
- `composer install --no-interaction` *(fails: dependency constraints require PHP <= 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68f8837ff6b88323a711fdb9f0770bc7