### PR TITLE
Add period filtering controls to income dashboard

### DIFF
--- a/resources/js/Components/Finance/FinancePageHeader.vue
+++ b/resources/js/Components/Finance/FinancePageHeader.vue
@@ -23,6 +23,68 @@
                     <slot name="metrics" />
                 </div>
             </div>
+
+            <div
+                v-if="showPeriodSelector"
+                class="mt-10 flex flex-col gap-4 rounded-2xl border border-white/20 bg-white/10 p-4 text-white/80 shadow-lg shadow-emerald-900/20 backdrop-blur print:hidden"
+            >
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                    <div class="text-xs font-semibold uppercase tracking-widest text-emerald-200/80">
+                        Selecciona periodo de análisis
+                    </div>
+                    <div class="flex flex-wrap gap-2 text-sm">
+                        <button
+                            v-for="option in periodOptions"
+                            :key="option.value"
+                            type="button"
+                            class="rounded-full border border-white/20 px-4 py-1.5 font-medium transition"
+                            :class="{
+                                'bg-white/90 text-emerald-700 shadow': option.value === periodMode,
+                                'hover:bg-white/20': option.value !== periodMode,
+                            }"
+                            :aria-pressed="option.value === periodMode"
+                            @click="selectPeriodMode(option.value)"
+                        >
+                            {{ option.label }}
+                        </button>
+                    </div>
+                </div>
+
+                <div
+                    v-if="canPickYear"
+                    class="flex flex-col gap-3 border-t border-white/10 pt-4 text-sm sm:flex-row sm:items-center sm:justify-between"
+                >
+                    <label class="flex items-center gap-2">
+                        <span class="text-xs font-semibold uppercase tracking-widest text-emerald-200/80">Año</span>
+                        <select
+                            class="rounded-xl border border-white/30 bg-white/10 px-3 py-2 text-sm font-medium text-white focus:border-white/60 focus:outline-none focus:ring-2 focus:ring-white/40"
+                            :value="selectedYear ?? (availableYears[0] ?? '')"
+                            @change="onYearChange"
+                        >
+                            <option v-for="year in availableYears" :key="year" :value="year">
+                                {{ year }}
+                            </option>
+                        </select>
+                    </label>
+
+                    <label v-if="canPickMonth" class="flex items-center gap-2">
+                        <span class="text-xs font-semibold uppercase tracking-widest text-emerald-200/80">Mes</span>
+                        <select
+                            class="rounded-xl border border-white/30 bg-white/10 px-3 py-2 text-sm font-medium text-white focus:border-white/60 focus:outline-none focus:ring-2 focus:ring-white/40"
+                            :value="selectedMonth ?? 1"
+                            @change="onMonthChange"
+                        >
+                            <option
+                                v-for="(monthLabel, index) in monthLabels"
+                                :key="monthLabel"
+                                :value="index + 1"
+                            >
+                                {{ monthLabel }}
+                            </option>
+                        </select>
+                    </label>
+                </div>
+            </div>
         </div>
     </div>
 </template>
@@ -47,7 +109,46 @@ const props = defineProps({
         type: Number,
         default: 4,
     },
+    showPeriodSelector: {
+        type: Boolean,
+        default: false,
+    },
+    periodMode: {
+        type: String,
+        default: 'general',
+    },
+    availableYears: {
+        type: Array,
+        default: () => [],
+    },
+    selectedYear: {
+        type: Number,
+        default: null,
+    },
+    selectedMonth: {
+        type: Number,
+        default: null,
+    },
+    monthNames: {
+        type: Array,
+        default: () => [
+            'Enero',
+            'Febrero',
+            'Marzo',
+            'Abril',
+            'Mayo',
+            'Junio',
+            'Julio',
+            'Agosto',
+            'Septiembre',
+            'Octubre',
+            'Noviembre',
+            'Diciembre',
+        ],
+    },
 });
