### PR TITLE
Mark Avero imported invoices as paid

### DIFF
--- a/app/Http/Controllers/Api/AveroInvoiceController.php
+++ b/app/Http/Controllers/Api/AveroInvoiceController.php
@@ -144,7 +144,7 @@ class AveroInvoiceController extends Controller
                     'name' => $invoiceNumber,
                     'number' => $invoiceNumber,
                     'external_reference' => $externalReference,
-                    'state' => 'pending',
+                    'state' => 'paid',
                     'base_imponible' => $summary['base_imponible'],
                     'iva' => $totals['effectiveRate'],
                     'monto_iva' => $summary['total_iva'],


### PR DESCRIPTION
## Summary
- ensure invoices imported through the Avero API are stored with a paid state by default

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242b24cd448323aba7481ec3108183)