### PR TITLE
Configure Vite to resolve xlsx module

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            xlsx: 'xlsx/xlsx.mjs',
+        },
+    },
     plugins: [
         laravel({
             input: [
@@ -19,4 +24,7 @@ export default defineConfig({
             },
         }),
     ],
+    optimizeDeps: {
+        include: ['xlsx'],
+    },
 });


### PR DESCRIPTION
## Summary
- add a Vite resolve alias for the xlsx module entry point
- ensure the xlsx package is pre-bundled by Vite optimizeDeps

## Testing
- npm ci
- npm run build *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*


------
https://chatgpt.com/codex/tasks/task_e_68f8b847d7bc8323bd3328b54bc67c96