### PR TITLE
Schedule recurring expense generator in kernel

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        $schedule->command('expenses:generate-recurring')
+            ->dailyAt('02:00')
+            ->description('Genera gastos pendientes de plantillas recurrentes.');
+
         $schedule->command('recurring-invoices:generate')
             ->dailyAt('03:00')
             ->description('Genera facturas pendientes de plantillas recurrentes.');


### PR DESCRIPTION
## Summary
- schedule the recurring expenses generation command to run daily at 02:00
- keep existing recurring invoice generation schedule intact

## Testing
- php artisan test --filter=Recurring *(fails: missing vendor dependencies with PHP 8.4)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692478d9e3508323862379572723dbb9)