### PR TITLE
Remove duplicate Rule import in InvoiceController

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -26,7 +26,6 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Barryvdh\DomPDF\Facade\Pdf; // Importa DomPDF
-use Illuminate\Validation\Rule;
 use phpseclib3\Crypt\RSA;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\PdfParser\StreamReader;


### PR DESCRIPTION
## Summary
- remove the duplicated import of Illuminate\Validation\Rule in InvoiceController to prevent class aliasing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8f5c6c9008323bb98cf3d53916da8