### PR TITLE
Add grouped modes to expense reports

### DIFF
--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -163,51 +163,311 @@ class ExpenseController extends Controller
         return Inertia::location(route('expenses.index'));
     }
     //Reports
-    public function report()
+    public function report(Request $request)
     {
-        $incomes = Income::where('company_id', Auth::user()->company_id)->get();
-        $expenses = Expense::where('company_id', Auth::user()->company_id)->get();
-        $clients= Client::where('company_id', Auth::user()->company_id)->get();
+        $mode = $this->resolveMode($request->string('mode')->toString());
+        $startDate = $request->input('start_date');
+        $endDate = $request->input('end_date');
+        $companyId = Auth::user()->company_id;
+
+        $expenses = Expense::where('company_id', $companyId)
+            ->when($startDate, function ($query, $startDate) {
+                return $query->whereDate('date', '>=', $startDate);
+            })
+            ->when($endDate, function ($query, $endDate) {
+                return $query->whereDate('date', '<=', $endDate);
+            })
+            ->orderBy('date')
+            ->get();
+
+        $incomes = Income::where('company_id', $companyId)
+            ->when($startDate, function ($query, $startDate) {
+                return $query->whereDate('date', '>=', $startDate);
+            })
+            ->when($endDate, function ($query, $endDate) {
+                return $query->whereDate('date', '<=', $endDate);
+            })
+            ->orderBy('date')
+            ->get();
+
+        $clients= Client::where('company_id', $companyId)->get();
 
         return Inertia::render('Expenses/Report',[
-            'expenses' => $expenses,
-            'incomes' => $incomes,
+            'report' => $this->buildReportPayload($expenses, $incomes, $mode),
+            'filters' => [
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'mode' => $mode,
+            ],
             'clients' => $clients,
         ]);
     }
+
     public function reportPrint(Request $request)
     {
-
+        $mode = $this->resolveMode($request->string('mode')->toString());
         $startDate = $request->input('start_date');
         $endDate = $request->input('end_date');
+        $companyId = Auth::user()->company_id;
 
-        $expenses = Expense::where('company_id', auth()->user()->company_id)
+        $expenses = Expense::where('company_id', $companyId)
             ->when($startDate, function ($query, $startDate) {
-                return $query->where('date', '>=', $startDate);
+                return $query->whereDate('date', '>=', $startDate);
             })
             ->when($endDate, function ($query, $endDate) {
-                return $query->where('date', '<=', $endDate);
+                return $query->whereDate('date', '<=', $endDate);
             })
-            ->orderBy('date', 'desc')
+            ->orderBy('date')
             ->get();
 
-        $incomes = Income::where('company_id', auth()->user()->company_id)
+        $incomes = Income::where('company_id', $companyId)
             ->when($startDate, function ($query, $startDate) {
-                return $query->where('date', '>=', $startDate);
+                return $query->whereDate('date', '>=', $startDate);
             })
             ->when($endDate, function ($query, $endDate) {
-                return $query->where('date', '<=', $endDate);
+                return $query->whereDate('date', '<=', $endDate);
             })
-            ->orderBy('date', 'desc')
+            ->orderBy('date')
             ->get();
 
-        $clients= Client::where('company_id', Auth::user()->company_id)->get();
+        $clients= Client::where('company_id', $companyId)->get();
 
         return Inertia::render('Expenses/ReportPrint', [
-            'expenses' => $expenses,
-            'incomes' => $incomes,
+            'report' => $this->buildReportPayload($expenses, $incomes, $mode),
+            'filters' => [
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'mode' => $mode,
+            ],
             'clients' => $clients,
         ]);
+    }
+
+    private function resolveMode(?string $mode): string
+    {
+        $mode = $mode ?: 'general';
+
+        return in_array($mode, ['monthly', 'annual', 'general'], true) ? $mode : 'general';
+    }
+
+    private function buildReportPayload($expenses, $incomes, string $mode): array
+    {
+        $mode = $this->resolveMode($mode);
+
+        $groups = $this->buildPeriodGroups($expenses, $incomes, $mode);
+
+        $overallSummary = $this->buildSummary($expenses, $incomes);
+
+        return [
+            'mode' => $mode,
+            'groups' => $groups,
+            'overall' => [
+                'label' => 'Resumen general',
+                'summary' => $overallSummary,
+            ],
+        ];
+    }
+
+    private function buildPeriodGroups($expenses, $incomes, string $mode): array
+    {
+        if ($mode === 'general') {
+            return [
+                $this->buildPeriod('general', 'Resumen general', $expenses, $incomes),
+            ];
+        }
+
+        $expenseGroups = $expenses->groupBy(function ($expense) use ($mode) {
+            if (empty($expense->date)) {
+                return 'undefined';
+            }
+
+            $date = Carbon::parse($expense->date);
+
+            return $mode === 'monthly' ? $date->format('Y-m') : $date->format('Y');
+        });
+
+        $incomeGroups = $incomes->groupBy(function ($income) use ($mode) {
+            if (empty($income->date)) {
+                return 'undefined';
+            }
+
+            $date = Carbon::parse($income->date);
+
+            return $mode === 'monthly' ? $date->format('Y-m') : $date->format('Y');
+        });
+
+        $keys = $expenseGroups->keys()->merge($incomeGroups->keys())->unique()->sort();
+
+        return $keys->map(function (string $key) use ($expenseGroups, $incomeGroups, $mode) {
+            $label = $this->formatPeriodLabel($key, $mode);
+            $periodExpenses = $expenseGroups->get($key, collect());
+            $periodIncomes = $incomeGroups->get($key, collect());
+
+            return $this->buildPeriod($key, $label, $periodExpenses, $periodIncomes, $mode);
+        })->values()->all();
+    }
+
+    private function buildPeriod(string $key, string $label, $expenses, $incomes, string $mode = 'general'): array
+    {
+        $expenseTotals = $this->calculateExpenseTotals($expenses);
+        $incomeTotals = $this->calculateIncomeTotals($incomes);
+        $summary = $this->calculateSummary($expenseTotals, $incomeTotals);
+
+        return [
+            'key' => $key,
+            'label' => $label,
+            'mode' => $mode,
+            'range' => $this->determineRange($key, $mode, $expenses, $incomes),
+            'expenses' => [
+                'items' => $expenses->values(),
+                'totals' => $expenseTotals,
+            ],
+            'incomes' => [
+                'items' => $incomes->values(),
+                'totals' => $incomeTotals,
+            ],
+            'summary' => $summary,
+        ];
+    }
+
+    private function determineRange(string $key, string $mode, $expenses, $incomes): array
+    {
+        if ($mode === 'general') {
+            $dates = $expenses->pluck('date')->merge($incomes->pluck('date'))->filter();
+            $start = $dates->min();
+            $end = $dates->max();
+
+            return [
+                'start' => $start,
+                'end' => $end,
+            ];
+        }
+
+        if ($key === 'undefined') {
+            return [
+                'start' => null,
+                'end' => null,
+            ];
+        }
+
+        if ($mode === 'monthly') {
+            $date = Carbon::createFromFormat('Y-m', $key)->startOfMonth();
+
+            return [
+                'start' => $date->toDateString(),
+                'end' => $date->endOfMonth()->toDateString(),
+            ];
+        }
+
+        $date = Carbon::createFromFormat('Y', $key)->startOfYear();
+
+        return [
+            'start' => $date->toDateString(),
+            'end' => $date->endOfYear()->toDateString(),
+        ];
+    }
+
+    private function formatPeriodLabel(string $key, string $mode): string
+    {
+        if ($key === 'undefined') {
+            return 'Sin fecha';
+        }
+
+        if ($mode === 'monthly') {
+            return Carbon::createFromFormat('Y-m', $key)->translatedFormat('F Y');
+        }
+
+        if ($mode === 'annual') {
+            return Carbon::createFromFormat('Y', $key)->format('Y');
+        }
+
+        return 'Resumen general';
+    }
+
+    private function calculateExpenseTotals($expenses): array
+    {
+        $base = $expenses->sum(function ($expense) {
+            return (float) ($expense->amount ?? 0);
+        });
+
+        $tax = $expenses->sum(function ($expense) {
+            $amount = (float) ($expense->amount ?? 0);
+            $rate = (float) ($expense->iva ?? 0);
+
+            return $amount * $rate / 100;
+        });
+
+        return [
+            'count' => $expenses->count(),
+            'base' => $base,
+            'tax' => $tax,
+            'total' => $base + $tax,
+        ];
+    }
+
+    private function calculateIncomeTotals($incomes): array
+    {
+        $base = $incomes->sum(function ($income) {
+            return (float) ($income->tax_base ?? 0);
+        });
+
+        $tax = $incomes->sum(function ($income) {
+            $taxAmount = $income->tax_amount;
+
+            if ($taxAmount !== null) {
+                return (float) $taxAmount;
+            }
+
+            $base = (float) ($income->tax_base ?? 0);
+            $rate = (float) ($income->tax_rate ?? 0);
+
+            return $base * $rate / 100;
+        });
+
+        $total = $incomes->sum(function ($income) {
+            if ($income->total_amount !== null) {
+                return (float) $income->total_amount;
+            }
+
+            $base = (float) ($income->tax_base ?? 0);
+            $taxAmount = (float) ($income->tax_amount ?? 0);
+
+            return $base + $taxAmount;
+        });
+
+        return [
+            'count' => $incomes->count(),
+            'base' => $base,
+            'tax' => $tax,
+            'total' => $total,
+        ];
+    }
+
+    private function calculateSummary(array $expenseTotals, array $incomeTotals): array
+    {
+        $grossMargin = $incomeTotals['base'] - $expenseTotals['base'];
+        $ivaBalance = $incomeTotals['tax'] - $expenseTotals['tax'];
+        $net = $incomeTotals['total'] - $expenseTotals['total'];
+
+        return [
+            'total_income' => $incomeTotals['total'],
+            'total_income_base' => $incomeTotals['base'],
+            'total_income_tax' => $incomeTotals['tax'],
+            'total_expense_base' => $expenseTotals['base'],
+            'total_expense_tax' => $expenseTotals['tax'],
+            'total_expense_total' => $expenseTotals['total'],
+            'gross_margin' => $grossMargin,
+            'iva_balance' => $ivaBalance,
+            'net_balance' => $net,
+        ];
+    }
+
+    private function buildSummary($expenses, $incomes): array
+    {
+        $expenseTotals = $this->calculateExpenseTotals($expenses);
+        $incomeTotals = $this->calculateIncomeTotals($incomes);
+
+        return $this->calculateSummary($expenseTotals, $incomeTotals);
     }
 
     protected function syncRecurringTemplate(Expense $expense, array $validated, bool $isNew = false): void

