### PR TITLE
Lazy load xlsx on leads page

### DIFF
--- a/resources/js/Pages/Leads/Index.vue
+++ b/resources/js/Pages/Leads/Index.vue
@@ -219,7 +219,15 @@ import EmptyState from '@/Components/Crm/EmptyState.vue';
 import Modal from '@/Components/Modal.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
-import * as XLSX from 'xlsx';
+let xlsxModulePromise = null;
+
+const loadXLSX = async () => {
+    if (!xlsxModulePromise) {
+        xlsxModulePromise = import('xlsx');
+    }
+
+    return xlsxModulePromise;
+};
 
 const props = defineProps({
     leads: {
@@ -413,8 +421,9 @@ const parseFile = file => {
     parsingError.value = '';
     const reader = new FileReader();
 
-    reader.onload = e => {
+    reader.onload = async e => {
         try {
+            const XLSX = await loadXLSX();
             const data = new Uint8Array(e.target.result);
             const workbook = XLSX.read(data, { type: 'array' });
             const [sheetName] = workbook.SheetNames;


### PR DESCRIPTION
## Summary
- replace the static xlsx import on the leads index page with a cached dynamic import
- load the spreadsheet library only when parsing uploaded files to avoid build resolution issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8c9ab43e48323b3399355bb77c77c