### PR TITLE
Implement VeriFactu SOAP client factory with TLS configuration

### DIFF
--- a/app/Services/Verifactu/SoapClientFactory.php
+++ b/app/Services/Verifactu/SoapClientFactory.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Services\Verifactu;
+
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use SoapClient;
+use SoapFault;
+use Throwable;
+
+class SoapClientFactory
+{
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  callable(string, array<string, mixed>): SoapClient|null  $clientCreator
+     */
+    public function __construct(
+        private array $config,
+        private LoggerInterface $logger,
+        private $clientCreator = null
+    ) {
+        $this->clientCreator ??= static fn (string $wsdl, array $options): SoapClient => new SoapClient($wsdl, $options);
+    }
+
+    public function create(string $environment, string $pemPath, string $password, array $overrides = []): SoapClient
+    {
+        $environmentConfig = $this->config['environments'][$environment] ?? null;
+        if ($environmentConfig === null) {
+            throw new InvalidArgumentException(sprintf('Unknown VeriFactu environment "%s".', $environment));
+        }
+
+        $options = $this->buildOptions($environmentConfig, $pemPath, $password, $overrides);
+        $wsdlCandidates = $this->buildWsdlCandidates($environmentConfig);
+
+        $lastException = null;
+
+        foreach ($wsdlCandidates as $index => $wsdl) {
+            try {
+                return ($this->clientCreator)($wsdl, $options);
+            } catch (SoapFault $fault) {
+                $lastException = $fault;
+
+                if ($index === 0 && count($wsdlCandidates) > 1) {
+                    $this->logger->warning(
+                        'Verifactu: error carregant el WSDL remot, utilitzant la còpia local',
+                        [
+                            'fault_code' => $fault->faultcode,
+                            'fault_message' => $fault->getMessage(),
+                        ]
+                    );
+
+                    continue;
+                }
+
+                throw $fault;
+            } catch (Throwable $throwable) {
+                $lastException = $throwable;
+
+                if ($index === 0 && count($wsdlCandidates) > 1) {
+                    $this->logger->warning(
+                        'Verifactu: error carregant el WSDL remot, utilitzant la còpia local',
+                        [
+                            'fault_code' => get_class($throwable),
+                            'fault_message' => $throwable->getMessage(),
+                        ]
+                    );
+
+                    continue;
+                }
+
+                throw $throwable;
+            }
+        }
+
+        if ($lastException instanceof Throwable) {
+            throw $lastException;
+        }
+
+        throw new SoapFault('WSDL', 'Unable to create VeriFactu SOAP client: no WSDL candidates available.');
+    }
+
+    /**
+     * @param  array<string, mixed>  $environmentConfig
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function buildOptions(array $environmentConfig, string $pemPath, string $password, array $overrides = []): array
+    {
+        $defaults = [
+            'trace' => true,
+            'exceptions' => true,
+            'cache_wsdl' => $this->config['wsdl_cache'] ?? (defined('WSDL_CACHE_NONE') ? WSDL_CACHE_NONE : 0),
+            'connection_timeout' => $this->config['connection_timeout'] ?? 30,
+            'local_cert' => $pemPath,
+        ];
+
+        if ($password !== '') {
+            $defaults['passphrase'] = $password;
+        }
+
+        if (!empty($environmentConfig['endpoint'])) {
+            $defaults['location'] = $environmentConfig['endpoint'];
+        }
+
+        $defaults['stream_context'] = $this->mergeStreamContextOptions(
+            $overrides['stream_context'] ?? null,
+            $pemPath,
+            $password
+        );
+
+        unset($overrides['stream_context']);
+
+        return array_replace_recursive($defaults, $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $environmentConfig
+     * @return list<string>
+     */
+    private function buildWsdlCandidates(array $environmentConfig): array
+    {
+        $candidates = [];
+
+        if (!empty($environmentConfig['wsdl'])) {
+            $candidates[] = $environmentConfig['wsdl'];
+        }
+
+        $localCandidates = array_filter([
+            $environmentConfig['local_wsdl'] ?? null,
+            $this->config['local_wsdl'] ?? null,
+        ], static fn (?string $path) => is_string($path) && $path !== '' && is_file($path));
+
+        foreach ($localCandidates as $path) {
+            if (!in_array($path, $candidates, true)) {
+                $candidates[] = $path;
+            }
+        }
+
+        return $candidates;
+    }
+
+    private function mergeStreamContextOptions(mixed $context, string $pemPath, string $password)
+    {
+        if ($context !== null && !is_array($context) && !is_resource($context)) {
+            throw new InvalidArgumentException('The stream_context override must be an array or a resource.');
+        }
+
+        $baseOptions = $this->buildDefaultStreamContextOptions($pemPath, $password);
+        $incomingOptions = [];
+
+        if (is_array($context)) {
+            $incomingOptions = $context;
+        } elseif (is_resource($context)) {
+            $incomingOptions = stream_context_get_options($context);
+        }
+
+        $merged = $this->mergeContextOptions($baseOptions, $incomingOptions);
+
+        return stream_context_create($merged);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDefaultStreamContextOptions(string $pemPath, string $password): array
+    {
+        $sslConfig = $this->config['ssl'] ?? [];
+        $cryptoMethod = $sslConfig['crypto_method'] ?? null;
+        unset($sslConfig['crypto_method']);
+
+        if ($cryptoMethod === null) {
+            $cryptoMethod = defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT')
+                ? STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT
+                : STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+        }
+
+        $sslOptions = array_merge(
+            [
+                'local_cert' => $pemPath,
+                'verify_peer' => $sslConfig['verify_peer'] ?? true,
+                'verify_peer_name' => $sslConfig['verify_peer_name'] ?? true,
+                'allow_self_signed' => $sslConfig['allow_self_signed'] ?? false,
+                'crypto_method' => $cryptoMethod,
+            ],
+            array_filter(
+                [
+                    'passphrase' => $password,
+                    'cafile' => $sslConfig['cafile'] ?? null,
+                    'capath' => $sslConfig['capath'] ?? null,
+                    'ciphers' => $sslConfig['ciphers'] ?? null,
+                ],
+                static fn ($value) => $value !== null && $value !== ''
+            )
+        );
+
+        return ['ssl' => $sslOptions];
+    }
+
+    /**
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function mergeContextOptions(array $base, array $overrides): array
+    {
+        $merged = $base;
+
+        foreach ($overrides as $key => $value) {
+            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = array_replace($merged[$key], $value);
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+}

--- a/config/verifactu.php
+++ b/config/verifactu.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'connection_timeout' => env('VERIFACTU_CONNECTION_TIMEOUT', 30),
+    'wsdl_cache' => env('VERIFACTU_WSDL_CACHE', defined('WSDL_CACHE_NONE') ? WSDL_CACHE_NONE : 0),
+    'local_wsdl' => env('VERIFACTU_LOCAL_WSDL', storage_path('app/verifactu/SistemaFacturacion.wsdl')),
+    'ssl' => [
+        'verify_peer' => env('VERIFACTU_VERIFY_PEER', true),
+        'verify_peer_name' => env('VERIFACTU_VERIFY_PEER_NAME', true),
+        'allow_self_signed' => env('VERIFACTU_ALLOW_SELF_SIGNED', false),
+        'cafile' => env('VERIFACTU_CAFILE'),
+        'capath' => env('VERIFACTU_CAPATH'),
+        'ciphers' => env('VERIFACTU_CIPHERS'),
+        'crypto_method' => env('VERIFACTU_CRYPTO_METHOD'),
+    ],
+    'environments' => [
+        'sandbox' => [
+            'wsdl' => env('VERIFACTU_SANDBOX_WSDL', 'https://prewww1.aeat.es/wlpl/TIKE-CONT/ws/SistemaFacturacion.wsdl'),
+            'endpoint' => env('VERIFACTU_SANDBOX_ENDPOINT'),
+            'local_wsdl' => env('VERIFACTU_SANDBOX_LOCAL_WSDL'),
+        ],
+        'production' => [
+            'wsdl' => env('VERIFACTU_PRODUCTION_WSDL', 'https://www1.aeat.es/wlpl/TIKE-CONT/ws/SistemaFacturacion.wsdl'),
+            'endpoint' => env('VERIFACTU_PRODUCTION_ENDPOINT'),
+            'local_wsdl' => env('VERIFACTU_PRODUCTION_LOCAL_WSDL'),
+        ],
+    ],
+];

--- a/tests/Unit/Verifactu/SoapClientFactoryTest.php
+++ b/tests/Unit/Verifactu/SoapClientFactoryTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Unit\Verifactu;
+
+use App\Services\Verifactu\SoapClientFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use SoapFault;
+
+class SoapClientFactoryTest extends TestCase
+{
+    private string $pemPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $path = tempnam(sys_get_temp_dir(), 'vf_pem_test_');
+        if ($path === false) {
+            $this->fail('Unable to create a temporary PEM file for testing.');
+        }
+
+        file_put_contents($path, <<<PEM
+-----BEGIN CERTIFICATE-----
+RHVtbXkgQ0VSVElGSUNBVEUK-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+RHVtbXkgUFJJVkFURSBLRVkK-----END PRIVATE KEY-----
+PEM);
+
+        $this->pemPath = $path;
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->pemPath);
+        parent::tearDown();
+    }
+
+    public function testItCreatesClientWithCertificateAndTlsOptions(): void
+    {
+        $config = [
+            'connection_timeout' => 25,
+            'wsdl_cache' => 0,
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
+            'environments' => [
+                'sandbox' => [
+                    'wsdl' => 'https://example.test/wsdl',
+                    'endpoint' => 'https://example.test/endpoint',
+                ],
+            ],
+        ];
+
+        $logger = new class extends AbstractLogger {
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = compact('level', 'message', 'context');
+            }
+        };
+
+        $captured = null;
+        $factory = new SoapClientFactory($config, $logger, function (string $wsdl, array $options) use (&$captured) {
+            $captured = compact('wsdl', 'options');
+
+            return new class extends \SoapClient {
+                public function __construct() {}
+            };
+        });
+
+        $client = $factory->create('sandbox', $this->pemPath, 'secret');
+
+        $this->assertInstanceOf(\SoapClient::class, $client);
+        $this->assertSame('https://example.test/wsdl', $captured['wsdl']);
+        $this->assertSame($this->pemPath, $captured['options']['local_cert']);
+        $this->assertSame('secret', $captured['options']['passphrase']);
+        $this->assertSame('https://example.test/endpoint', $captured['options']['location']);
+        $this->assertSame(25, $captured['options']['connection_timeout']);
+
+        $streamOptions = stream_context_get_options($captured['options']['stream_context']);
+        $this->assertSame($this->pemPath, $streamOptions['ssl']['local_cert']);
+        $this->assertSame('secret', $streamOptions['ssl']['passphrase']);
+        $this->assertTrue($streamOptions['ssl']['verify_peer']);
+        $this->assertTrue($streamOptions['ssl']['verify_peer_name']);
+        $this->assertArrayHasKey('crypto_method', $streamOptions['ssl']);
+    }
+
+    public function testItFallsBackToLocalWsdl(): void
+    {
+        $localWsdl = tempnam(sys_get_temp_dir(), 'vf_wsdl_');
+        if ($localWsdl === false) {
+            $this->fail('Unable to create a temporary WSDL file.');
+        }
+
+        file_put_contents($localWsdl, '<definitions></definitions>');
+
+        $config = [
+            'environments' => [
+                'sandbox' => [
+                    'wsdl' => 'https://example.test/wsdl',
+                    'local_wsdl' => $localWsdl,
+                ],
+            ],
+        ];
+
+        $logger = new class extends AbstractLogger {
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = compact('level', 'message', 'context');
+            }
+        };
+
+        $attempts = [];
+        $factory = new SoapClientFactory($config, $logger, function (string $wsdl, array $options) use (&$attempts, $localWsdl) {
+            $attempts[] = $wsdl;
+
+            if ($wsdl !== $localWsdl) {
+                throw new SoapFault('WSDL', 'remote unavailable');
+            }
+
+            return new class extends \SoapClient {
+                public function __construct() {}
+            };
+        });
+
+        $factory->create('sandbox', $this->pemPath, 'secret');
+
+        $this->assertSame(['https://example.test/wsdl', $localWsdl], $attempts);
+        $this->assertNotEmpty($logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+        $this->assertSame('Verifactu: error carregant el WSDL remot, utilitzant la còpia local', $logger->records[0]['message']);
+        $this->assertSame('WSDL', $logger->records[0]['context']['fault_code']);
+        $this->assertSame('remote unavailable', $logger->records[0]['context']['fault_message']);
+
+        @unlink($localWsdl);
+    }
+
+    public function testItThrowsWhenEnvironmentIsUnknown(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $logger = new class extends AbstractLogger {
+            public function log($level, $message, array $context = []): void {}
+        };
+
+        $factory = new SoapClientFactory(['environments' => []], $logger);
+        $factory->create('missing', $this->pemPath, 'secret');
+    }
+
+    public function testStreamContextOverrideMergesWithDefaults(): void
+    {
+        $config = [
+            'ssl' => [
+                'verify_peer' => true,
+            ],
+            'environments' => [
+                'sandbox' => [
+                    'wsdl' => 'https://example.test/wsdl',
+                ],
+            ],
+        ];
+
+        $logger = new class extends AbstractLogger {
+            public function log($level, $message, array $context = []): void {}
+        };
+
+        $captured = null;
+        $factory = new SoapClientFactory($config, $logger, function (string $wsdl, array $options) use (&$captured) {
+            $captured = $options;
+
+            return new class extends \SoapClient {
+                public function __construct() {}
+            };
+        });
+
+        $factory->create('sandbox', $this->pemPath, 'secret', [
+            'stream_context' => [
+                'ssl' => [
+                    'verify_peer' => false,
+                    'ciphers' => 'DEFAULT',
+                ],
+            ],
+        ]);
+
+        $options = stream_context_get_options($captured['stream_context']);
+        $this->assertFalse($options['ssl']['verify_peer']);
+        $this->assertSame('DEFAULT', $options['ssl']['ciphers']);
+        $this->assertSame($this->pemPath, $options['ssl']['local_cert']);
+        $this->assertSame('secret', $options['ssl']['passphrase']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `config/verifactu.php` file to centralise endpoints, SSL flags, and local WSDL overrides
- introduce `SoapClientFactory` to build SOAP clients with the VeriFactu certificate, TLS 1.2+ crypto settings, and logging-backed WSDL fallbacks
- cover the factory with unit tests that assert TLS options, WSDL fallback behaviour, and stream context overrides

## Testing
- `composer install --no-interaction --no-progress` *(fails: dependency constraints require PHP ≤ 8.3)*
- `./vendor/bin/phpunit` *(not run: vendor directory unavailable after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68f889ea83948323ab58028b6fd6e1bc