### PR TITLE
Add async status updates for budgets and invoices

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
 use App\Services\DocumentNumberGenerator;
+use Illuminate\Validation\Rule;
 
 class BudgetController extends Controller
 {
@@ -238,6 +239,46 @@ class BudgetController extends Controller
         }
 
         return Inertia::location(route('budgets.index'));
+    }
+
+    public function updateStatus(Request $request, Budget $budget)
+    {
+        if ($budget->company_id !== Auth::user()->company_id) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'state' => ['required', Rule::in(['accepted', 'in_process', 'rejected'])],
+        ]);
+
+        $previousState = $budget->state;
+
+        if ($previousState !== $validated['state']) {
+            $budget->forceFill(['state' => $validated['state']])->save();
+
+            if ($budget->state === 'accepted') {
+                app(UserNotificationController::class)->createNotification(
+                    'Presupuesto aceptado ID: ' . $budget->id,
+                    'Se ha aceptado un presupuesto.',
+                    'Facturación'
+                );
+            } elseif ($budget->state === 'rejected') {
+                app(UserNotificationController::class)->createNotification(
+                    'Presupuesto rechazado ID: ' . $budget->id,
+                    'Se ha rechazado un presupuesto.',
+                    'Facturación'
+                );
+            }
+        }
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'message' => 'Estado del presupuesto actualizado correctamente.',
+                'budget' => $budget->fresh(),
+            ]);
+        }
+
+        return back()->with('success', 'Estado del presupuesto actualizado correctamente.');
     }
 
     public function destroy(Budget $budget)

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
 use Barryvdh\DomPDF\Facade\Pdf; // Importa DomPDF
+use Illuminate\Validation\Rule;
 use phpseclib3\Crypt\RSA;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\PdfParser\StreamReader;
@@ -246,6 +247,47 @@ class InvoiceController extends Controller
 
 
         return Inertia::location(route('invoices.index'));
+    }
+
+    public function updateStatus(Request $request, Invoice $invoice)
+    {
+        if ($invoice->company_id !== Auth::user()->company_id) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'state' => ['required', Rule::in(['paid', 'pending', 'cancelled'])],
+        ]);
+
+        $previousState = $invoice->state;
+
+        if ($previousState !== $validated['state']) {
+            $invoice->forceFill(['state' => $validated['state']])->save();
+
+            if ($previousState === 'paid' && $invoice->state !== 'paid') {
+                $this->destroyIncomeFromInvoice($invoice);
+            }
+
+            if ($invoice->state === 'paid') {
+                $this->destroyIncomeFromInvoice($invoice);
+                $this->createIncomeFromInvoice($invoice);
+            } elseif ($invoice->state === 'cancelled') {
+                app(UserNotificationController::class)->createNotification(
+                    'Factura cancelada',
+                    'Se ha cancelado una factura',
+                    'Facturación'
+                );
+            }
+        }
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'message' => 'Estado de la factura actualizado correctamente.',
+                'invoice' => $invoice->fresh(),
+            ]);
+        }
+
+        return back()->with('success', 'Estado de la factura actualizado correctamente.');
     }
 
     public function destroy(Invoice $invoice)

