### PR TITLE
Fix invoice numbering to rely on stored numbers

### DIFF
--- a/app/Services/DocumentNumberGenerator.php
+++ b/app/Services/DocumentNumberGenerator.php
@@ -16,7 +16,6 @@ class DocumentNumberGenerator
         $pattern = sprintf('%s-%s-', $prefix, $yearSuffix);
 
         $latestDocument = $modelClass::where('company_id', $companyId)
-            ->whereYear('date', $year)
             ->where($numberColumn, 'like', $pattern . '%')
             ->orderBy($numberColumn, 'desc')
             ->first();

--- a/tests/Unit/DocumentNumberGeneratorTest.php
+++ b/tests/Unit/DocumentNumberGeneratorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Services\DocumentNumberGenerator;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DocumentNumberGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backdated_invoice_numbers_are_considered_when_generating_sequence(): void
+    {
+        $company = Company::factory()->create();
+
+        $client = Client::create([
+            'company_id' => $company->id,
+            'name' => 'Client Test',
+            'nif' => 'A12345678',
+        ]);
+
+        Invoice::create([
+            'company_id' => $company->id,
+            'client_id' => $client->id,
+            'name' => 'FA-25-0005',
+            'date' => Carbon::create(2024, 12, 31),
+            'state' => 'in_process',
+            'base_imponible' => 100,
+            'iva' => 21,
+            'monto_iva' => 21,
+            'total' => 121,
+        ]);
+
+        $nextNumber = DocumentNumberGenerator::generate(
+            Invoice::class,
+            'name',
+            'FA',
+            $company->id,
+            Carbon::create(2025, 1, 5)
+        );
+
+        $this->assertSame('FA-25-0006', $nextNumber);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure document numbers increment based on the stored number column prefix rather than the invoice date
- add a regression test proving that a backdated invoice with a 2025 number still advances the counter

## Testing
- `./vendor/bin/phpunit tests/Unit/DocumentNumberGeneratorTest.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd7be249883238b19861654aaca11)