### PR TITLE
Fix Vite xlsx resolution error in leads import view

### DIFF
--- a/resources/js/Pages/Leads/Index.vue
+++ b/resources/js/Pages/Leads/Index.vue
@@ -223,7 +223,7 @@ let xlsxModulePromise = null;
 
 const loadXLSX = async () => {
     if (!xlsxModulePromise) {
-        xlsxModulePromise = import('xlsx');
+        xlsxModulePromise = import('xlsx/xlsx.mjs').then(module => module.default ?? module);
     }
 
     return xlsxModulePromise;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,32 +1,15 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-const xlsxEntry = ['xlsx.mjs', 'xlsx.js']
-    .map((candidate) => path.resolve(__dirname, `node_modules/xlsx/${candidate}`))
-    .find((candidate) => existsSync(candidate));
-
-const aliases = {};
-
-if (xlsxEntry) {
-    aliases.xlsx = xlsxEntry;
-}
 
 export default defineConfig({
-    resolve: {
-        alias: aliases,
-    },
     plugins: [
         laravel({
             input: [
                 'resources/css/app.css',
                 'resources/js/app.js',
-            ],            refresh: true,
+            ],
+            refresh: true,
         }),
         vue({
             template: {
@@ -38,6 +21,6 @@ export default defineConfig({
         }),
     ],
     optimizeDeps: {
-        include: ['xlsx'],
+        include: ['xlsx/xlsx.mjs'],
     },
 });


### PR DESCRIPTION
## Summary
- load the xlsx module directly from its ESM entry point within the Leads page
- simplify the Vite configuration now that no alias is required and update dependency optimization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8cc8431408323bb6f786e7c1bf31e