--- a/resources/js/Pages/Expenses/Report.vue
+++ b/resources/js/Pages/Expenses/Report.vue
@@ -13,9 +13,17 @@
                     </PrimaryButton>
                 </template>
                 <template #metrics>
-                    <FinanceSummaryCard label="Ingresos filtrados" :value="formatCurrency(totalIncomes)" :helper="`${filteredIncomes.length} registros`" />
-                    <FinanceSummaryCard label="Gastos filtrados" :value="formatCurrency(totalExpenses)" :helper="`${filteredExpenses.length} registros`" />
-                    <FinanceSummaryCard :label="netBalanceLabel" :value="formatCurrency(netBalance)" :helper="ivaHelper" />
+                    <FinanceSummaryCard
+                        label="Ingresos filtrados"
+                        :value="formatCurrency(totalIncomes)"
+                        :helper="`${totalIncomeCount} registros`"
+                    />
+                    <FinanceSummaryCard
+                        label="Gastos filtrados"
+                        :value="formatCurrency(totalExpensesWithTax)"
+                        :helper="`${totalExpenseCount} registros`"
+                    />
+                    <FinanceSummaryCard :label="netBalanceLabel" :value="formatCurrency(netBalance)" :helper="ivaAndMarginHelper" />
                 </template>
             </FinancePageHeader>
 
@@ -23,23 +31,42 @@
                 <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
                     <header class="mb-6 border-b border-slate-200 pb-4">
                         <h2 class="text-xl font-semibold text-slate-800">Filtros temporales</h2>
-                        <p class="mt-1 text-sm text-slate-500">Selecciona un periodo para recalcular automáticamente todos los indicadores y tablas.</p>
+                        <p class="mt-1 text-sm text-slate-500">
+                            Selecciona un periodo y el modo de agrupación para recalcular automáticamente todos los indicadores y tablas.
+                        </p>
                     </header>
