### PR TITLE
Generate invoice numbers for Avero imports

### DIFF
--- a/app/Http/Controllers/Api/AveroInvoiceController.php
+++ b/app/Http/Controllers/Api/AveroInvoiceController.php
@@ -10,7 +10,9 @@ use App\Models\Invoice;
 use App\Models\InvoiceItem;
 use App\Models\Product;
 use App\Services\AveroInvoiceNotifier;
+use App\Services\DocumentNumberGenerator;
 use App\Services\DocumentTotalsCalculator;
+use Carbon\Carbon;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -108,13 +110,25 @@ class AveroInvoiceController extends Controller
                 Log::info('Calculated totals for Avero invoice import', ['totals' => $totals]);
 
                 $summary = $validated['summary'];
-                Log::debug('Creating invoice from Avero payload', ['summary' => $summary]);
+                $issueDate = Carbon::parse($validated['date']);
+                $invoiceNumber = DocumentNumberGenerator::generate(
+                    Invoice::class,
+                    'name',
+                    config('services.avero.invoice_prefix', 'FA'),
+                    $company->id,
+                    $issueDate
+                );
+
+                Log::debug('Creating invoice from Avero payload', [
+                    'summary' => $summary,
+                    'generated_invoice_number' => $invoiceNumber,
+                ]);
                 $invoice = Invoice::create([
                     'company_id' => $company->id,
                     'client_id' => $client->id,
-                    'date' => $validated['date'],
+                    'date' => $issueDate->toDateString(),
                     'due_date' => $validated['due_date'] ?? null,
-                    'name' => $validated['document_number'],
+                    'name' => $invoiceNumber,
                     'state' => 'pending',
                     'base_imponible' => $summary['base_imponible'],
                     'iva' => $totals['effectiveRate'],


### PR DESCRIPTION
## Summary
- ensure invoices imported from Avero use Jesty's own sequential numbering instead of the external document number
- log the generated number and normalize the stored issue date so the new generator input is consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db9944d448323bcf1b420b914cf6f)