### PR TITLE
Update Vite config to resolve xlsx alias via path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
     resolve: {
         alias: {
-            xlsx: 'xlsx/xlsx.mjs',
+            xlsx: path.resolve(__dirname, 'node_modules/xlsx/xlsx.mjs'),
         },
     },
     plugins: [


### PR DESCRIPTION
## Summary
- add path utilities to vite config to compute __dirname
- point the xlsx alias at the resolved ESM entry inside node_modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8bf7abd44832384e240743340b971