-                    <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
-                        <div class="md:col-span-1">
-                            <InputLabel for="start_date" value="Fecha de inicio" />
-                            <TextInput id="start_date" v-model="filter.start_date" type="date" class="mt-2 block w-full" />
+                    <form class="space-y-6" @submit.prevent="applyFilters">
+                        <div class="grid grid-cols-1 gap-6 md:grid-cols-4">
+                            <div class="md:col-span-1">
+                                <InputLabel for="start_date" value="Fecha de inicio" />
+                                <TextInput id="start_date" v-model="filters.start_date" type="date" class="mt-2 block w-full" />
+                            </div>
+                            <div class="md:col-span-1">
+                                <InputLabel for="end_date" value="Fecha de fin" />
+                                <TextInput id="end_date" v-model="filters.end_date" type="date" class="mt-2 block w-full" />
+                            </div>
+                            <div class="md:col-span-1">
+                                <InputLabel for="mode" value="Modo de agrupación" />
+                                <select
+                                    id="mode"
+                                    v-model="filters.mode"
+                                    class="mt-2 block w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-emerald-500"
+                                >
+                                    <option value="general">General</option>
+                                    <option value="monthly">Mensual</option>
+                                    <option value="annual">Anual</option>
+                                </select>
+                            </div>
+                            <div class="md:col-span-1 flex items-end justify-start gap-3">
+                                <PrimaryButton type="submit" class="w-full justify-center">
+                                    Aplicar filtros
+                                </PrimaryButton>
+                                <SecondaryButton type="button" class="w-full justify-center" @click="resetFilters">
+                                    Limpiar filtros
+                                </SecondaryButton>
+                            </div>
                         </div>
-                        <div class="md:col-span-1">
-                            <InputLabel for="end_date" value="Fecha de fin" />
-                            <TextInput id="end_date" v-model="filter.end_date" type="date" class="mt-2 block w-full" />
-                        </div>
-                        <div class="md:col-span-1 flex items-end">
-                            <SecondaryButton type="button" class="w-full justify-center" @click="resetFilters">
-                                Limpiar filtros
-                            </SecondaryButton>
-                        </div>
-                    </div>
+                    </form>
                     <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
                         <div class="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-700">
                             <h3 class="text-xs font-semibold uppercase tracking-widest">Ingresos netos</h3>
@@ -48,7 +75,7 @@
                         </div>
                         <div class="rounded-2xl border border-rose-100 bg-rose-50 p-4 text-rose-700">
                             <h3 class="text-xs font-semibold uppercase tracking-widest">Gastos totales</h3>
-                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(totalExpenses + totalExpenseTaxes) }}</p>
+                            <p class="mt-3 text-2xl font-semibold">{{ formatCurrency(totalExpensesWithTax) }}</p>
                             <p class="mt-2 text-xs text-rose-800/70">Incluye base imponible e IVA.</p>
                         </div>
                         <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-slate-700">
@@ -59,13 +86,13 @@
                     </div>
                 </section>
 
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                <section v-if="mode === 'general'" class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
                     <header class="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-end sm:justify-between">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-800">Gastos</h2>
                             <p class="text-sm text-slate-500">Detalle de gastos filtrados por fecha con su base imponible e impuestos asociados.</p>
                         </div>
-                        <span class="text-sm text-slate-500">{{ filteredExpenses.length }} registros</span>
+                        <span class="text-sm text-slate-500">{{ generalExpenseTotals.count }} registros</span>
                     </header>
                     <div class="mt-6 overflow-x-auto">
                         <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
@@ -80,7 +107,7 @@
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-slate-100">
-                                <tr v-for="expense in filteredExpenses" :key="expense.id" class="bg-white/60">
+                                <tr v-for="expense in generalExpenses" :key="expense.id" class="bg-white/60">
                                     <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
                                     <td class="px-4 py-3 font-medium text-slate-700">{{ expense.name }}</td>
                                     <td class="px-4 py-3">{{ expense.description || '—' }}</td>
@@ -88,29 +115,29 @@
                                     <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount * (expense.iva ?? 0) / 100) }}</td>
                                     <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount + expense.amount * (expense.iva ?? 0) / 100) }}</td>
                                 </tr>
-                                <tr v-if="filteredExpenses.length === 0">
+                                <tr v-if="generalExpenses.length === 0">
                                     <td colspan="6" class="px-4 py-4 text-center text-slate-400">No hay gastos en este rango de fechas.</td>
                                 </tr>
                             </tbody>
                             <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
                                 <tr>
                                     <td colspan="3" class="px-4 py-3">Totales</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenses) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenseTaxes) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalExpenses + totalExpenseTaxes) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalExpenseTotals.base) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalExpenseTotals.tax) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalExpenseTotals.total) }}</td>
                                 </tr>
                             </tfoot>
                         </table>
                     </div>
                 </section>
 
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                <section v-if="mode === 'general'" class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
                     <header class="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-end sm:justify-between">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-800">Ingresos</h2>
                             <p class="text-sm text-slate-500">Incluye nombre, origen y cantidades con impuestos para facilitar la conciliación.</p>
                         </div>
-                        <span class="text-sm text-slate-500">{{ filteredIncomes.length }} registros</span>
+                        <span class="text-sm text-slate-500">{{ generalIncomeTotals.count }} registros</span>
                     </header>
                     <div class="mt-6 overflow-x-auto">
                         <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
@@ -125,7 +152,7 @@
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-slate-100">
-                                <tr v-for="income in filteredIncomes" :key="income.id" class="bg-white/60">
+                                <tr v-for="income in generalIncomes" :key="income.id" class="bg-white/60">
                                     <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(income.date) }}</td>
                                     <td class="px-4 py-3 font-medium text-slate-700">{{ income.name }}</td>
                                     <td class="px-4 py-3">{{ income.source || '—' }}</td>
@@ -133,19 +160,204 @@
                                     <td class="px-4 py-3 text-right">{{ formatCurrency(income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100) }}</td>
                                     <td class="px-4 py-3 text-right">{{ formatCurrency(income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)) }}</td>
                                 </tr>
-                                <tr v-if="filteredIncomes.length === 0">
+                                <tr v-if="generalIncomes.length === 0">
                                     <td colspan="6" class="px-4 py-4 text-center text-slate-400">No hay ingresos en este rango de fechas.</td>
                                 </tr>
                             </tbody>
                             <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
                                 <tr>
                                     <td colspan="3" class="px-4 py-3">Totales</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomeBase) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomeTaxes) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(totalIncomes) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalIncomeTotals.base) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalIncomeTotals.tax) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(generalIncomeTotals.total) }}</td>
                                 </tr>
                             </tfoot>
                         </table>
