### PR TITLE
Fix Vite xlsx alias fallback for missing ESM entry

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,13 +3,18 @@ import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const xlsxEntry = ['xlsx.mjs', 'xlsx.js']
+    .map((candidate) => path.resolve(__dirname, `node_modules/xlsx/${candidate}`))
+    .find((candidate) => existsSync(candidate));
 
 export default defineConfig({
     resolve: {
         alias: {
-            xlsx: path.resolve(__dirname, 'node_modules/xlsx/xlsx.mjs'),
+            xlsx: xlsxEntry ?? 'xlsx',
         },
     },
     plugins: [


### PR DESCRIPTION
## Summary
- detect the available xlsx entry file at build time and alias to it so deployments do not fail when the ESM bundle is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8c3c048c48323b889318dc87c6eca