### PR TITLE
Fix conditional XLSX alias resolution

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,11 +11,15 @@ const xlsxEntry = ['xlsx.mjs', 'xlsx.js']
     .map((candidate) => path.resolve(__dirname, `node_modules/xlsx/${candidate}`))
     .find((candidate) => existsSync(candidate));
 
+const aliases = {};
+
+if (xlsxEntry) {
+    aliases.xlsx = xlsxEntry;
+}
+
 export default defineConfig({
     resolve: {
-        alias: {
-            xlsx: xlsxEntry ?? 'xlsx',
-        },
+        alias: aliases,
     },
     plugins: [
         laravel({


### PR DESCRIPTION
## Summary
- register the XLSX alias only when the resolved entry file exists so builds fall back to normal module resolution otherwise

## Testing
- npm run build *(fails: command hung in the container after dependency install, interrupted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68f8c7062edc8323856c916da21b749b