+                    </div>
+                </section>
+
+                <section v-else class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="flex flex-col gap-2 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Resumen agrupado</h2>
+                        <p class="text-sm text-slate-500">
+                            Visualiza los totales por periodo seleccionado y compara de un vistazo los ingresos, gastos, IVA y márgenes asociados.
+                        </p>
+                    </header>
+
+                    <div v-if="mode === 'monthly'" class="mt-6 space-y-8">
+                        <div v-for="year in monthlyYears" :key="year.year" class="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow">
+                            <header class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                                <h3 class="text-lg font-semibold text-slate-800">{{ year.year }}</h3>
+                                <p class="text-sm text-slate-500">
+                                    IVA acumulado: {{ formatCurrency(year.summary.iva_balance) }} · Margen bruto: {{ formatCurrency(year.summary.gross_margin) }} · Saldo neto: {{ formatCurrency(year.summary.net_balance) }}
+                                </p>
+                            </header>
+                            <div class="mt-4 overflow-x-auto">
+                                <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                                    <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3">Mes</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Ingresos (IVA incl.)</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Gastos (IVA incl.)</th>
+                                            <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Margen bruto</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Saldo neto</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-slate-100">
+                                        <tr v-for="month in year.months" :key="month.key" class="bg-white/60">
+                                            <td class="px-4 py-3 font-medium text-slate-700">{{ month.label }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(month.summary.total_income) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(month.summary.total_expense_total) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(month.summary.iva_balance) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(month.summary.gross_margin) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(month.summary.net_balance) }}</td>
+                                        </tr>
+                                        <tr v-if="year.months.length === 0">
+                                            <td colspan="6" class="px-4 py-4 text-center text-slate-400">Sin datos para este año.</td>
+                                        </tr>
+                                    </tbody>
+                                    <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                                        <tr>
+                                            <td class="px-4 py-3">Totales {{ year.year }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.total_income) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.total_expense_total) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.iva_balance) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.gross_margin) }}</td>
+                                            <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.net_balance) }}</td>
+                                        </tr>
+                                    </tfoot>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div v-else class="mt-6 overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                <tr>
+                                    <th scope="col" class="px-4 py-3">Año</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Ingresos (IVA incl.)</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Gastos (IVA incl.)</th>
+                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Margen bruto</th>
+                                    <th scope="col" class="px-4 py-3 text-right">Saldo neto</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <tr v-for="year in annualGroups" :key="year.key" class="bg-white/60">
+                                    <td class="px-4 py-3 font-medium text-slate-700">{{ year.label }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.total_income) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.total_expense_total) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.iva_balance) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.gross_margin) }}</td>
+                                    <td class="px-4 py-3 text-right">{{ formatCurrency(year.summary.net_balance) }}</td>
+                                </tr>
+                                <tr v-if="annualGroups.length === 0">
+                                    <td colspan="6" class="px-4 py-4 text-center text-slate-400">No hay datos para el modo anual.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section v-if="mode !== 'general'" class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
+                    <header class="flex flex-col gap-2 border-b border-slate-200 pb-4">
+                        <h2 class="text-xl font-semibold text-slate-800">Detalle por periodo</h2>
+                        <p class="text-sm text-slate-500">Cada bloque muestra los registros individuales de ingresos y gastos junto con sus totales para el periodo indicado.</p>
+                    </header>
+                    <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+                        <article
+                            v-for="group in groups"
+                            :key="group.key"
+                            class="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow"
+                        >
+                            <header class="flex flex-col gap-1 border-b border-slate-200 pb-4">
+                                <h3 class="text-lg font-semibold text-slate-800">{{ group.label }}</h3>
+                                <p class="text-sm text-slate-500">Periodo: {{ formatRange(group.range) }}</p>
+                                <p class="text-sm text-slate-500">
+                                    IVA: {{ formatCurrency(group.summary.iva_balance) }} · Margen bruto: {{ formatCurrency(group.summary.gross_margin) }} · Saldo neto: {{ formatCurrency(group.summary.net_balance) }}
+                                </p>
+                            </header>
+                            <div class="mt-4 grid grid-cols-1 gap-4">
+                                <div>
+                                    <h4 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Ingresos ({{ group.incomes.totals.count }})</h4>
+                                    <div class="mt-2 overflow-x-auto">
+                                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                                <tr>
+                                                    <th scope="col" class="px-3 py-2">Fecha</th>
+                                                    <th scope="col" class="px-3 py-2">Nombre</th>
+                                                    <th scope="col" class="px-3 py-2">Origen</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">Base</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">IVA</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">Total</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="divide-y divide-slate-100">
+                                                <tr v-for="income in group.incomes.items" :key="income.id" class="bg-white/60">
+                                                    <td class="px-3 py-2 whitespace-nowrap">{{ formatDate(income.date) }}</td>
+                                                    <td class="px-3 py-2 font-medium text-slate-700">{{ income.name }}</td>
+                                                    <td class="px-3 py-2">{{ income.source || '—' }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(income.tax_base ?? 0) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)) }}</td>
+                                                </tr>
+                                                <tr v-if="group.incomes.items.length === 0">
+                                                    <td colspan="6" class="px-3 py-3 text-center text-slate-400">Sin ingresos registrados.</td>
+                                                </tr>
+                                            </tbody>
+                                            <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                                                <tr>
+                                                    <td colspan="3" class="px-3 py-2">Totales</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.base) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.tax) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.total) }}</td>
+                                                </tr>
+                                            </tfoot>
+                                        </table>
+                                    </div>
+                                </div>
+                                <div>
+                                    <h4 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Gastos ({{ group.expenses.totals.count }})</h4>
+                                    <div class="mt-2 overflow-x-auto">
+                                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
+                                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
+                                                <tr>
+                                                    <th scope="col" class="px-3 py-2">Fecha</th>
+                                                    <th scope="col" class="px-3 py-2">Nombre</th>
+                                                    <th scope="col" class="px-3 py-2">Descripción</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">Base</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">IVA</th>
+                                                    <th scope="col" class="px-3 py-2 text-right">Total</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="divide-y divide-slate-100">
+                                                <tr v-for="expense in group.expenses.items" :key="expense.id" class="bg-white/60">
+                                                    <td class="px-3 py-2 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
+                                                    <td class="px-3 py-2 font-medium text-slate-700">{{ expense.name }}</td>
+                                                    <td class="px-3 py-2">{{ expense.description || '—' }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount + expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                                </tr>
+                                                <tr v-if="group.expenses.items.length === 0">
+                                                    <td colspan="6" class="px-3 py-3 text-center text-slate-400">Sin gastos registrados.</td>
+                                                </tr>
+                                            </tbody>
+                                            <tfoot class="bg-slate-50 text-xs uppercase tracking-widest text-slate-500">
+                                                <tr>
+                                                    <td colspan="3" class="px-3 py-2">Totales</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.base) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.tax) }}</td>
+                                                    <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.total) }}</td>
+                                                </tr>
+                                            </tfoot>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </article>
                     </div>
                 </section>
             </main>
@@ -154,7 +366,8 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, reactive, watch } from 'vue';
+import { router } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
 import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
