### PR TITLE
Fix Vite build imports for Ziggy and Jetstream components

### DIFF
--- a/resources/js/Components/RadarChart.vue
+++ b/resources/js/Components/RadarChart.vue
@@ -6,20 +6,25 @@
 
 <script setup>
 import { onMounted, ref, watch } from 'vue';
-import { Chart } from 'chart.js';
-
-// Importamos los elementos necesarios de Chart.js
-import { Radar } from 'chart.js';
-import { Chart as ChartJS } from 'chart.js';
-import { Title, Tooltip, Legend, RadialLinearScale, PointElement, LineElement } from 'chart.js';
+import {
+    Chart as ChartJS,
+    Title,
+    Tooltip,
+    Legend,
+    RadialLinearScale,
+    PointElement,
+    LineElement,
+    Filler,
+} from 'chart.js';
 
 ChartJS.register(
-    RadialLinearScale,   // Escala radial para el gráfico de radar
-    PointElement,        // Elemento para los puntos
-    LineElement,         // Elemento para las líneas
-    Title,               // Título
-    Tooltip,             // Tooltip
-    Legend               // Leyenda
+    RadialLinearScale, // Escala radial para el gráfico de radar
+    PointElement, // Elemento para los puntos
+    LineElement, // Elemento para las líneas
+    Title, // Título
+    Tooltip, // Tooltip
+    Legend, // Leyenda
+    Filler,
 );
 
 const props = defineProps({
@@ -27,6 +32,7 @@ const props = defineProps({
 });
 
 const radarChart = ref(null);
+const chartInstance = ref(null);
 
 onMounted(() => {
     createChart();
@@ -37,30 +43,36 @@ watch(() => props.data, () => {
 }, { immediate: true });
 
 const createChart = () => {
-    if (radarChart.value) {
-        new Chart(radarChart.value, {
-            type: 'radar',
-            data: props.data,
-            options: {
-                responsive: true,
-                scales: {
-                    r: {
-                        min: 0,
-                        max: 100,
-                        beginAtZero: true,
-                        ticks: {
-                            stepSize: 10,
-                        },
-                    },
-                },
-                elements: {
-                    line: {
-                        borderWidth: 2,
+    if (!radarChart.value) {
+        return;
+    }
+
+    if (chartInstance.value) {
+        chartInstance.value.destroy();
+    }
+
+    chartInstance.value = new ChartJS(radarChart.value, {
+        type: 'radar',
+        data: props.data,
+        options: {
+            responsive: true,
+            scales: {
+                r: {
+                    min: 0,
+                    max: 100,
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 10,
                     },
                 },
             },
-        });
-    }
+            elements: {
+                line: {
+                    borderWidth: 2,
+                },
+            },
+        },
+    });
 };
 </script>
 

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -106,7 +106,7 @@
 <script setup>
 import {reactive, ref, onMounted} from 'vue';
 import { loadStripe } from '@stripe/stripe-js';
-import NavLink from "../../../../vendor/laravel/jetstream/stubs/inertia/resources/js/Components/NavLink.vue";
+import NavLink from "../../Components/NavLink.vue";
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
 

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -167,7 +167,7 @@
 import { computed } from 'vue';
 import Calendar from '@/Components/Calendar.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import NavLink from "../../../vendor/laravel/jetstream/stubs/inertia/resources/js/Components/NavLink.vue";
+import NavLink from "../Components/NavLink.vue";
 import { Inertia } from "@inertiajs/inertia";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,7 +5,7 @@ import '../css/app.css';
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import { ZiggyVue } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'JESTY';
 


### PR DESCRIPTION
## Summary
- update the Ziggy Vue plugin import to use the ziggy-js package instead of the vendor directory
- point Jetstream NavLink imports at the local component copies used in the Inertia views
- refactor the radar chart component to use modular Chart.js imports and reuse a single chart instance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8b95b3f0883239097a4971f7f8570