--- a/resources/js/Components/StatusUpdateModal.vue
+++ b/resources/js/Components/StatusUpdateModal.vue
@@ -1,0 +1,165 @@
+<script setup>
+import { computed } from 'vue';
+import Modal from '@/Components/Modal.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+
+const props = defineProps({
+    show: {
+        type: Boolean,
+        default: false,
+    },
+    title: {
+        type: String,
+        default: 'Actualitzar estat',
+    },
+    documentName: {
+        type: String,
+        default: '',
+    },
+    currentStatusLabel: {
+        type: String,
+        default: '',
+    },
+    currentStatusClass: {
+        type: String,
+        default: '',
+    },
+    options: {
+        type: Array,
+        default: () => [],
+    },
+    modelValue: {
+        type: String,
+        default: '',
+    },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
+    confirmDisabled: {
+        type: Boolean,
+        default: false,
+    },
+    confirmLabel: {
+        type: String,
+        default: 'Actualitzar estat',
+    },
+    error: {
+        type: String,
+        default: '',
+    },
+});
+
+const emit = defineEmits(['close', 'confirm', 'update:modelValue']);
+
+const selected = computed({
+    get: () => props.modelValue,
+    set: (value) => emit('update:modelValue', value),
+});
+
+const computedCurrentStatusClass = computed(() => {
+    if (props.currentStatusClass) {
+        return props.currentStatusClass;
+    }
+
+    return 'inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-inset ring-slate-300/60 shadow-sm';
+});
+</script>
+
+<template>
+    <Modal :show="show" max-width="lg" @close="emit('close')">
+        <div class="relative rounded-lg bg-white p-6 shadow-2xl">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                    <h2 class="text-lg font-semibold text-slate-800">
+                        {{ title || 'Actualitzar estat' }}
+                    </h2>
+                    <p v-if="documentName" class="mt-1 text-sm text-slate-500">
+                        Document seleccionat: <span class="font-medium text-slate-700">{{ documentName }}</span>
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    class="-mr-2 -mt-2 inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                    @click="emit('close')"
+                    :disabled="loading"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                        <path fill-rule="evenodd" d="M5.47 5.47a.75.75 0 0 1 1.06 0L12 10.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L13.06 12l5.47 5.47a.75.75 0 0 1-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                    </svg>
+                </button>
+            </div>
+
+            <div class="mt-6 rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Estat actual</p>
+                <span :class="[computedCurrentStatusClass, 'mt-3 w-fit']">
+                    {{ currentStatusLabel || 'Sense estat' }}
+                </span>
+            </div>
+
+            <div class="mt-6">
+                <p class="text-sm font-medium text-slate-600">Selecciona un nou estat disponible:</p>
+                <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <button
+                        v-for="option in options"
+                        :key="option.value"
+                        type="button"
+                        class="flex flex-col gap-3 rounded-2xl border bg-white p-4 text-left shadow-sm transition"
+                        :class="[
+                            option.value === selected
+                                ? 'border-sky-500 ring-2 ring-sky-200/60'
+                                : 'border-slate-200 hover:border-sky-400 hover:shadow-md',
+                        ]"
+                        @click="selected = option.value"
+                        :disabled="loading"
+                    >
+                        <div class="flex items-center justify-between">
+                            <span class="text-sm font-semibold text-slate-700">{{ option.label }}</span>
+                            <span v-if="option.value === selected" class="text-sky-500">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
+                                    <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.25 7.338a1 1 0 0 1-1.434.012l-3.492-3.5a1 1 0 1 1 1.414-1.414l2.772 2.778 6.536-6.613a1 1 0 0 1 1.448-.015Z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </div>
+                        <span
+                            :class="[
+                                'inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset',
+                                option.badgeClass || 'bg-slate-100 text-slate-600 ring-slate-300/60',
+                            ]"
+                        >
+                            {{ option.label }}
+                        </span>
+                        <p v-if="option.description" class="text-xs leading-relaxed text-slate-500">
+                            {{ option.description }}
+                        </p>
+                    </button>
+                </div>
+                <p v-if="error" class="mt-2 text-sm text-rose-600">{{ error }}</p>
+            </div>
+
+            <div class="mt-8 flex items-center justify-end gap-3">
+                <SecondaryButton type="button" @click="emit('close')" :disabled="loading">
+                    Cancel·lar
+                </SecondaryButton>
+                <button
+                    type="button"
+                    class="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-sky-500 via-sky-600 to-blue-700 px-5 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white shadow-lg shadow-sky-900/30 transition ease-in-out duration-200 disabled:cursor-not-allowed disabled:opacity-70"
+                    :disabled="loading || confirmDisabled"
+                    @click="emit('confirm')"
+                >
+                    <svg
+                        v-if="loading"
+                        class="h-5 w-5 animate-spin"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                    >
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                    </svg>
+                    <span>{{ confirmLabel }}</span>
+                </button>
+            </div>
+        </div>
+    </Modal>
+</template>