@@ -164,76 +377,137 @@ import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 
 const props = defineProps({
-    expenses: {
+    report: {
+        type: Object,
+        default: () => ({}),
+    },
+    filters: {
+        type: Object,
+        default: () => ({}),
+    },
+    clients: {
         type: Array,
         default: () => [],
     },
-    incomes: {
-        type: Array,
-        default: () => [],
+});
+
+const filters = reactive({
+    start_date: props.filters.start_date ?? '',
+    end_date: props.filters.end_date ?? '',
+    mode: props.filters.mode ?? props.report?.mode ?? 'general',
+});
+
+watch(
+    () => props.filters,
+    (value) => {
+        filters.start_date = value.start_date ?? '';
+        filters.end_date = value.end_date ?? '';
+        filters.mode = value.mode ?? props.report?.mode ?? 'general';
     },
-});
+    { deep: true }
+);
 
-const filter = ref({
-    start_date: '',
-    end_date: '',
-});
+const mode = computed(() => props.report?.mode ?? filters.mode ?? 'general');
+const groups = computed(() => props.report?.groups ?? []);
+const overallSummary = computed(() => props.report?.overall?.summary ?? createEmptySummary());
 
-const parseDate = (value) => {
-    if (!value) {
-        return null;
-    }
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date;
-};
-
-const filteredExpenses = computed(() => {
-    if (!filter.value.start_date && !filter.value.end_date) {
-        return props.expenses;
-    }
-    const start = parseDate(filter.value.start_date);
-    const end = parseDate(filter.value.end_date);
-    return props.expenses.filter((expense) => {
-        const date = parseDate(expense.date);
-        if (!date) {
-            return false;
-        }
-        const afterStart = start ? date >= start : true;
-        const beforeEnd = end ? date <= end : true;
-        return afterStart && beforeEnd;
-    });
-});
-
-const filteredIncomes = computed(() => {
-    if (!filter.value.start_date && !filter.value.end_date) {
-        return props.incomes;
-    }
-    const start = parseDate(filter.value.start_date);
-    const end = parseDate(filter.value.end_date);
-    return props.incomes.filter((income) => {
-        const date = parseDate(income.date);
-        if (!date) {
-            return false;
-        }
-        const afterStart = start ? date >= start : true;
-        const beforeEnd = end ? date <= end : true;
-        return afterStart && beforeEnd;
-    });
-});
-
-const sumBy = (collection, callback) => {
-    return collection.reduce((total, item) => total + Number(callback(item) || 0), 0);
-};
-
-const totalExpenses = computed(() => sumBy(filteredExpenses.value, (expense) => expense.amount));
-const totalExpenseTaxes = computed(() => sumBy(filteredExpenses.value, (expense) => expense.amount * (expense.iva ?? 0) / 100));
-const totalIncomes = computed(() => sumBy(filteredIncomes.value, (income) => income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)));
-const totalIncomeBase = computed(() => sumBy(filteredIncomes.value, (income) => income.tax_base ?? 0));
-const totalIncomeTaxes = computed(() => sumBy(filteredIncomes.value, (income) => income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100));
-
-const netBalance = computed(() => totalIncomes.value - (totalExpenses.value + totalExpenseTaxes.value));
+const totalIncomes = computed(() => Number(overallSummary.value.total_income ?? 0));
+const totalIncomeBase = computed(() => Number(overallSummary.value.total_income_base ?? 0));
+const totalIncomeTaxes = computed(() => Number(overallSummary.value.total_income_tax ?? 0));
+const totalExpenses = computed(() => Number(overallSummary.value.total_expense_base ?? 0));
+const totalExpenseTaxes = computed(() => Number(overallSummary.value.total_expense_tax ?? 0));
+const totalExpensesWithTax = computed(() => Number(overallSummary.value.total_expense_total ?? totalExpenses.value + totalExpenseTaxes.value));
+const netBalance = computed(() => Number(overallSummary.value.net_balance ?? 0));
 const netBalanceLabel = computed(() => (netBalance.value >= 0 ? 'Beneficio neto' : 'Pérdida neta'));