+
+const emit = defineEmits(['update:periodMode', 'update:selectedYear', 'update:selectedMonth']);
 
 const metricsGridClass = computed(() => {
     const base = 'grid grid-cols-1 gap-5';
@@ -61,4 +162,34 @@ const metricsGridClass = computed(() => {
 
     return variants[props.metricsColumns] ?? variants[4];
 });
+
+const periodOptions = [
+    { value: 'monthly', label: 'Mensual' },
+    { value: 'annual', label: 'Anual' },
+    { value: 'general', label: 'General' },
+];
+
+const canPickYear = computed(() => props.periodMode !== 'general' && props.availableYears.length > 0);
+const canPickMonth = computed(() => props.periodMode === 'monthly');
+const monthLabels = computed(() => props.monthNames.length ? props.monthNames : periodOptions.map(option => option.label));
+
+const selectPeriodMode = (value) => {
+    if (value !== props.periodMode) {
+        emit('update:periodMode', value);
+    }
+};
+
+const onYearChange = (event) => {
+    const value = Number(event.target.value);
+    if (!Number.isNaN(value)) {
+        emit('update:selectedYear', value);
+    }
+};
+
+const onMonthChange = (event) => {
+    const value = Number(event.target.value);
+    if (!Number.isNaN(value)) {
+        emit('update:selectedMonth', value);
+    }
+};
 </script>

--- a/resources/js/Pages/Incomes/Index.vue
+++ b/resources/js/Pages/Incomes/Index.vue
@@ -5,6 +5,15 @@
                 eyebrow="Control financiero"
                 title="Ingresos registrados"
                 description="Explora la evolución de tus ingresos, analiza su origen y mantén un registro claro con herramientas preparadas para impresión."
+                :show-period-selector="true"
+                :period-mode="selectedPeriodMode"
+                :available-years="availableYears"
+                :selected-year="selectedYear"
+                :selected-month="selectedMonth"
+                :month-names="monthNames"
+                @update:period-mode="onPeriodModeChange"
+                @update:selected-year="onYearChange"
+                @update:selected-month="onMonthChange"
             >
                 <template #actions>
                     <NavLink
@@ -23,9 +32,21 @@
                 </template>
 
                 <template #metrics>
-                    <FinanceSummaryCard label="Total ingresos" :value="formatCurrency(totalGross)" :helper="`Impuestos incluidos: ${formatCurrency(totalTax)}`" />
-                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(totalBase)" :helper="`IVA medio ${averageTaxRate}%`" />
-                    <FinanceSummaryCard label="Ticket medio" :value="formatCurrency(averageTicket)" :helper="`${incomes.length} registros`" />
+                    <FinanceSummaryCard
+                        label="Total ingresos"
+                        :value="formatCurrency(totalGross)"
+                        :helper="`Impuestos incluidos: ${formatCurrency(totalTax)} · ${activePeriodLabel}`"
+                    />
+                    <FinanceSummaryCard
+                        label="Base imponible"
+                        :value="formatCurrency(totalBase)"
+                        :helper="`IVA medio ${averageTaxRate}% · ${activePeriodLabel}`"
+                    />
+                    <FinanceSummaryCard
+                        label="Ticket medio"
+                        :value="formatCurrency(averageTicket)"
+                        :helper="`${filteredIncomes.length} registros · ${activePeriodLabel}`"
+                    />
                     <FinanceSummaryCard label="Máximo registrado" :value="formatCurrency(highestIncome)" :helper="highestIncomeSource" />
                 </template>
             </FinancePageHeader>
@@ -35,7 +56,7 @@
                     <header class="flex flex-col gap-2 border-b border-slate-100 pb-4 sm:flex-row sm:items-end sm:justify-between">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-800">Resumen mensual</h2>
-                            <p class="text-sm text-slate-500">Suma las entradas por mes para detectar patrones de estacionalidad.</p>
+                            <p class="text-sm text-slate-500">Suma las entradas por mes para detectar patrones de estacionalidad · {{ activePeriodLabel }}</p>
                         </div>
                         <div class="flex items-center gap-3 text-sm text-slate-500">
                             <span class="inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500"></span>
@@ -92,10 +113,10 @@
                     <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-800">Detalle de ingresos</h2>
-                            <p class="text-sm text-slate-500">Tabla optimizada para manejar grandes volúmenes con totales calculados.</p>
+                            <p class="text-sm text-slate-500">Tabla optimizada para manejar grandes volúmenes con totales calculados · {{ activePeriodLabel }}</p>
                         </div>
                         <div class="text-right text-sm text-slate-500">
-                            Total registros: {{ incomes.length }}
+                            Total registros: {{ filteredIncomes.length }}
                         </div>
                     </header>
                     <div class="mt-6 overflow-x-auto print:overflow-visible">
@@ -114,7 +135,7 @@
                             </thead>
                             <tbody class="divide-y divide-slate-100">
                                 <tr
-                                    v-for="income in incomes"
+                                    v-for="income in filteredIncomes"
                                     :key="income.id"
                                     class="bg-white/60 transition hover:bg-emerald-50/60"
                                 >
@@ -161,8 +182,8 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { router } from '@inertiajs/vue3';
+import { computed, isRef, ref, watch } from 'vue';
+import { router, useRemember } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
 import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
@@ -180,6 +201,129 @@ const props = defineProps({
 });
 
 const incomes = computed(() => props.incomes ?? []);
+
+const monthNames = [
+    'Enero',
+    'Febrero',
+    'Marzo',
+    'Abril',
+    'Mayo',
+    'Junio',
+    'Julio',
+    'Agosto',
+    'Septiembre',
+    'Octubre',
+    'Noviembre',
+    'Diciembre',
+];
+
+const now = new Date();
+const initialFilters = {
+    periodMode: 'general',
+    year: Number.isNaN(now.getFullYear()) ? undefined : now.getFullYear(),
+    month: Number.isNaN(now.getMonth()) ? 1 : now.getMonth() + 1,
+};
+
+const rememberedFilters = useRemember(initialFilters, 'incomes.index.period');
+const rememberedRaw = isRef(rememberedFilters) ? rememberedFilters.value : rememberedFilters;
+
+const selectedPeriodMode = ref(rememberedRaw?.periodMode ?? initialFilters.periodMode);
+const selectedYear = ref(rememberedRaw?.year ?? initialFilters.year);
+const selectedMonth = ref(rememberedRaw?.month ?? initialFilters.month);
+
+const availableYears = computed(() => {
+    const years = incomes.value.reduce((acc, income) => {
+        const date = new Date(income.date);
+        if (!Number.isNaN(date.getTime())) {
+            acc.add(date.getFullYear());
+        }
+        return acc;
+    }, new Set());
+
+    return Array.from(years).sort((a, b) => b - a);
+});
+
+const syncRememberedFilters = () => {
+    const target = isRef(rememberedFilters) ? rememberedFilters.value : rememberedFilters;
+    if (!target) {
+        return;
+    }
+    target.periodMode = selectedPeriodMode.value;
+    target.year = selectedYear.value;
+    target.month = selectedMonth.value;
+};
+
+watch([selectedPeriodMode, selectedYear, selectedMonth], syncRememberedFilters, { immediate: true });
+
+watch(availableYears, (years) => {
+    if (!years.length) {
+        return;
+    }
+
+    if (!years.includes(selectedYear.value)) {
+        [selectedYear.value] = years;
+    }
+});
+
+const onPeriodModeChange = (value) => {
+    selectedPeriodMode.value = value;
+    if (value !== 'general' && availableYears.value.length && !availableYears.value.includes(selectedYear.value)) {
+        [selectedYear.value] = availableYears.value;
+    }
+    if (value === 'monthly' && (selectedMonth.value < 1 || selectedMonth.value > 12)) {
+        selectedMonth.value = initialFilters.month ?? 1;
+    }
+};
+
+const onYearChange = (value) => {
+    const numericValue = Number(value);
+    if (!Number.isNaN(numericValue)) {
+        selectedYear.value = numericValue;
+    }
+};
+
+const onMonthChange = (value) => {
+    const normalized = Math.min(12, Math.max(1, Number(value) || 1));
+    selectedMonth.value = normalized;
+};
+
+const filteredIncomes = computed(() => {
+    if (selectedPeriodMode.value === 'general') {
+        return incomes.value;
+    }
+
+    return incomes.value.filter((income) => {
+        const date = new Date(income.date);
+        if (Number.isNaN(date.getTime())) {
+            return false;
+        }
+
+        const incomeYear = date.getFullYear();
+        if (selectedPeriodMode.value === 'annual') {
+            return incomeYear === selectedYear.value;
+        }
+
+        if (selectedPeriodMode.value === 'monthly') {
+            return incomeYear === selectedYear.value && date.getMonth() + 1 === selectedMonth.value;
+        }
+
+        return true;
+    });
+});
+
+const activePeriodLabel = computed(() => {
+    if (selectedPeriodMode.value === 'annual' && selectedYear.value) {
+        return `Año ${selectedYear.value}`;
+    }
+
+    if (selectedPeriodMode.value === 'monthly' && selectedYear.value && selectedMonth.value) {
+        const monthIndex = Math.max(1, Math.min(12, selectedMonth.value)) - 1;
+        const monthLabel = monthNames[monthIndex] ?? `Mes ${selectedMonth.value}`;
+        return `${monthLabel} ${selectedYear.value}`;
+    }
+
+    return 'Periodo general';
+});
 
 const formatCurrency = (value) => {
     return new Intl.NumberFormat('es-ES', {
@@ -215,37 +359,37 @@ const totalAmount = (income) => {
     return base + taxAmount(income);
 };
 
-const totalBase = computed(() => incomes.value.reduce((acc, income) => acc + Number(income?.tax_base ?? 0), 0));
-const totalTax = computed(() => incomes.value.reduce((acc, income) => acc + taxAmount(income), 0));
+const totalBase = computed(() => filteredIncomes.value.reduce((acc, income) => acc + Number(income?.tax_base ?? 0), 0));
+const totalTax = computed(() => filteredIncomes.value.reduce((acc, income) => acc + taxAmount(income), 0));
 const totalGross = computed(() => totalBase.value + totalTax.value);
 
 const averageTicket = computed(() => {
-    if (!incomes.value.length) {
+    if (!filteredIncomes.value.length) {
         return 0;
     }
-    return totalGross.value / incomes.value.length;
+    return totalGross.value / filteredIncomes.value.length;
 });
 
 const averageTaxRate = computed(() => {
-    if (!incomes.value.length) {
+    if (!filteredIncomes.value.length) {
         return 0;
     }
-    const totalRate = incomes.value.reduce((acc, income) => acc + Number(income?.tax_rate ?? 0), 0);
-    return (totalRate / incomes.value.length).toFixed(1);
+    const totalRate = filteredIncomes.value.reduce((acc, income) => acc + Number(income?.tax_rate ?? 0), 0);
+    return (totalRate / filteredIncomes.value.length).toFixed(1);
 });
 
 const highestIncome = computed(() => {
-    if (!incomes.value.length) {
+    if (!filteredIncomes.value.length) {
         return 0;
     }
-    return Math.max(...incomes.value.map(income => totalAmount(income)));
+    return Math.max(...filteredIncomes.value.map((income) => totalAmount(income)));
 });
 
 const highestIncomeSource = computed(() => {
-    if (!incomes.value.length) {
-        return 'Sin registros';
+    if (!filteredIncomes.value.length) {
+        return `Sin registros · ${activePeriodLabel.value}`;
     }
-    const richest = incomes.value.reduce((acc, income) => {
+    const richest = filteredIncomes.value.reduce((acc, income) => {
         const amount = totalAmount(income);
         if (!acc || amount > acc.amount) {
             return { amount, source: income.source || 'Sin origen' };
@@ -253,21 +397,21 @@ const highestIncomeSource = computed(() => {
         return acc;
     }, null);
 
-    return richest ? `Origen ${richest.source}` : 'Sin registros';
+    return richest ? `Origen ${richest.source} · ${activePeriodLabel.value}` : `Sin registros · ${activePeriodLabel.value}`;
 });
 
 const uniqueSources = computed(() => {
-    const sources = new Set(incomes.value.map(income => income.source || 'Sin origen'));
+    const sources = new Set(filteredIncomes.value.map((income) => income.source || 'Sin origen'));
     return sources.size;
 });
 
 const sortedIncomes = computed(() => {
-    return [...incomes.value].sort((a, b) => new Date(a.date) - new Date(b.date));
+    return [...filteredIncomes.value].sort((a, b) => new Date(a.date) - new Date(b.date));
 });
 
 const lastIncomeFormatted = computed(() => {
     if (!sortedIncomes.value.length) {
-        return { amount: formatCurrency(0), date: 'Sin fecha', source: 'Sin origen' };
+        return { amount: formatCurrency(0), date: 'Sin registros', source: activePeriodLabel.value };
     }
     const income = sortedIncomes.value[sortedIncomes.value.length - 1];
     return {
@@ -279,7 +423,7 @@ const lastIncomeFormatted = computed(() => {
 
 const firstIncomeFormatted = computed(() => {
     if (!sortedIncomes.value.length) {
-        return { amount: formatCurrency(0), date: 'Sin fecha', source: 'Sin origen' };
+        return { amount: formatCurrency(0), date: 'Sin registros', source: activePeriodLabel.value };
     }
     const income = sortedIncomes.value[0];
     return {
@@ -290,20 +434,20 @@ const firstIncomeFormatted = computed(() => {
 });
 
 const averageDeviation = computed(() => {
-    if (incomes.value.length <= 1) {
+    if (filteredIncomes.value.length <= 1) {
         return 0;
     }
     const avg = averageTicket.value;
-    const variance = incomes.value.reduce((acc, income) => {
+    const variance = filteredIncomes.value.reduce((acc, income) => {
         const diff = totalAmount(income) - avg;
         return acc + diff * diff;
-    }, 0) / (incomes.value.length - 1);
+    }, 0) / (filteredIncomes.value.length - 1);
     return Math.sqrt(variance);
 });
 
 const monthlyIncomeData = computed(() => {
     const monthlyTotals = Array(12).fill(0);
-    incomes.value.forEach(income => {
+    filteredIncomes.value.forEach((income) => {
         const date = new Date(income.date);
         if (!Number.isNaN(date.getTime())) {
             monthlyTotals[date.getMonth()] += totalAmount(income);
@@ -327,7 +471,7 @@ const monthlyIncomeData = computed(() => {
 const palette = ['#0EA5E9', '#10B981', '#6366F1', '#F97316', '#F43F5E', '#8B5CF6', '#14B8A6', '#F59E0B', '#0F172A', '#84CC16', '#A855F7', '#0EA5E9'];
 
 const sourceDistributionData = computed(() => {
-    if (!incomes.value.length) {
+    if (!filteredIncomes.value.length) {
         return {
             labels: ['Sin datos'],
             datasets: [
@@ -340,7 +484,7 @@ const sourceDistributionData = computed(() => {
         };
     }
 
-    const totals = incomes.value.reduce((acc, income) => {
+    const totals = filteredIncomes.value.reduce((acc, income) => {
         const source = income.source || 'Sin origen';
         acc[source] = (acc[source] || 0) + totalAmount(income);
         return acc;


### PR DESCRIPTION
## Summary
- add reusable period selection controls to the finance page header component
- enable period mode, year, and month filters on the incomes index view with persistence
- recalculate income summaries, charts, and tables against the filtered dataset and update helper messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa3d52ece88323a3c6af411f1adc77