--- a/resources/js/Pages/Budgets/Index.vue
+++ b/resources/js/Pages/Budgets/Index.vue
@@ -1,5 +1,40 @@
 <template>
     <AppLayout>
+        <transition
+            enter-active-class="duration-300 ease-out"
+            enter-from-class="translate-y-2 opacity-0"
+            enter-to-class="translate-y-0 opacity-100"
+            leave-active-class="duration-200 ease-in"
+            leave-from-class="translate-y-0 opacity-100"
+            leave-to-class="translate-y-2 opacity-0"
+        >
+            <div v-if="toast.show" class="fixed right-6 top-24 z-[60] w-80">
+                <div :class="toastContainerClasses">
+                    <span :class="toastIconClasses">
+                        <svg v-if="toast.variant === 'error'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                            <path fill-rule="evenodd" d="M10.29 3.86a2 2 0 0 1 3.42 0l7.162 12.321c.73 1.257-.174 2.819-1.71 2.819H4.838c-1.536 0-2.44-1.562-1.71-2.819L10.29 3.86Zm1.71 4.64a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 1.5 0v-4.5Zm-.75 8.25a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" clip-rule="evenodd" />
+                        </svg>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                            <path fill-rule="evenodd" d="M2.25 12a9.75 9.75 0 1 1 19.5 0 9.75 9.75 0 0 1-19.5 0Zm14.28-1.53a.75.75 0 0 0-1.06-1.06l-4.72 4.72-1.94-1.94a.75.75 0 1 0-1.06 1.06l2.47 2.47a.75.75 0 0 0 1.06 0l5.25-5.25Z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
+                    <div class="flex-1">
+                        <p class="text-sm font-semibold text-slate-700">{{ toastTitle }}</p>
+                        <p class="mt-1 text-sm text-slate-500">{{ toast.message }}</p>
+                    </div>
+                    <button
+                        type="button"
+                        class="-mr-2 -mt-2 inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                        @click="dismissToast"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4">
+                            <path fill-rule="evenodd" d="M5.47 5.47a.75.75 0 0 1 1.06 0L12 10.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L13.06 12l5.47 5.47a.75.75 0 0 1-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </transition>
+
         <div class="min-h-screen bg-slate-900">
             <div class="bg-gradient-to-r from-blue-600 via-indigo-600 to-slate-900 pb-20">
                 <div class="max-w-7xl mx-auto px-6 pt-12">
@@ -113,7 +148,16 @@
                                     <td class="px-6 py-4">{{ getClientName(budget.client_id) || '—' }}</td>
                                     <td class="px-6 py-4">{{ formatDate(budget.date) }}</td>
                                     <td class="px-6 py-4">
-                                        <span :class="statusBadgeClasses(budget.state)">{{ statusCopy(budget.state) }}</span>
+                                        <span
+                                            :class="[statusBadgeClasses(budget.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
+                                            role="button"
+                                            tabindex="0"
+                                            @click="openBudgetStatusModal(budget)"
+                                            @keydown.enter.prevent="openBudgetStatusModal(budget)"
+                                            @keydown.space.prevent="openBudgetStatusModal(budget)"
+                                        >
+                                            {{ statusCopy(budget.state) }}
+                                        </span>
                                     </td>
                                     <td class="px-6 py-4 font-semibold text-slate-700">{{ formatCurrency(budget.total) }}</td>
                                     <td class="px-6 py-4">
@@ -139,23 +183,159 @@
                 </div>
             </div>
         </div>
