### PR TITLE
Implement full Avero invoice intake flow

### DIFF
--- a/app/Http/Controllers/Api/AveroInvoiceController.php
+++ b/app/Http/Controllers/Api/AveroInvoiceController.php
@@ -9,8 +9,10 @@ use App\Models\Company;
 use App\Models\Invoice;
 use App\Models\InvoiceItem;
 use App\Models\Product;
+use App\Services\DocumentNumberGenerator;
 use App\Services\DocumentTotalsCalculator;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -29,14 +31,15 @@ class AveroInvoiceController extends Controller
         ]);
 
         $validated = $request->validate([
-            'document_number' => 'required|string|max:255',
+            'document_number' => 'nullable|string|max:255',
+            'source_reference' => 'nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'nullable|date',
             'notes' => 'nullable|string',
             'client.name' => 'required|string|max:255',
             'client.nif' => 'required|string|max:255',
-            'client.email' => 'nullable|email',
-            'client.address' => 'nullable|string',
+            'client.email' => 'required|email',
+            'client.address' => 'required|string',
             'client.city' => 'nullable|string',
             'client.postal_code' => 'nullable|string',
             'client.country' => 'nullable|string',
@@ -62,12 +65,29 @@ class AveroInvoiceController extends Controller
             'items_count' => count($validated['items']),
         ]);
 