-const ivaHelper = computed(() => `IVA: ${formatCurrency(totalIncomeTaxes.value - totalExpenseTaxes.value)}`);
+const grossMargin = computed(() => Number(overallSummary.value.gross_margin ?? 0));
+const ivaBalance = computed(() => Number(overallSummary.value.iva_balance ?? 0));
+
+const ivaAndMarginHelper = computed(
+    () => `IVA: ${formatCurrency(ivaBalance.value)} · Margen bruto: ${formatCurrency(grossMargin.value)}`
+);
+
+const totalIncomeCount = computed(() =>
+    groups.value.reduce((acc, group) => acc + Number(group?.incomes?.totals?.count ?? 0), 0)
+);
+const totalExpenseCount = computed(() =>
+    groups.value.reduce((acc, group) => acc + Number(group?.expenses?.totals?.count ?? 0), 0)
+);
+
+const generalGroup = computed(() => (mode.value === 'general' ? groups.value[0] ?? null : null));
+const generalExpenses = computed(() => generalGroup.value?.expenses?.items ?? []);
+const generalIncomes = computed(() => generalGroup.value?.incomes?.items ?? []);
+const generalExpenseTotals = computed(() => generalGroup.value?.expenses?.totals ?? createEmptyTotals());
+const generalIncomeTotals = computed(() => generalGroup.value?.incomes?.totals ?? createEmptyTotals());
+
+const monthlyYears = computed(() => {
+    if (mode.value !== 'monthly') {
+        return [];
+    }
+
+    const yearMap = new Map();
+
+    groups.value.forEach((group) => {
+        const [year] = group.key.split('-');
+        if (!yearMap.has(year)) {
+            yearMap.set(year, []);
+        }
+        yearMap.get(year).push(group);
+    });
+
+    return Array.from(yearMap.entries())
+        .map(([year, months]) => {
+            months.sort((a, b) => a.key.localeCompare(b.key));
+            return {
+                year,
+                months,
+                summary: sumSummaries(months),
+            };
+        })
+        .sort((a, b) => a.year.localeCompare(b.year));
+});
+
+const annualGroups = computed(() => {
+    if (mode.value !== 'annual') {
+        return [];
+    }
+
+    return groups.value.map((group) => ({
+        ...group,
+        summary: group.summary ?? createEmptySummary(),
+    }));
+});
+
+const applyFilters = () => {
+    router.get(
+        route('expenses.report'),
+        {
+            start_date: filters.start_date || undefined,
+            end_date: filters.end_date || undefined,
+            mode: filters.mode || undefined,
+        },
+        {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        }
+    );
+};
+
+const resetFilters = () => {
+    filters.start_date = '';
+    filters.end_date = '';
+    filters.mode = 'general';
+    applyFilters();
+};
+
+const printReport = () => {
+    const url = route('expenses.reportsPrint', {
+        start_date: filters.start_date || undefined,
+        end_date: filters.end_date || undefined,
+        mode: filters.mode || undefined,
+    });
+    window.open(url, '_blank');
+};
 
 const formatCurrency = (value) => {
     return new Intl.NumberFormat('es-ES', {
@@ -258,16 +532,51 @@ const formatDate = (value) => {
     }).format(date);
 };
 
-const resetFilters = () => {
-    filter.value.start_date = '';
-    filter.value.end_date = '';
+const formatRange = (range) => {
+    if (!range?.start && !range?.end) {
+        return 'Sin periodo';
+    }
+
+    if (range?.start && range?.end && range.start === range.end) {
+        return formatDate(range.start);
+    }
+
+    return `${range?.start ? formatDate(range.start) : '—'} – ${range?.end ? formatDate(range.end) : '—'}`;
 };
 
-const printReport = () => {
-    const url = route('expenses.reportsPrint', {
-        start_date: filter.value.start_date,
-        end_date: filter.value.end_date,
+function createEmptySummary() {
+    return {
+        total_income: 0,
+        total_income_base: 0,
+        total_income_tax: 0,
+        total_expense_base: 0,
+        total_expense_tax: 0,
+        total_expense_total: 0,
+        gross_margin: 0,
+        iva_balance: 0,
+        net_balance: 0,
+    };
+}
+
+function createEmptyTotals() {
+    return {
+        count: 0,
+        base: 0,
+        tax: 0,
+        total: 0,
+    };
+}
+
+function sumSummaries(items) {
+    const accumulator = createEmptySummary();
+
+    items.forEach((item) => {
+        const summary = item.summary ?? {};
+        Object.keys(accumulator).forEach((key) => {
+            accumulator[key] += Number(summary[key] ?? 0);
+        });
     });
-    window.open(url, '_blank');
-};
+
+    return accumulator;
+}
 </script>

--- a/resources/js/Pages/Expenses/ReportPrint.vue
+++ b/resources/js/Pages/Expenses/ReportPrint.vue
@@ -1,68 +1,208 @@
 <template>
-    <div class="p-6">
-        <h1 class="text-3xl font-bold mb-8">Reporte de Gastos e Ingresos</h1>
+    <div class="p-6 space-y-10 text-slate-800">
+        <header class="border-b border-slate-200 pb-6">
+            <h1 class="text-3xl font-bold">Reporte de Gastos e Ingresos</h1>
+            <p class="mt-2 text-sm text-slate-600">Modo: {{ modeLabel }}</p>
+            <p class="text-sm text-slate-600">Periodo: {{ formatRange(filters) }}</p>
+        </header>
 
-        <!-- Sección de Gastos -->
-        <h2 class="text-2xl font-semibold mt-8 mb-4">Gastos</h2>
-        <table class="min-w-full bg-white border border-gray-300 mb-8">
-            <thead>
-            <tr>
-                <th class="py-2 px-4 border-b">Fecha</th>
-                <th class="py-2 px-4 border-b">Nombre</th>
-                <th class="py-2 px-4 border-b">Descripción</th>
-                <th class="py-2 px-4 border-b">Monto</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="expense in expenses" :key="expense.id">
-                <td class="py-2 px-4 border-b">{{ expense.date }}</td>
-                <td class="py-2 px-4 border-b">{{ expense.name }}</td>
-                <td class="py-2 px-4 border-b">{{ expense.description }}</td>
-                <td class="py-2 px-4 border-b">{{ expense.amount }}</td>
-            </tr>
-            </tbody>
-        </table>
+        <section>
+            <h2 class="text-2xl font-semibold mb-4">Resumen general</h2>
+            <table class="min-w-full border border-slate-300 text-sm">
+                <thead class="bg-slate-100 text-left font-semibold text-slate-600">
+                    <tr>
+                        <th class="px-4 py-2">Indicador</th>
+                        <th class="px-4 py-2 text-right">Valor</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="border-t border-slate-200 px-4 py-2">Ingresos totales (IVA incluido)</td>
+                        <td class="border-t border-slate-200 px-4 py-2 text-right">{{ formatCurrency(overallSummary.total_income) }}</td>
+                    </tr>
+                    <tr>
+                        <td class="border-t border-slate-200 px-4 py-2">Gastos totales (IVA incluido)</td>
+                        <td class="border-t border-slate-200 px-4 py-2 text-right">{{ formatCurrency(overallSummary.total_expense_total) }}</td>
+                    </tr>
+                    <tr>
+                        <td class="border-t border-slate-200 px-4 py-2">IVA neto</td>
+                        <td class="border-t border-slate-200 px-4 py-2 text-right">{{ formatCurrency(overallSummary.iva_balance) }}</td>
+                    </tr>
+                    <tr>
+                        <td class="border-t border-slate-200 px-4 py-2">Margen bruto</td>
+                        <td class="border-t border-slate-200 px-4 py-2 text-right">{{ formatCurrency(overallSummary.gross_margin) }}</td>
+                    </tr>
+                    <tr>
+                        <td class="border-t border-slate-200 px-4 py-2 font-semibold">Saldo neto</td>
+                        <td class="border-t border-slate-200 px-4 py-2 text-right font-semibold">{{ formatCurrency(overallSummary.net_balance) }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
 
-        <!-- Sección de Ingresos -->
-        <h2 class="text-2xl font-semibold mt-8 mb-4">Ingresos</h2>
-        <table class="min-w-full bg-white border border-gray-300 mb-8">
-            <thead>
-            <tr>
-                <th class="py-2 px-4 border-b">Fecha</th>
-                <th class="py-2 px-4 border-b">Nombre</th>
-                <th class="py-2 px-4 border-b">Cliente</th>
-                <th class="py-2 px-4 border-b">Monto</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="income in incomes" :key="income.id">
-                <td class="py-2 px-4 border-b">{{ income.date }}</td>
-                <td class="py-2 px-4 border-b">{{ income.name }}</td>
-                <td class="py-2 px-4 border-b">{{ income.source }}</td>
-                <td class="py-2 px-4 border-b">{{ income.total_amount }}</td>
-            </tr>
-            </tbody>
-        </table>
+        <section>
+            <h2 class="text-2xl font-semibold mb-4">Resumen por periodo</h2>
+            <div v-if="mode === 'monthly'" class="space-y-8">
+                <div v-for="year in monthlyYears" :key="year.year" class="border border-slate-300">
+                    <header class="border-b border-slate-200 bg-slate-50 px-4 py-3 font-semibold">{{ year.year }}</header>
+                    <table class="min-w-full text-sm">
+                        <thead class="bg-slate-100 text-left text-slate-600">
+                            <tr>
+                                <th class="px-4 py-2">Mes</th>
+                                <th class="px-4 py-2 text-right">Ingresos</th>
+                                <th class="px-4 py-2 text-right">Gastos</th>
+                                <th class="px-4 py-2 text-right">IVA</th>
+                                <th class="px-4 py-2 text-right">Margen bruto</th>
+                                <th class="px-4 py-2 text-right">Saldo neto</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="month in year.months" :key="month.key" class="border-t border-slate-200">
+                                <td class="px-4 py-2">{{ month.label }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(month.summary.total_income) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(month.summary.total_expense_total) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(month.summary.iva_balance) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(month.summary.gross_margin) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(month.summary.net_balance) }}</td>
+                            </tr>
+                            <tr v-if="year.months.length === 0">
+                                <td colspan="6" class="px-4 py-3 text-center text-slate-400">Sin datos para este año.</td>
+                            </tr>
+                        </tbody>
+                        <tfoot class="bg-slate-50 font-semibold text-slate-700">
+                            <tr>
+                                <td class="px-4 py-2">Totales {{ year.year }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(year.summary.total_income) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(year.summary.total_expense_total) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(year.summary.iva_balance) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(year.summary.gross_margin) }}</td>
+                                <td class="px-4 py-2 text-right">{{ formatCurrency(year.summary.net_balance) }}</td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+            <div v-else>
+                <table class="min-w-full border border-slate-300 text-sm">
+                    <thead class="bg-slate-100 text-left text-slate-600">
+                        <tr>
+                            <th class="px-4 py-2">Periodo</th>
+                            <th class="px-4 py-2 text-right">Ingresos</th>
+                            <th class="px-4 py-2 text-right">Gastos</th>
+                            <th class="px-4 py-2 text-right">IVA</th>
+                            <th class="px-4 py-2 text-right">Margen bruto</th>
+                            <th class="px-4 py-2 text-right">Saldo neto</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="group in groups" :key="group.key" class="border-t border-slate-200">
+                            <td class="px-4 py-2">{{ group.label }}</td>
+                            <td class="px-4 py-2 text-right">{{ formatCurrency(group.summary.total_income) }}</td>
+                            <td class="px-4 py-2 text-right">{{ formatCurrency(group.summary.total_expense_total) }}</td>
+                            <td class="px-4 py-2 text-right">{{ formatCurrency(group.summary.iva_balance) }}</td>
+                            <td class="px-4 py-2 text-right">{{ formatCurrency(group.summary.gross_margin) }}</td>
+                            <td class="px-4 py-2 text-right">{{ formatCurrency(group.summary.net_balance) }}</td>
+                        </tr>
+                        <tr v-if="groups.length === 0">
+                            <td colspan="6" class="px-4 py-3 text-center text-slate-400">No hay datos para el periodo seleccionado.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
 
-        <!-- Sección de Comparativa de Beneficios -->
-        <h2 class="text-2xl font-semibold mt-8 mb-4">Comparativa de Beneficios</h2>
-        <div class="bg-white border border-gray-300 p-4 mb-8">
-            <p><strong>Beneficio Bruto:</strong> {{ grossBenefit }}</p>
-            <p><strong>Monto de IVA:</strong> {{ ivaAmount }}</p>
-            <p><strong>Beneficio Neto:</strong> {{ netBenefit }}</p>
-        </div>
+        <section>
+            <h2 class="text-2xl font-semibold mb-4">Detalle por periodo</h2>
+            <div class="space-y-8">
+                <article v-for="group in groups" :key="group.key" class="border border-slate-300">
+                    <header class="border-b border-slate-200 bg-slate-50 px-4 py-3">
+                        <h3 class="text-lg font-semibold">{{ group.label }}</h3>
+                        <p class="text-sm text-slate-600">Periodo: {{ formatRange(group.range) }}</p>
+                        <p class="text-sm text-slate-600">
+                            IVA: {{ formatCurrency(group.summary.iva_balance) }} · Margen bruto: {{ formatCurrency(group.summary.gross_margin) }} · Saldo neto: {{ formatCurrency(group.summary.net_balance) }}
+                        </p>
+                    </header>
+                    <div class="grid grid-cols-1 gap-6 p-4 lg:grid-cols-2">
+                        <div>
+                            <h4 class="text-sm font-semibold uppercase tracking-widest text-slate-500 mb-2">Ingresos ({{ group.incomes.totals.count }})</h4>
+                            <table class="min-w-full border border-slate-200 text-xs">
+                                <thead class="bg-slate-100 text-left text-slate-600">
+                                    <tr>
+                                        <th class="px-3 py-2">Fecha</th>
+                                        <th class="px-3 py-2">Nombre</th>
+                                        <th class="px-3 py-2">Origen</th>
+                                        <th class="px-3 py-2 text-right">Base</th>
+                                        <th class="px-3 py-2 text-right">IVA</th>
+                                        <th class="px-3 py-2 text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="income in group.incomes.items" :key="income.id" class="border-t border-slate-200">
+                                        <td class="px-3 py-2">{{ formatDate(income.date) }}</td>
+                                        <td class="px-3 py-2">{{ income.name }}</td>
+                                        <td class="px-3 py-2">{{ income.source || '—' }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(income.tax_base ?? 0) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(income.tax_amount ?? (income.tax_base ?? 0) * (income.tax_rate ?? 0) / 100) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(income.total_amount ?? (income.tax_base ?? 0) + (income.tax_amount ?? 0)) }}</td>
+                                    </tr>
+                                    <tr v-if="group.incomes.items.length === 0">
+                                        <td colspan="6" class="px-3 py-3 text-center text-slate-400">Sin ingresos registrados.</td>
+                                    </tr>
+                                </tbody>
+                                <tfoot class="bg-slate-100 font-semibold text-slate-600">
+                                    <tr>
+                                        <td colspan="3" class="px-3 py-2">Totales</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.base) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.tax) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.incomes.totals.total) }}</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                        <div>
+                            <h4 class="text-sm font-semibold uppercase tracking-widest text-slate-500 mb-2">Gastos ({{ group.expenses.totals.count }})</h4>
+                            <table class="min-w-full border border-slate-200 text-xs">
+                                <thead class="bg-slate-100 text-left text-slate-600">
+                                    <tr>
+                                        <th class="px-3 py-2">Fecha</th>
+                                        <th class="px-3 py-2">Nombre</th>
+                                        <th class="px-3 py-2">Descripción</th>
+                                        <th class="px-3 py-2 text-right">Base</th>
+                                        <th class="px-3 py-2 text-right">IVA</th>
+                                        <th class="px-3 py-2 text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="expense in group.expenses.items" :key="expense.id" class="border-t border-slate-200">
+                                        <td class="px-3 py-2">{{ formatDate(expense.date) }}</td>
+                                        <td class="px-3 py-2">{{ expense.name }}</td>
+                                        <td class="px-3 py-2">{{ expense.description || '—' }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(expense.amount + expense.amount * (expense.iva ?? 0) / 100) }}</td>
+                                    </tr>
+                                    <tr v-if="group.expenses.items.length === 0">
+                                        <td colspan="6" class="px-3 py-3 text-center text-slate-400">Sin gastos registrados.</td>
+                                    </tr>
+                                </tbody>
+                                <tfoot class="bg-slate-100 font-semibold text-slate-600">
+                                    <tr>
+                                        <td colspan="3" class="px-3 py-2">Totales</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.base) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.tax) }}</td>
+                                        <td class="px-3 py-2 text-right">{{ formatCurrency(group.expenses.totals.total) }}</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
 
