### PR TITLE
Fix role feature table reference in agenda migration

### DIFF
--- a/database/migrations/2025_02_15_000001_add_agenda_feature.php
+++ b/database/migrations/2025_02_15_000001_add_agenda_feature.php
@@ -40,13 +40,13 @@ return new class extends Migration
         $roles = DB::table('roles')->pluck('id');
 
         foreach ($roles as $roleId) {
-            $roleHasFeature = DB::table('role_features')
+            $roleHasFeature = DB::table('role_feature')
                 ->where('role_id', $roleId)
                 ->where('feature_id', $featureId)
                 ->exists();
 
             if (!$roleHasFeature) {
-                DB::table('role_features')->insert([
+                DB::table('role_feature')->insert([
                     'role_id' => $roleId,
                     'feature_id' => $featureId,
                     'created_at' => now(),
@@ -62,7 +62,7 @@ return new class extends Migration
 
         if ($featureId) {
             DB::table('plan_feature')->where('feature_id', $featureId)->delete();
-            DB::table('role_features')->where('feature_id', $featureId)->delete();
+            DB::table('role_feature')->where('feature_id', $featureId)->delete();
             DB::table('features')->where('id', $featureId)->delete();
         }
     }


### PR DESCRIPTION
## Summary
- update agenda feature migration to use existing role_feature pivot table instead of role_features
- keep cleanup in down method aligned with correct table name

## Testing
- not run (production prompt during migrations)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692480c628c08323b606ee1b5a7e58dd)