+
+        <StatusUpdateModal
+            :show="showBudgetStatusModal"
+            title="Actualitzar estat del pressupost"
+            :document-name="selectedBudget ? selectedBudget.name : ''"
+            :current-status-label="selectedBudget ? statusCopy(selectedBudget.state) : ''"
+            :current-status-class="selectedBudget ? statusBadgeClasses(selectedBudget.state) : ''"
+            :options="budgetStatusOptions"
+            v-model="budgetStatusForm.state"
+            :loading="budgetStatusForm.processing"
+            :confirm-disabled="!canSubmitBudgetStatus"
+            :error="budgetStatusForm.errors.state"
+            confirm-label="Actualitzar estat"
+            @close="closeBudgetStatusModal"
+            @confirm="submitBudgetStatus"
+        />
     </AppLayout>
 </template>
 
 <script setup>
 import { Inertia } from '@inertiajs/inertia';
+import { router, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import NavLink from "@/Components/NavLink.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
-import { computed, reactive } from 'vue';
+import StatusUpdateModal from '@/Components/StatusUpdateModal.vue';
+import { computed, reactive, ref } from 'vue';
 
 const props = defineProps({
     budgets: Array,
     clients: Array,
 });
+
+const budgetStatusOptions = [
+    {
+        value: 'accepted',
+        label: 'Aceptado',
+        badgeClass: 'bg-emerald-100 text-emerald-700 ring-emerald-500/30',
+        description: 'Confirma que el presupuesto ha sido aprobado por el cliente.',
+    },
+    {
+        value: 'in_process',
+        label: 'En proceso',
+        badgeClass: 'bg-blue-100 text-blue-700 ring-blue-500/30',
+        description: 'Mantén el presupuesto en revisión mientras se negocian los detalles.',
+    },
+    {
+        value: 'rejected',
+        label: 'Rechazado',
+        badgeClass: 'bg-rose-100 text-rose-700 ring-rose-500/30',
+        description: 'Marca el presupuesto como rechazado para registrar el resultado.',
+    },
+];
+
+const showBudgetStatusModal = ref(false);
+const selectedBudget = ref(null);
+const budgetStatusForm = useForm({
+    state: '',
+});
+
+const toast = reactive({
+    show: false,
+    message: '',
+    variant: 'success',
+});
+
+let toastTimeout;
+
+const toastTitle = computed(() => (toast.variant === 'error' ? 'Hi ha hagut un problema' : 'Estat actualitzat'));
+
+const toastContainerClasses = computed(() => {
+    const base = 'flex w-full items-start gap-3 rounded-2xl border px-4 py-4 shadow-xl backdrop-blur bg-white/95';
+    return toast.variant === 'error' ? `${base} border-rose-200` : `${base} border-emerald-200`;
+});
+
+const toastIconClasses = computed(() =>
+    toast.variant === 'error'
+        ? 'flex h-9 w-9 items-center justify-center rounded-xl bg-rose-500/10 text-rose-500'
+        : 'flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500'
+);
+
+const showToast = (message, variant = 'success') => {
+    toast.message = message;
+    toast.variant = variant;
+    toast.show = true;
+
+    if (toastTimeout) {
+        clearTimeout(toastTimeout);
+    }
+
+    toastTimeout = setTimeout(() => {
+        toast.show = false;
+        toastTimeout = null;
+    }, 3200);
+};
+
+const dismissToast = () => {
+    toast.show = false;
+    if (toastTimeout) {
+        clearTimeout(toastTimeout);
+        toastTimeout = null;
+    }
+};
+
+const openBudgetStatusModal = (budget) => {
+    selectedBudget.value = budget;
+    budgetStatusForm.state = budget.state;
+    budgetStatusForm.clearErrors();
+    showBudgetStatusModal.value = true;
+};
+
+const closeBudgetStatusModal = () => {
+    showBudgetStatusModal.value = false;
+    budgetStatusForm.clearErrors();
+    selectedBudget.value = null;
+};
+
+const canSubmitBudgetStatus = computed(() => {
+    if (!selectedBudget.value) {
+        return false;
+    }
+
+    return budgetStatusForm.state !== '' && budgetStatusForm.state !== selectedBudget.value.state;
+});
+
+const submitBudgetStatus = () => {
+    if (!selectedBudget.value || !canSubmitBudgetStatus.value) {
+        return;
+    }
+
+    budgetStatusForm.patch(route('budgets.updateStatus', selectedBudget.value.id), {
+        preserveScroll: true,
+        onSuccess: () => {
+            router.reload({
+                only: ['budgets'],
+                preserveScroll: true,
+                onSuccess: () => {
+                    showToast('Estat del pressupost actualitzat correctament.');
+                    closeBudgetStatusModal();
+                },
+                onError: () => {
+                    showToast('No s\'ha pogut refrescar la llista de pressupostos.', 'error');
+                },
+            });
+        },
+        onError: () => {
+            showToast('No s\'ha pogut actualitzar l\'estat del pressupost.', 'error');
+        },
+    });
+};
 
 const filters = reactive({
     state: '',
@@ -216,15 +396,17 @@ const statusCopy = (state) => {
 };
 
 const statusBadgeClasses = (state) => {
+    const base = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shadow-sm ring-1 ring-inset';
+
     switch (state) {
         case 'accepted':
-            return 'inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700';
+            return `${base} bg-emerald-100 text-emerald-700 ring-emerald-500/30`;
         case 'in_process':
-            return 'inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700';
+            return `${base} bg-blue-100 text-blue-700 ring-blue-500/30`;
         case 'rejected':
-            return 'inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-700';
+            return `${base} bg-rose-100 text-rose-700 ring-rose-500/30`;
         default:
-            return 'inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600';
+            return `${base} bg-slate-100 text-slate-600 ring-slate-300/60`;
     }
 };
 

--- a/resources/js/Pages/Invoices/Index.vue
+++ b/resources/js/Pages/Invoices/Index.vue
@@ -1,5 +1,40 @@
 <template>
     <AppLayout>
+        <transition
+            enter-active-class="duration-300 ease-out"
+            enter-from-class="translate-y-2 opacity-0"
+            enter-to-class="translate-y-0 opacity-100"
+            leave-active-class="duration-200 ease-in"
+            leave-from-class="translate-y-0 opacity-100"
+            leave-to-class="translate-y-2 opacity-0"
+        >
+            <div v-if="toast.show" class="fixed right-6 top-24 z-[60] w-80">
+                <div :class="toastContainerClasses">
+                    <span :class="toastIconClasses">
+                        <svg v-if="toast.variant === 'error'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                            <path fill-rule="evenodd" d="M10.29 3.86a2 2 0 0 1 3.42 0l7.162 12.321c.73 1.257-.174 2.819-1.71 2.819H4.838c-1.536 0-2.44-1.562-1.71-2.819L10.29 3.86Zm1.71 4.64a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 1.5 0v-4.5Zm-.75 8.25a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" clip-rule="evenodd" />
+                        </svg>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                            <path fill-rule="evenodd" d="M2.25 12a9.75 9.75 0 1 1 19.5 0 9.75 9.75 0 0 1-19.5 0Zm14.28-1.53a.75.75 0 0 0-1.06-1.06l-4.72 4.72-1.94-1.94a.75.75 0 1 0-1.06 1.06l2.47 2.47a.75.75 0 0 0 1.06 0l5.25-5.25Z" clip-rule="evenodd" />
+                        </svg>
+                    </span>
+                    <div class="flex-1">
+                        <p class="text-sm font-semibold text-slate-700">{{ toastTitle }}</p>
+                        <p class="mt-1 text-sm text-slate-500">{{ toast.message }}</p>
+                    </div>
+                    <button
+                        type="button"
+                        class="-mr-2 -mt-2 inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                        @click="dismissToast"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4">
+                            <path fill-rule="evenodd" d="M5.47 5.47a.75.75 0 0 1 1.06 0L12 10.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L13.06 12l5.47 5.47a.75.75 0 0 1-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </transition>
+
         <div class="min-h-screen bg-slate-900">
             <div class="bg-gradient-to-r from-sky-600 via-blue-600 to-slate-900 pb-20">
                 <div class="max-w-7xl mx-auto px-6 pt-12">
@@ -118,7 +153,16 @@
                                     <td class="px-6 py-4">{{ getClientName(invoice.client_id) || '—' }}</td>
                                     <td class="px-6 py-4">{{ formatDate(invoice.date) }}</td>
                                     <td class="px-6 py-4">
-                                        <span :class="statusBadgeClasses(invoice.state)">{{ statusCopy(invoice.state) }}</span>
+                                        <span
+                                            :class="[statusBadgeClasses(invoice.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
+                                            role="button"
+                                            tabindex="0"
+                                            @click="openInvoiceStatusModal(invoice)"
+                                            @keydown.enter.prevent="openInvoiceStatusModal(invoice)"
+                                            @keydown.space.prevent="openInvoiceStatusModal(invoice)"
+                                        >
+                                            {{ statusCopy(invoice.state) }}
+                                        </span>
                                     </td>
                                     <td class="px-6 py-4 font-semibold text-slate-700">{{ formatCurrency(invoice.total) }}</td>
                                     <td class="px-6 py-4">
@@ -144,23 +188,159 @@
                 </div>
             </div>
         </div>
+
+        <StatusUpdateModal
+            :show="showInvoiceStatusModal"
+            title="Actualitzar estat de la factura"
+            :document-name="selectedInvoice ? selectedInvoice.name : ''"
+            :current-status-label="selectedInvoice ? statusCopy(selectedInvoice.state) : ''"
+            :current-status-class="selectedInvoice ? statusBadgeClasses(selectedInvoice.state) : ''"
+            :options="invoiceStatusOptions"
+            v-model="invoiceStatusForm.state"
+            :loading="invoiceStatusForm.processing"
+            :confirm-disabled="!canSubmitInvoiceStatus"
+            :error="invoiceStatusForm.errors.state"
+            confirm-label="Actualitzar estat"
+            @close="closeInvoiceStatusModal"
+            @confirm="submitInvoiceStatus"
+        />
     </AppLayout>
 </template>
 
 <script setup>
 import { Inertia } from '@inertiajs/inertia';
+import { router, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import NavLink from "@/Components/NavLink.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
-import { computed, ref } from "vue";
+import StatusUpdateModal from '@/Components/StatusUpdateModal.vue';
+import { computed, reactive, ref } from "vue";
 
 const props = defineProps({
     invoices: Array,
     clients: Array,
 });
+
+const invoiceStatusOptions = [
+    {
+        value: 'paid',
+        label: 'Pagado',
+        badgeClass: 'bg-emerald-100 text-emerald-700 ring-emerald-500/30',
+        description: 'Marca la factura como cobrada y registra el ingreso asociado.',
+    },
+    {
+        value: 'pending',
+        label: 'Pendiente',
+        badgeClass: 'bg-amber-100 text-amber-700 ring-amber-500/30',
+        description: 'Mantén la factura abierta hasta recibir el pago del cliente.',
+    },
+    {
+        value: 'cancelled',
+        label: 'Cancelado',
+        badgeClass: 'bg-rose-100 text-rose-700 ring-rose-500/30',
+        description: 'Anula la factura y deja constancia de que no generará cobro.',
+    },
+];
+
+const showInvoiceStatusModal = ref(false);
+const selectedInvoice = ref(null);
+const invoiceStatusForm = useForm({
+    state: '',
+});
+
+const toast = reactive({
+    show: false,
+    message: '',
+    variant: 'success',
+});
+
+let toastTimeout;
+
+const toastTitle = computed(() => (toast.variant === 'error' ? 'Hi ha hagut un problema' : 'Estat actualitzat'));
+
+const toastContainerClasses = computed(() => {
+    const base = 'flex w-full items-start gap-3 rounded-2xl border px-4 py-4 shadow-xl backdrop-blur bg-white/95';
+    return toast.variant === 'error' ? `${base} border-rose-200` : `${base} border-emerald-200`;
+});
+
+const toastIconClasses = computed(() =>
+    toast.variant === 'error'
+        ? 'flex h-9 w-9 items-center justify-center rounded-xl bg-rose-500/10 text-rose-500'
+        : 'flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500'
+);
+
+const showToast = (message, variant = 'success') => {
+    toast.message = message;
+    toast.variant = variant;
+    toast.show = true;
+
+    if (toastTimeout) {
+        clearTimeout(toastTimeout);
+    }
+
+    toastTimeout = setTimeout(() => {
+        toast.show = false;
+        toastTimeout = null;
+    }, 3200);
+};
+
+const dismissToast = () => {
+    toast.show = false;
+    if (toastTimeout) {
+        clearTimeout(toastTimeout);
+        toastTimeout = null;
+    }
+};
+
+const openInvoiceStatusModal = (invoice) => {
+    selectedInvoice.value = invoice;
+    invoiceStatusForm.state = invoice.state;
+    invoiceStatusForm.clearErrors();
+    showInvoiceStatusModal.value = true;
+};
+
+const closeInvoiceStatusModal = () => {
+    showInvoiceStatusModal.value = false;
+    invoiceStatusForm.clearErrors();
+    selectedInvoice.value = null;
+};
+
+const canSubmitInvoiceStatus = computed(() => {
+    if (!selectedInvoice.value) {
+        return false;
+    }
+
+    return invoiceStatusForm.state !== '' && invoiceStatusForm.state !== selectedInvoice.value.state;
+});
+
+const submitInvoiceStatus = () => {
+    if (!selectedInvoice.value || !canSubmitInvoiceStatus.value) {
+        return;
+    }
+
+    invoiceStatusForm.patch(route('invoices.updateStatus', selectedInvoice.value.id), {
+        preserveScroll: true,
+        onSuccess: () => {
+            router.reload({
+                only: ['invoices'],
+                preserveScroll: true,
+                onSuccess: () => {
+                    showToast('Estat de la factura actualitzat correctament.');
+                    closeInvoiceStatusModal();
+                },
+                onError: () => {
+                    showToast('No s\'ha pogut refrescar la llista de factures.', 'error');
+                },
+            });
+        },
+        onError: () => {
+            showToast('No s\'ha pogut actualitzar l\'estat de la factura.', 'error');
+        },
+    });
+};
 
 const selectedClient = ref('');
 const selectedStatus = ref('');
@@ -225,15 +405,17 @@ const statusCopy = (state) => {
 };
 
 const statusBadgeClasses = (state) => {
+    const base = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shadow-sm ring-1 ring-inset';
+
     switch (state) {
         case 'paid':
-            return 'inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700';
+            return `${base} bg-emerald-100 text-emerald-700 ring-emerald-500/30`;
         case 'pending':
-            return 'inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700';
+            return `${base} bg-amber-100 text-amber-700 ring-amber-500/30`;
         case 'cancelled':
-            return 'inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-700';
+            return `${base} bg-rose-100 text-rose-700 ring-rose-500/30`;
         default:
-            return 'inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600';
+            return `${base} bg-slate-100 text-slate-600 ring-slate-300/60`;
     }
 };
 

--- a/routes/web/Facturacion.php
+++ b/routes/web/Facturacion.php
@@ -35,6 +35,7 @@ Route::middleware(['route.features.access:1'])->group(function() {
             'update' => 'invoices.update',
             'destroy' => 'invoices.destroy',
         ]);
+    Route::patch('invoices/{invoice}/status', [InvoiceController::class, 'updateStatus'])->name('invoices.updateStatus');
     Route::post('/invoices/create-from-budget/{budget}', [InvoiceController::class, 'createFromBudget'])->name('invoices.create-from-budget');
     Route::post('/invoices/store-with-items', [InvoiceController::class, 'storeWithItems'])->name('invoices.storeWithItems');
     Route::get('/invoices/{invoice}/print', [InvoiceController::class, 'print'])->name('invoices.print');
@@ -63,6 +64,7 @@ Route::middleware(['route.features.access:1'])->group(function() {
             'update' => 'budgets.update',
             'destroy' => 'budgets.destroy',
         ]);
+    Route::patch('budgets/{budget}/status', [BudgetController::class, 'updateStatus'])->name('budgets.updateStatus');
 
     Route::post('/budgets/store-with-items', [BudgetController::class, 'storeWithItems'])->name('budgets.storeWithItems');
     Route::get('/budgets/{budget}/print', [BudgetController::class, 'print'])->name('budgets.print');

--- a/tests/Feature/BudgetStatusUpdateTest.php
+++ b/tests/Feature/BudgetStatusUpdateTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckCompanyPlan;
+use App\Http\Middleware\RouteFeaturesAccess;
+use App\Models\Budget;
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BudgetStatusUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_budget_status_can_be_updated_via_new_route(): void
+    {
+        $this->withoutMiddleware([
+            RouteFeaturesAccess::class,
+            CheckCompanyPlan::class,
+        ]);
+
+        $company = Company::create([
+            'name' => 'Test Company',
+            'nif' => 'A12345678',
+        ]);
+
+        $user = User::factory()->create([
+            'company_id' => $company->id,
+        ]);
+
+        $client = Client::create([
+            'company_id' => $company->id,
+            'name' => 'Client Test',
+            'nif' => 'B12345678',
+            'email' => 'client@example.com',
+        ]);
+
+        $budget = Budget::create([
+            'company_id' => $company->id,
+            'client_id' => $client->id,
+            'name' => 'PR-0001',
+            'date' => now()->toDateString(),
+            'state' => 'in_process',
+            'base_imponible' => 100,
+            'iva' => 21,
+            'monto_iva' => 21,
+            'total' => 121,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patchJson(route('budgets.updateStatus', $budget), ['state' => 'accepted']);
+
+        $response->assertOk()
+            ->assertJsonPath('budget.state', 'accepted');
+
+        $this->assertDatabaseHas('budgets', [
+            'id' => $budget->id,
+            'state' => 'accepted',
+        ]);
+    }
+}

--- a/tests/Feature/InvoiceStatusUpdateTest.php
+++ b/tests/Feature/InvoiceStatusUpdateTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckCompanyPlan;
+use App\Http\Middleware\RouteFeaturesAccess;
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvoiceStatusUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invoice_status_can_be_updated_via_new_route(): void
+    {
+        $this->withoutMiddleware([
+            RouteFeaturesAccess::class,
+            CheckCompanyPlan::class,
+        ]);
+
+        $company = Company::create([
+            'name' => 'Test Company',
+            'nif' => 'A12345678',
+        ]);
+
+        $user = User::factory()->create([
+            'company_id' => $company->id,
+        ]);
+
+        $client = Client::create([
+            'company_id' => $company->id,
+            'name' => 'Client Test',
+            'nif' => 'B12345678',
+            'email' => 'client@example.com',
+        ]);
+
+        $invoice = Invoice::create([
+            'company_id' => $company->id,
+            'client_id' => $client->id,
+            'name' => 'FA-0001',
+            'date' => now()->toDateString(),
+            'state' => 'pending',
+            'base_imponible' => 100,
+            'iva' => 21,
+            'monto_iva' => 21,
+            'total' => 121,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patchJson(route('invoices.updateStatus', $invoice), ['state' => 'paid']);
+
+        $response->assertOk()
+            ->assertJsonPath('invoice.state', 'paid');
+
+        $this->assertDatabaseHas('invoices', [
+            'id' => $invoice->id,
+            'state' => 'paid',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add PATCH endpoints for updating budget and invoice states with validation, notifications, and JSON support
- introduce a shared StatusUpdateModal Vue component and integrate it into the budgets and invoices listings with toasts and spinners
- cover the new workflow with feature tests ensuring status persistence via the fresh routes

## Testing
- php artisan test --filter=StatusUpdate *(fails: vendor dependencies incompatible with PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68f8b11bfdf483239baae6469e74e3d5