-        <!-- Información de fechas -->
-        <div class="mt-8">
-            <p><strong>Fechas:</strong> {{ start_date }} - {{ end_date }}</p>
-        </div>
-
-        <!-- Botón de imprimir -->
-        <div class="mt-8">
-            <button @click="printReport" class="bg-blue-900 text-white px-4 py-2 rounded">
-                Imprimir Reporte
-            </button>
-        </div>
+        <footer class="border-t border-slate-200 pt-6">
+            <button @click="printReport" class="bg-blue-900 text-white px-4 py-2 rounded shadow">Imprimir reporte</button>
+        </footer>
     </div>
 </template>
 
@@ -70,69 +210,126 @@
 import { computed } from 'vue';
 
 const props = defineProps({
-    expenses: Array,
-    incomes: Array,
-    clients: Array,
-    start_date: String,
-    end_date: String,
+    report: {
+        type: Object,
+        default: () => ({}),
+    },
+    filters: {
+        type: Object,
+        default: () => ({}),
+    },
+    clients: {
+        type: Array,
+        default: () => [],
+    },
 });
 
-// Filtrado de gastos e ingresos por fecha
-const filteredExpenses = computed(() => {
-    return props.expenses
-});
-const filteredIncomes = computed(() => {
-    return props.incomes
-});
-
-console.log(filteredExpenses.value);
-console.log(filteredIncomes.value);
-
-// Cálculos de beneficios
-const grossBenefit = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount, 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount, 0);
-    return totalIncomes - totalExpenses; // Beneficio bruto
+const mode = computed(() => props.report?.mode ?? 'general');
+const modeLabel = computed(() => {
+    switch (mode.value) {
+        case 'monthly':
+            return 'Mensual';
+        case 'annual':
+            return 'Anual';
+        default:
+            return 'General';
+    }
 });
 
