### PR TITLE
Sort listings by newest first

### DIFF
--- a/resources/js/Pages/Budgets/Index.vue
+++ b/resources/js/Pages/Budgets/Index.vue
@@ -344,14 +344,17 @@ const filters = reactive({
     end_date: ''
 });
 
-const filteredBudgets = computed(() => props.budgets.filter(budget => {
-    const matchesState = !filters.state || budget.state === filters.state;
-    const matchesClient = !filters.client_id || budget.client_id === filters.client_id;
-    const matchesStartDate = !filters.start_date || new Date(budget.date) >= new Date(filters.start_date);
-    const matchesEndDate = !filters.end_date || new Date(budget.date) <= new Date(filters.end_date);
+const filteredBudgets = computed(() => props.budgets
+    .filter(budget => {
+        const matchesState = !filters.state || budget.state === filters.state;
+        const matchesClient = !filters.client_id || budget.client_id === filters.client_id;
+        const matchesStartDate = !filters.start_date || new Date(budget.date) >= new Date(filters.start_date);
+        const matchesEndDate = !filters.end_date || new Date(budget.date) <= new Date(filters.end_date);
 
-    return matchesState && matchesClient && matchesStartDate && matchesEndDate;
-}));
+        return matchesState && matchesClient && matchesStartDate && matchesEndDate;
+    })
+    .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0))
+);
 
 const filteredBudgetsTotal = computed(() => filteredBudgets.value.reduce((total, budget) => total + Number(budget.total || 0), 0));
 

--- a/resources/js/Pages/Invoices/Index.vue
+++ b/resources/js/Pages/Invoices/Index.vue
@@ -348,18 +348,21 @@ const startDate = ref('');
 const endDate = ref('');
 const minTotal = ref(null);
 
-const filteredInvoices = computed(() => props.invoices.filter(invoice => {
-    const clientMatch = selectedClient.value === '' || invoice.client_id === selectedClient.value;
-    const statusMatch = selectedStatus.value === '' || invoice.state === selectedStatus.value;
+const filteredInvoices = computed(() => props.invoices
+    .filter(invoice => {
+        const clientMatch = selectedClient.value === '' || invoice.client_id === selectedClient.value;
+        const statusMatch = selectedStatus.value === '' || invoice.state === selectedStatus.value;
 
-    const invoiceDate = new Date(invoice.date);
-    const startDateMatch = startDate.value === '' || invoiceDate >= new Date(startDate.value);
-    const endDateMatch = endDate.value === '' || invoiceDate <= new Date(endDate.value);
+        const invoiceDate = new Date(invoice.date);
+        const startDateMatch = startDate.value === '' || invoiceDate >= new Date(startDate.value);
+        const endDateMatch = endDate.value === '' || invoiceDate <= new Date(endDate.value);
 
-    const totalMatch = minTotal.value === null || Number(invoice.total) >= Number(minTotal.value || 0);
+        const totalMatch = minTotal.value === null || Number(invoice.total) >= Number(minTotal.value || 0);
 
-    return clientMatch && statusMatch && startDateMatch && endDateMatch && totalMatch;
-}));
+        return clientMatch && statusMatch && startDateMatch && endDateMatch && totalMatch;
+    })
+    .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0))
+);
 
 const filteredInvoicesTotal = computed(() => filteredInvoices.value.reduce((total, invoice) => total + Number(invoice.total || 0), 0));
 

--- a/resources/js/Pages/Parts/Index.vue
+++ b/resources/js/Pages/Parts/Index.vue
@@ -321,13 +321,15 @@ const formatCurrency = (value) =>
 const formatDate = (value) => (value ? new Date(value).toLocaleDateString('ca-ES') : '—');
 
 const filteredParts = computed(() =>
-    props.parts.filter((part) => {
-        const matchesStatus = !filters.status || part.status === filters.status;
-        const matchesClient = !filters.client_id || part.client_id === Number(filters.client_id);
-        const matchesStart = !filters.start_date || new Date(part.date) >= new Date(filters.start_date);
-        const matchesEnd = !filters.end_date || new Date(part.date) <= new Date(filters.end_date);
-        return matchesStatus && matchesClient && matchesStart && matchesEnd;
-    })
+    props.parts
+        .filter((part) => {
+            const matchesStatus = !filters.status || part.status === filters.status;
+            const matchesClient = !filters.client_id || part.client_id === Number(filters.client_id);
+            const matchesStart = !filters.start_date || new Date(part.date) >= new Date(filters.start_date);
+            const matchesEnd = !filters.end_date || new Date(part.date) <= new Date(filters.end_date);
+            return matchesStatus && matchesClient && matchesStart && matchesEnd;
+        })
+        .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0))
 );
 
 const filteredTotal = computed(() => filteredParts.value.reduce((total, part) => total + Number(part.total || 0), 0));


### PR DESCRIPTION
## Summary
- sort invoice index results by date descending to show newest first
- apply descending date ordering to budget index filters
- display parts index entries from most recent to oldest after filtering

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee131962483239d6f04aea4b09911)