### PR TITLE
Add unique supplier constraint per company

### DIFF
--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -7,6 +7,7 @@ use App\Models\StockEntry;
 use App\Models\Supplier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 
 class SupplierController extends Controller
@@ -33,10 +34,17 @@ class SupplierController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => 'required|string|max:255',
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('suppliers')->where(fn ($query) => $query->where('company_id', Auth::user()->company_id)),
+            ],
             'email' => 'nullable|email',
             'phone' => 'nullable|string|max:255',
             'address' => 'nullable|string|max:255',
+        ], [
+            'name.unique' => 'Ya existe un proveedor con este nombre en la empresa.',
         ]);
 
         Supplier::create(array_merge($request->all(), [
@@ -58,10 +66,19 @@ class SupplierController extends Controller
     {
 
         $request->validate([
-            'name' => 'required|string|max:255',
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('suppliers')
+                    ->where(fn ($query) => $query->where('company_id', $supplier->company_id))
+                    ->ignore($supplier->id),
+            ],
             'email' => 'nullable|email',
             'phone' => 'nullable|string|max:255',
             'address' => 'nullable|string|max:255',
+        ], [
+            'name.unique' => 'Ya existe un proveedor con este nombre en la empresa.',
         ]);
 
         $supplier->update($request->all());

--- a/database/migrations/2024_11_21_151947_create_suppliers_table.php
+++ b/database/migrations/2024_11_21_151947_create_suppliers_table.php
@@ -23,6 +23,7 @@ class CreateSuppliersTable extends Migration
             $table->timestamps();
 
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->unique(['company_id', 'name']);
         });
     }
 

--- a/database/migrations/2025_09_10_120000_deduplicate_suppliers_and_add_unique_index.php
+++ b/database/migrations/2025_09_10_120000_deduplicate_suppliers_and_add_unique_index.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('suppliers')) {
+            return;
+        }
+
+        $duplicates = DB::table('suppliers')
+            ->select('company_id', 'name', DB::raw('MIN(id) as keeper_id'), DB::raw('COUNT(*) as total'))
+            ->groupBy('company_id', 'name')
+            ->having('total', '>', 1)
+            ->get();
+
+        foreach ($duplicates as $duplicate) {
+            DB::table('suppliers')
+                ->where('company_id', $duplicate->company_id)
+                ->where('name', $duplicate->name)
+                ->where('id', '!=', $duplicate->keeper_id)
+                ->delete();
+        }
+
+        if (! $this->hasCompanyNameUniqueIndex()) {
+            Schema::table('suppliers', function (Blueprint $table) {
+                $table->unique(['company_id', 'name']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('suppliers')) {
+            return;
+        }
+
+        if ($this->hasCompanyNameUniqueIndex()) {
+            Schema::table('suppliers', function (Blueprint $table) {
+                $table->dropUnique('suppliers_company_id_name_unique');
+            });
+        }
+    }
+
+    private function hasCompanyNameUniqueIndex(): bool
+    {
+        $connection = Schema::getConnection();
+        $driver = $connection->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $indexes = $connection->select("PRAGMA index_list('suppliers')");
+
+            foreach ($indexes as $index) {
+                if (! empty($index->unique)) {
+                    $indexInfo = $connection->select("PRAGMA index_info('{$index->name}')");
+                    $columns = collect($indexInfo)->pluck('name')->all();
+
+                    if ($columns === ['company_id', 'name']) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $schema = $connection->getDatabaseName();
+            $result = $connection->select(
+                "SELECT COUNT(*) as count FROM information_schema.statistics WHERE table_schema = ? AND table_name = 'suppliers' AND non_unique = 0 AND index_name = 'suppliers_company_id_name_unique'",
+                [$schema]
+            );
+
+            return ! empty($result) && (int) $result[0]->count > 0;
+        }
+
+        return false;
+    }
+};


### PR DESCRIPTION
## Summary
- add a corrective migration that removes duplicate suppliers and enforces a unique index per company
- include the unique constraint in the original suppliers table definition for new environments
- update supplier validation to return a clear error when attempting to reuse an existing name

## Testing
- php artisan test *(fails: missing vendor/autoload.php in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693adc337b3883239a3e51448033ceff)