-        try {
-            $invoice = DB::transaction(function () use ($validated) {
-                Log::debug('Resolving company for Avero invoice import');
-                $company = $this->resolveCompany();
-                Log::info('Company resolved for Avero invoice import', ['company_id' => $company->id]);
+        $externalReference = $validated['document_number'] ?? ($validated['source_reference'] ?? null);
 
+        try {
+            $company = $this->resolveCompany();
+            Log::info('Company resolved for Avero invoice import', ['company_id' => $company->id]);
+
+            if (! empty($externalReference)) {
+                $existingInvoice = $this->findInvoiceByExternalReference($company->id, $externalReference);
+
+                if ($existingInvoice) {
+                    $existingInvoice = $existingInvoice->fresh(['client', 'company', 'items.product']);
+                    Log::info('Invoice already imported from Avero, returning existing data', [
+                        'invoice_id' => $existingInvoice->id,
+                        'external_reference' => $externalReference,
+                    ]);
+
+                    $pdfUrl = $this->ensureInvoicePdf($existingInvoice);
+
+                    return response()->json($this->formatInvoiceResponse($existingInvoice, $pdfUrl));
+                }
+            }
+
+            $invoice = DB::transaction(function () use ($validated, $company, $externalReference) {
                 Log::debug('Resolving client for Avero invoice import', ['client' => $validated['client']]);
                 $client = $this->findOrCreateClient($company->id, $validated['client']);
                 Log::info('Client resolved for Avero invoice import', ['client_id' => $client->id]);
@@ -103,13 +123,27 @@ class AveroInvoiceController extends Controller
                 Log::info('Calculated totals for Avero invoice import', ['totals' => $totals]);
 
                 $summary = $validated['summary'];
-                Log::debug('Creating invoice from Avero payload', ['summary' => $summary]);
+                $invoiceNumber = DocumentNumberGenerator::generate(
+                    Invoice::class,
+                    'number',
+                    config('services.avero.invoice_prefix', 'FA'),
+                    $company->id,
+                    Carbon::parse($validated['date'])
+                );
+
+                Log::debug('Creating invoice from Avero payload', [
+                    'summary' => $summary,
+                    'invoice_number' => $invoiceNumber,
+                ]);
+
                 $invoice = Invoice::create([
                     'company_id' => $company->id,
                     'client_id' => $client->id,
                     'date' => $validated['date'],
                     'due_date' => $validated['due_date'] ?? null,
-                    'name' => $validated['document_number'],
+                    'name' => $invoiceNumber,
+                    'number' => $invoiceNumber,
+                    'external_reference' => $externalReference,
                     'state' => 'pending',
                     'base_imponible' => $summary['base_imponible'],
                     'iva' => $totals['effectiveRate'],
@@ -145,26 +179,16 @@ class AveroInvoiceController extends Controller
                 return $invoice;
             });
 
-            Log::debug('Generating PDF for Avero invoice', ['invoice_id' => $invoice->id]);
-            $pdfUrl = $this->generateInvoicePdf($invoice->fresh(['client', 'company', 'items.product']));
+            $invoice = $invoice->fresh(['client', 'company', 'items.product']);
+            $pdfUrl = $this->ensureInvoicePdf($invoice);
             Log::info('PDF generated for Avero invoice', ['invoice_id' => $invoice->id, 'pdf_url' => $pdfUrl]);
 
             Log::info('Invoice import from Avero completed successfully', [
                 'invoice_id' => $invoice->id,
-                'response' => [
-                    'status' => 'success',
-                    'message' => null,
-                    'pdf_url' => $pdfUrl,
-                    'invoice_id' => $invoice->id,
-                ],
+                'invoice_number' => $invoice->number,
             ]);
 
-            return response()->json([
-                'status' => 'success',
-                'message' => null,
-                'pdf_url' => $pdfUrl,
-                'invoice_id' => $invoice->id,
-            ]);
+            return response()->json($this->formatInvoiceResponse($invoice, $pdfUrl));
         } catch (Throwable $exception) {
             Log::error('Error importing invoice from Avero', [
                 'message' => $exception->getMessage(),
@@ -173,8 +197,7 @@ class AveroInvoiceController extends Controller
             ]);
 
             return response()->json([
-                'status' => 'error',
-                'message' => $exception->getMessage(),
+                'message' => 'Internal server error.',
             ], 500);
         }
     }
@@ -273,22 +296,60 @@ class AveroInvoiceController extends Controller
         return $product;
     }
 
-    protected function generateInvoicePdf(Invoice $invoice): string
+    protected function ensureInvoicePdf(Invoice $invoice): string
     {
-        Log::debug('Rendering invoice PDF for Avero import', ['invoice_id' => $invoice->id]);
-        $pdf = Pdf::loadView('pdfs.invoice', [
-            'invoice' => $invoice,
-            'client' => $invoice->client,
-            'company' => $invoice->company,
-        ]);
+        $invoice->loadMissing('client', 'company', 'items.product');
 
-        $fileName = sprintf('invoices/%s-%s.pdf', $invoice->name, Str::uuid());
-        Log::debug('Storing invoice PDF for Avero import', ['invoice_id' => $invoice->id, 'file_name' => $fileName]);
-        Storage::disk('public')->put($fileName, $pdf->output());
+        $disk = Storage::disk('public');
+        $shouldGenerate = empty($invoice->pdf_path) || ! $disk->exists($invoice->pdf_path);
 
-        $invoice->forceFill(['pdf_path' => $fileName])->save();
+        if ($shouldGenerate) {
+            Log::debug('Rendering invoice PDF for Avero import', ['invoice_id' => $invoice->id]);
+            $pdf = Pdf::loadView('pdfs.invoice', [
+                'invoice' => $invoice,
+                'client' => $invoice->client,
+                'company' => $invoice->company,
+            ]);
 
-        return Storage::disk('public')->url($fileName);
+            $fileName = sprintf(
+                'invoices/%s-%s.pdf',
+                Str::slug($invoice->number ?? $invoice->name ?? (string) $invoice->id),
+                Str::uuid()
+            );
+
+            Log::debug('Storing invoice PDF for Avero import', ['invoice_id' => $invoice->id, 'file_name' => $fileName]);
+            $disk->put($fileName, $pdf->output());
+
+            $invoice->forceFill(['pdf_path' => $fileName])->save();
+        }
+
+        if (! $invoice->public_token) {
+            $invoice->forceFill(['public_token' => (string) Str::uuid()])->save();
+        }
+
+        return route('invoices.public.show', ['token' => $invoice->public_token]);
+    }
+
+    protected function findInvoiceByExternalReference(int $companyId, ?string $reference): ?Invoice
+    {
+        if (! $reference) {
+            return null;
+        }
+
+        return Invoice::where('company_id', $companyId)
+            ->where('external_reference', $reference)
+            ->first();
+    }
+
+    protected function formatInvoiceResponse(Invoice $invoice, string $pdfUrl): array
+    {
+        return [
+            'invoice_id' => $invoice->id,
+            'invoice_number' => $invoice->number ?? $invoice->name,
+            'invoice_date' => $invoice->date ? $invoice->date->toDateString() : null,
+            'invoice_total' => (float) $invoice->total,
+            'invoice_url' => $pdfUrl,
+        ];
     }
 
     protected function calculateLineTotal(float $quantity, float $unitPrice, float $discount): float

--- a/app/Http/Controllers/InvoicePublicController.php
+++ b/app/Http/Controllers/InvoicePublicController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Invoice;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+
+class InvoicePublicController extends Controller
+{
+    public function __invoke(string $token)
+    {
+        $invoice = Invoice::whereNotNull('public_token')
+            ->where('public_token', $token)
+            ->firstOrFail();
+
+        if (! $invoice->pdf_path || ! Storage::disk('public')->exists($invoice->pdf_path)) {
+            abort(404);
+        }
+
+        $fileName = sprintf('%s.pdf', $invoice->number ?? $invoice->name ?? $invoice->id);
+
+        return new Response(
+            Storage::disk('public')->get($invoice->pdf_path),
+            200,
+            [
+                'Content-Type' => 'application/pdf',
+                'Content-Disposition' => sprintf('inline; filename="%s"', $fileName),
+            ]
+        );
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -12,9 +12,12 @@ class Invoice extends Model
     protected $fillable = [
         'recurring_invoice_id',
         'client_id',
+        'company_id',
         'date',
         'due_date',
         'name',
+        'number',
+        'external_reference',
         'base_imponible',
         'iva',
         'monto_iva',
@@ -23,8 +26,19 @@ class Invoice extends Model
         'notes',
         'irpf_tax',
         'total_irpf',
-        'company_id',
         'pdf_path',
+        'public_token',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'due_date' => 'date',
+        'base_imponible' => 'float',
+        'iva' => 'float',
+        'monto_iva' => 'float',
+        'total' => 'float',
+        'irpf_tax' => 'float',
+        'total_irpf' => 'float',
     ];
 
     public function company()

--- a/config/services.php
+++ b/config/services.php
@@ -43,6 +43,7 @@ return [
     'avero' => [
         'company_id' => env('AVERO_COMPANY_ID'),
         'default_category' => env('AVERO_CATEGORY', 'Avero'),
+        'invoice_prefix' => env('AVERO_INVOICE_PREFIX', 'FA'),
     ],
 
 ];

--- a/database/migrations/2025_09_01_000000_add_numbering_fields_to_invoices_table.php
+++ b/database/migrations/2025_09_01_000000_add_numbering_fields_to_invoices_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (! Schema::hasColumn('invoices', 'number')) {
+                $table->string('number')->nullable()->after('name');
+                $table->index(['company_id', 'number']);
+            }
+
+            if (! Schema::hasColumn('invoices', 'external_reference')) {
+                $table->string('external_reference')->nullable()->after('number');
+                $table->index(['company_id', 'external_reference']);
+            }
+
+            if (! Schema::hasColumn('invoices', 'public_token')) {
+                $table->string('public_token')->nullable()->after('pdf_path');
+                $table->unique('public_token');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (Schema::hasColumn('invoices', 'public_token')) {
+                $table->dropUnique('invoices_public_token_unique');
+                $table->dropColumn('public_token');
+            }
+
+            if (Schema::hasColumn('invoices', 'external_reference')) {
+                $table->dropIndex('invoices_company_id_external_reference_index');
+                $table->dropColumn('external_reference');
+            }
+
+            if (Schema::hasColumn('invoices', 'number')) {
+                $table->dropIndex('invoices_company_id_number_index');
+                $table->dropColumn('number');
+            }
+        });
+    }
+};

--- a/resources/views/pdfs/invoice.blade.php
+++ b/resources/views/pdfs/invoice.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Factura #{{ $invoice->name ?? $invoice->id }}</title>
+    <title>Factura #{{ $invoice->number ?? $invoice->name ?? $invoice->id }}</title>
     <style>
         * {
             box-sizing: border-box;
@@ -80,7 +80,7 @@
 </head>
 <body>
 <header>
-    <p><strong>Número:</strong> {{ $invoice->name }}</p>
+    <p><strong>Número:</strong> {{ $invoice->number ?? $invoice->name ?? $invoice->id }}</p>
     <p><strong>Fecha:</strong> {{ $invoice->date }}</p>
     @if($invoice->due_date)
         <p><strong>Vencimiento:</strong> {{ $invoice->due_date }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\ExpenseCategoryController;
 use App\Http\Controllers\ExpenseController;
 use App\Http\Controllers\IncomeController;
+use App\Http\Controllers\InvoicePublicController;
 use App\Http\Controllers\InvoiceController;
 use App\Http\Controllers\InvoiceItemController;
 use App\Http\Controllers\LeadController;
@@ -37,6 +38,8 @@ use Inertia\Inertia;
 |
 */
 
+
+Route::get('invoices/public/{token}', InvoicePublicController::class)->name('invoices.public.show');
 
 Route::get('/', function () {
     return Inertia::render('Welcome', [


### PR DESCRIPTION
## Summary
- add numbering/public-token columns for invoices and expose the invoice prefix setting
- implement the full Avero ingestion flow with client reuse, JesTy numbering, PDF generation, idempotency, and the required response payload
- expose secure public invoice downloads and show the internal number in the rendered PDF

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in the provided environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dcda1cda48323962a75a82f9f6307)