-const ivaAmount = computed(() => {
-    const totalExpenses = filteredExpenses.value.reduce((total, expense) => total + expense.amount * (expense.iva / 100), 0);
-    const totalIncomes = filteredIncomes.value.reduce((total, income) => total + income.total_amount * (income.tax_rate / 100), 0);
-    return totalIncomes - totalExpenses; // Monto de IVA
+const groups = computed(() => props.report?.groups ?? []);
+const overallSummary = computed(() => props.report?.overall?.summary ?? createEmptySummary());
+
+const monthlyYears = computed(() => {
+    if (mode.value !== 'monthly') {
+        return [];
+    }
+
+    const yearMap = new Map();
+
+    groups.value.forEach((group) => {
+        const [year] = group.key.split('-');
+        if (!yearMap.has(year)) {
+            yearMap.set(year, []);
+        }
+        yearMap.get(year).push(group);
+    });
+
+    return Array.from(yearMap.entries())
+        .map(([year, months]) => {
+            months.sort((a, b) => a.key.localeCompare(b.key));
+            return {
+                year,
+                months,
+                summary: sumSummaries(months),
+            };
+        })
+        .sort((a, b) => a.year.localeCompare(b.year));
 });
 
-const netBenefit = computed(() => {
-    return grossBenefit.value - ivaAmount.value; // Beneficio neto
-});
+const filters = computed(() => ({
+    start: props.filters.start_date ?? null,
+    end: props.filters.end_date ?? null,
+}));
 
-// Método para imprimir el reporte
-const printReport = () => {
-    window.print(); // Llama a la función de impresión del navegador
+const printReport = () => window.print();
+
+const formatCurrency = (value) => {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
 };
-</script>
 
-<style>
-@media print {
-    /* Estilos para la impresión */
-    body {
-        font-family: Arial, sans-serif;
+const formatDate = (value) => {
+    if (!value) {
+        return 'Sin fecha';
     }
-    table {
-        width: 100%;
-        border-collapse: collapse;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
     }
-    th, td {
-        border: 1px solid #ddd;
-        padding: 8px;
+    return new Intl.DateTimeFormat('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+};
+
+const formatRange = (range) => {
+    if (!range?.start && !range?.end) {
+        return 'Sin periodo';
     }
-    th {
-        background-color: #f2f2f2;
+    if (range.start && range.end && range.start === range.end) {
+        return formatDate(range.start);
     }
-    tr:nth-child(even) {
-        background-color: #f2f2f2;
-    }
-    button {
-        display: none;
-    }
+    return `${range?.start ? formatDate(range.start) : '—'} – ${range?.end ? formatDate(range.end) : '—'}`;
+};
+
+function createEmptySummary() {
+    return {
+        total_income: 0,
+        total_income_base: 0,
+        total_income_tax: 0,
+        total_expense_base: 0,
+        total_expense_tax: 0,
+        total_expense_total: 0,
+        gross_margin: 0,
+        iva_balance: 0,
+        net_balance: 0,
+    };
 }
-</style>
+
+function sumSummaries(items) {
+    const accumulator = createEmptySummary();
+
+    items.forEach((item) => {
+        const summary = item.summary ?? {};
+        Object.keys(accumulator).forEach((key) => {
+            accumulator[key] += Number(summary[key] ?? 0);
+        });
+    });
+
+    return accumulator;
+}
+</script>


### PR DESCRIPTION
## Summary
- add server-side aggregation helpers for expense reports so monthly and annual modes provide period summaries with IVA and margin balances
- refresh the interactive expense report UI to submit filters to the server, expose mode selection, and render grouped summaries and detailed tables per period
- align the printable report view with the new grouped data so printed exports include the same breakdowns and totals

## Testing
- npm run build *(fails: missing dependency `xlsx` referenced from resources/js/Pages/Leads/Index.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68fa423c16b48323a67e00b811182986