### PR TITLE
Add remember token column to users table

### DIFF
--- a/database/migrations/2024_10_10_000001_add_remember_token_to_users_table.php
+++ b/database/migrations/2024_10_10_000001_add_remember_token_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'remember_token')) {
+                $table->rememberToken()->after('password');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'remember_token')) {
+                $table->dropColumn('remember_token');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that introduces the `remember_token` column to the users table
- ensure the new column can be safely rolled back

## Testing
- `php artisan test` *(fails: missing vendor autoloader in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e8ccdd448323b6981ec4c62af0d9