### PR TITLE
Refresh UI components with minimal styling

### DIFF
--- a/resources/js/Components/Checkbox.vue
+++ b/resources/js/Components/Checkbox.vue
@@ -31,6 +31,6 @@ const proxyChecked = computed({
         v-model="proxyChecked"
         type="checkbox"
         :value="value"
-        class="rounded border-slate-500 bg-slate-900/60 text-sky-400 shadow-sm focus:ring-sky-400"
+        class="rounded border-slate-300 bg-white text-slate-700 shadow-sm focus:ring-2 focus:ring-slate-200"
     >
 </template>

--- a/resources/js/Components/Crud/CrudFilterBar.vue
+++ b/resources/js/Components/Crud/CrudFilterBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-sm backdrop-blur">
+    <section class="rounded-2xl border border-slate-200 bg-white p-6">
         <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
             <slot />
             <div class="md:ml-auto">

--- a/resources/js/Components/Crud/CrudPageHeader.vue
+++ b/resources/js/Components/Crud/CrudPageHeader.vue
@@ -20,15 +20,14 @@ const props = defineProps({
 </script>
 
 <template>
-    <section class="relative overflow-hidden rounded-3xl bg-gradient-to-r text-white shadow-xl">
-        <div class="absolute inset-0 bg-gradient-to-r opacity-90" :class="accent"></div>
-        <div class="relative flex flex-col gap-6 px-8 py-10 md:flex-row md:items-center">
-            <div v-if="icon" class="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/20 backdrop-blur">
-                <component :is="icon" class="h-9 w-9 text-white" />
+    <section class="rounded-2xl border border-slate-200 bg-white">
+        <div class="flex flex-col gap-6 px-8 py-8 md:flex-row md:items-center">
+            <div v-if="icon" class="flex h-14 w-14 items-center justify-center rounded-xl bg-slate-100 text-slate-700">
+                <component :is="icon" class="h-7 w-7" />
             </div>
             <div class="max-w-3xl">
-                <h1 class="text-3xl font-semibold tracking-tight md:text-4xl">{{ title }}</h1>
-                <p v-if="description" class="mt-3 text-base text-white/80 md:text-lg">
+                <h1 class="text-2xl font-semibold tracking-tight text-slate-900 md:text-3xl">{{ title }}</h1>
+                <p v-if="description" class="mt-2 text-sm text-slate-500 md:text-base">
                     {{ description }}
                 </p>
             </div>

--- a/resources/js/Components/Crud/CrudStatCard.vue
+++ b/resources/js/Components/Crud/CrudStatCard.vue
@@ -20,8 +20,8 @@ const props = defineProps({
 </script>
 
 <template>
-    <div class="flex items-center gap-5 rounded-3xl border border-slate-200/60 bg-white/80 p-5 shadow-sm backdrop-blur">
-        <div v-if="icon" class="flex h-12 w-12 items-center justify-center rounded-2xl" :class="iconBackground">
+    <div class="flex items-center gap-5 rounded-2xl border border-slate-200 bg-white p-5">
+        <div v-if="icon" class="flex h-11 w-11 items-center justify-center rounded-xl" :class="iconBackground">
             <component :is="icon" class="h-6 w-6" />
         </div>
         <div>

--- a/resources/js/Components/Crud/CrudTable.vue
+++ b/resources/js/Components/Crud/CrudTable.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/90 shadow-sm backdrop-blur">
+    <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white">
         <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-slate-200">
-                <thead class="bg-slate-50/80">
+                <thead class="bg-slate-50">
                     <slot name="head" />
                 </thead>
-                <tbody class="divide-y divide-slate-200/70 bg-white/50">
+                <tbody class="divide-y divide-slate-200 bg-white">
                     <slot />
                 </tbody>
             </table>
         </div>
-        <div v-if="$slots.footer" class="border-t border-slate-200/70 bg-slate-50/80 px-6 py-4">
+        <div v-if="$slots.footer" class="border-t border-slate-200 bg-slate-50 px-6 py-4">
             <slot name="footer" />
         </div>
     </div>

--- a/resources/js/Components/DangerButton.vue
+++ b/resources/js/Components/DangerButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex items-center justify-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex items-center justify-center rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-200 focus:ring-offset-2">
         <slot />
     </button>
 </template>

--- a/resources/js/Components/InputLabel.vue
+++ b/resources/js/Components/InputLabel.vue
@@ -5,7 +5,7 @@ defineProps({
 </script>
 
 <template>
-    <label class="block font-medium text-sm text-gray-700">
+    <label class="block text-sm font-medium text-slate-600">
         <span v-if="value">{{ value }}</span>
         <span v-else><slot /></span>
     </label>

--- a/resources/js/Components/KpiCard.vue
+++ b/resources/js/Components/KpiCard.vue
@@ -1,9 +1,9 @@
 <template>
     <div
         :class="[
-            'rounded-2xl border shadow-lg transition-transform duration-200',
-            bordered ? 'border-white/15' : 'border-slate-200/50',
-            gradient ? 'bg-white/10 backdrop-blur text-white' : 'bg-white text-slate-900',
+            'rounded-2xl border transition-transform duration-200',
+            bordered ? 'border-slate-200' : 'border-slate-200',
+            gradient ? 'bg-slate-50 text-slate-900' : 'bg-white text-slate-900',
             padding,
         ]"
     >
@@ -48,7 +48,7 @@ const props = defineProps({
     },
 });
 
-const subtitleClass = computed(() => props.gradient ? 'text-fuchsia-200' : 'text-slate-500');
-const valueClass = computed(() => props.gradient ? 'text-white' : 'text-slate-900');
-const descriptionClass = computed(() => props.gradient ? 'text-fuchsia-200' : 'text-slate-500');
+const subtitleClass = computed(() => props.gradient ? 'text-slate-500' : 'text-slate-500');
+const valueClass = computed(() => props.gradient ? 'text-slate-900' : 'text-slate-900');
+const descriptionClass = computed(() => props.gradient ? 'text-slate-500' : 'text-slate-500');
 </script>

--- a/resources/js/Components/NavLink.vue
+++ b/resources/js/Components/NavLink.vue
@@ -9,8 +9,8 @@ const props = defineProps({
 
 const classes = computed(() => {
     return props.active
-        ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 text-sm font-medium leading-5  focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
-        : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5  hover:text-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out';
+        ? 'inline-flex items-center border-b border-slate-900 px-1 pt-1 text-sm font-medium leading-5 text-slate-900 transition duration-150 ease-in-out'
+        : 'inline-flex items-center border-b border-transparent px-1 pt-1 text-sm font-medium leading-5 text-slate-500 transition duration-150 ease-in-out hover:text-slate-900 hover:border-slate-300 focus:outline-none focus:text-slate-900 focus:border-slate-300';
 });
 </script>
 

--- a/resources/js/Components/NewChildNavLink.vue
+++ b/resources/js/Components/NewChildNavLink.vue
@@ -10,8 +10,8 @@ const props = defineProps({
 
 const classes = computed(() => {
     return props.active
-        ? 'block w-full ps-3 pe-4 py-2  text-start text-base font-medium text-gray-950 bg-gray-50 rounded-full focus:outline-none focus:rounded-full hover:rounded-full focus:text-text-gray-950 focus:bg-withe focus:border-blue-700 transition duration-150 ease-in-out'
-        : 'block w-full ps-3 pe-4 py-2  text-start text-base font-medium text-gray-600 hover:text-gray-800 focus:rounded-full hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out';
+        ? 'block w-full rounded-lg bg-slate-100 px-3 py-2 text-start text-sm font-medium text-slate-900 transition duration-150 ease-in-out'
+        : 'block w-full rounded-lg px-3 py-2 text-start text-sm font-medium text-slate-500 transition duration-150 ease-in-out hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:bg-slate-100 focus:text-slate-900';
 });
 </script>
 

--- a/resources/js/Components/NewNavLink.vue
+++ b/resources/js/Components/NewNavLink.vue
@@ -18,14 +18,14 @@ const classes = computed(() => {
     const ring = 'ring-1 ring-transparent';
 
     const variantBase = props.variant === 'sub'
-        ? 'rounded-xl px-3 py-2 text-sm font-medium'
-        : 'rounded-2xl px-4 py-3 text-sm font-semibold';
+        ? 'rounded-lg px-3 py-2 text-sm font-medium'
+        : 'rounded-lg px-4 py-3 text-sm font-medium';
 
     const state = props.active
         ? props.variant === 'sub'
-            ? 'bg-white/10 text-white ring-blue-400/40 shadow-inner'
-            : 'bg-gradient-to-r from-blue-500 via-indigo-500 to-slate-900 text-white shadow-lg shadow-blue-500/30 ring-blue-400/50'
-        : 'text-blue-100/70 hover:text-white hover:bg-white/10 hover:ring-white/10';
+            ? 'bg-slate-900 text-white ring-slate-900'
+            : 'bg-slate-900 text-white ring-slate-900'
+        : 'text-slate-500 hover:text-slate-900 hover:bg-slate-100 hover:ring-slate-200';
 
     return [base, ring, variantBase, state].join(' ');
 });

--- a/resources/js/Components/PrimaryButton.vue
+++ b/resources/js/Components/PrimaryButton.vue
@@ -10,7 +10,7 @@ defineProps({
 <template>
     <button
         :type="type"
-        class="inline-flex items-center justify-center px-5 py-3 bg-gradient-to-r from-sky-500 via-sky-600 to-blue-700 border border-transparent rounded-lg font-semibold text-sm text-white uppercase tracking-[0.2em] shadow-lg shadow-sky-900/30 hover:from-sky-400 hover:via-sky-500 hover:to-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-400 transition ease-in-out duration-200"
+        class="inline-flex items-center justify-center rounded-md border border-slate-900 bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2"
     >
         <slot />
     </button>

--- a/resources/js/Components/ResponsiveNavLink.vue
+++ b/resources/js/Components/ResponsiveNavLink.vue
@@ -10,8 +10,8 @@ const props = defineProps({
 
 const classes = computed(() => {
     return props.active
-        ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-blue-400 text-start text-base font-medium text-blue-700 bg-blue-50 focus:outline-none focus:text-blue-800 focus:bg-blue-100 focus:border-blue-700 transition duration-150 ease-in-out'
-        : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 hover:rounded-full focus:rounded-full hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out';
+        ? 'block w-full border-l border-slate-900 bg-slate-50 px-3 py-2 text-start text-sm font-medium text-slate-900 transition duration-150 ease-in-out'
+        : 'block w-full border-l border-transparent px-3 py-2 text-start text-sm font-medium text-slate-500 transition duration-150 ease-in-out hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900 focus:outline-none focus:border-slate-300 focus:bg-slate-50 focus:text-slate-900';
 });
 </script>
 

--- a/resources/js/Components/SecondaryButton.vue
+++ b/resources/js/Components/SecondaryButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-200 focus:ring-offset-2 disabled:opacity-50">
         <slot />
     </button>
 </template>

--- a/resources/js/Components/SelectInput.vue
+++ b/resources/js/Components/SelectInput.vue
@@ -29,7 +29,7 @@ const updateValue = (event) => {
 <template>
     <select
         ref="select"
-        class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+        class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
         :value="modelValue"
         :disabled="disabled"
         @input="updateValue"

--- a/resources/js/Components/TextInput.vue
+++ b/resources/js/Components/TextInput.vue
@@ -21,7 +21,7 @@ defineExpose({ focus: () => input.value.focus() });
 <template>
     <input
         ref="input"
-        class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+        class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
         :value="modelValue"
         @input="$emit('update:modelValue', $event.target.value)"
     >

--- a/resources/js/Components/TextareaInput.vue
+++ b/resources/js/Components/TextareaInput.vue
@@ -27,7 +27,7 @@ const updateValue = (event) => emit('update:modelValue', event.target.value);
 <template>
     <textarea
         ref="textarea"
-        class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+        class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
         :rows="rows"
         :value="modelValue"
         @input="updateValue"

--- a/resources/js/Components/UI/DataTable.vue
+++ b/resources/js/Components/UI/DataTable.vue
@@ -9,9 +9,9 @@
                     </th>
                 </tr>
             </thead>
-            <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
+            <tbody class="divide-y divide-slate-200 text-sm text-slate-600">
                 <template v-if="items.length">
-                    <tr v-for="item in items" :key="resolveKey(item)" class="hover:bg-slate-50/80 transition" tabindex="0">
+                    <tr v-for="item in items" :key="resolveKey(item)" class="transition hover:bg-slate-50" tabindex="0">
                         <slot name="row" :item="item" />
                     </tr>
                 </template>

--- a/resources/js/Components/UI/Panel.vue
+++ b/resources/js/Components/UI/Panel.vue
@@ -1,9 +1,9 @@
 <template>
-    <section :aria-labelledby="headingId" class="bg-white rounded-3xl shadow-xl p-6" role="region">
-        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4" :class="headerBorder ? 'border-b border-slate-100 pb-5' : ''">
+    <section :aria-labelledby="headingId" class="rounded-2xl border border-slate-200 bg-white p-6" role="region">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between" :class="headerBorder ? 'border-b border-slate-200 pb-5' : ''">
             <div>
-                <h2 v-if="title" :id="headingId" class="text-xl font-semibold text-slate-800">{{ title }}</h2>
-                <p v-if="description" class="text-sm text-slate-500 mt-1">{{ description }}</p>
+                <h2 v-if="title" :id="headingId" class="text-lg font-semibold text-slate-900">{{ title }}</h2>
+                <p v-if="description" class="mt-1 text-sm text-slate-500">{{ description }}</p>
             </div>
             <div>
                 <slot name="actions" />

--- a/resources/js/Components/UI/SummaryCard.vue
+++ b/resources/js/Components/UI/SummaryCard.vue
@@ -1,10 +1,10 @@
 <template>
     <div :class="wrapperClass">
         <p v-if="eyebrow" class="text-xs uppercase tracking-[0.3em]" :class="eyebrowClass">{{ eyebrow }}</p>
-        <p class="text-3xl font-semibold mt-2">
+        <p class="mt-2 text-3xl font-semibold">
             <slot name="value">{{ value }}</slot>
         </p>
-        <p v-if="description || hasDescriptionSlot" class="text-sm mt-3" :class="descriptionClass">
+        <p v-if="description || hasDescriptionSlot" class="mt-3 text-sm" :class="descriptionClass">
             <slot name="description">{{ description }}</slot>
         </p>
     </div>
@@ -34,13 +34,13 @@ const props = defineProps({
 
 const variantStyles = {
     glass: {
-        wrapper: 'rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg',
-        eyebrow: 'text-emerald-200',
-        description: 'text-emerald-200',
+        wrapper: 'rounded-2xl border border-slate-200 bg-white p-6 text-slate-800',
+        eyebrow: 'text-slate-500',
+        description: 'text-slate-500',
     },
     light: {
-        wrapper: 'rounded-2xl border border-slate-200 bg-white p-6 text-slate-800 shadow-lg',
-        eyebrow: 'text-emerald-500',
+        wrapper: 'rounded-2xl border border-slate-200 bg-white p-6 text-slate-800',
+        eyebrow: 'text-slate-500',
         description: 'text-slate-500',
     },
 };

--- a/resources/js/Components/UserDropdown.vue
+++ b/resources/js/Components/UserDropdown.vue
@@ -1,11 +1,11 @@
 <template>
     <Dropdown align="right" width="48">
         <template #trigger>
-            <button v-if="$page.props.jetstream.managesProfilePhotos" class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition">
+            <button v-if="$page.props.jetstream.managesProfilePhotos" class="flex rounded-full border border-slate-200 text-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200 focus:ring-offset-2">
                 <img class="h-8 w-8 rounded-full object-cover" :src="$page.props.auth.user.profile_photo_url" :alt="$page.props.auth.user.name">
             </button>
             <span v-else class="inline-flex rounded-md">
-                <button type="button" class="inline-flex items-center bg-blue-500 text-gray-50 rounded-2xl  px-3 py-2 border border-transparent text-sm leading-4 font-medium hover:text-gray-200 focus:outline-none focus:bg-blue-700 focus:text-gray-200 active:bg-gray-50 transition ease-in-out duration-150">
+                <button type="button" class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-200 focus:ring-offset-2">
                     {{ $page.props.auth.user.name }}
                     <svg class="ms-2 -me-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />


### PR DESCRIPTION
### Motivation
- Harmonize the app UI to a minimal, light aesthetic by replacing heavy gradients and deep shadows with thin borders, light backgrounds, and cleaner typography across controls and layout components.
- Improve consistency between navigation, form controls, buttons, cards, and tables so components share the same visual language and spacing scale.
- Reduce visual noise for data-heavy screens (CRUD tables, KPI/summary cards) to make content and actions clearer.

### Description
- Restyled primary, secondary and danger buttons in `resources/js/Components/{PrimaryButton.vue,SecondaryButton.vue,DangerButton.vue}` to use `rounded-md` shapes, thin borders, subtle backgrounds and consistent font sizes.
- Reworked form controls in `TextInput.vue`, `SelectInput.vue`, `TextareaInput.vue`, `Checkbox.vue`, and `InputLabel.vue` to use full-width inputs, `border-slate-300` borders, `bg-white` backgrounds, consistent paddings, and `focus:ring-2` focus states.
- Simplified navigation and menu components in `NavLink.vue`, `NewNavLink.vue`, `NewChildNavLink.vue`, `ResponsiveNavLink.vue`, and `UserDropdown.vue` to use slate color tokens, thinner borders, `rounded-lg` radii and cleaner active/hover states.
- Updated layout and data components (`resources/js/Components/UI/Panel.vue`, `UI/DataTable.vue`, `UI/SummaryCard.vue`, `KpiCard.vue`, and `resources/js/Components/Crud/{CrudTable.vue,CrudPageHeader.vue,CrudFilterBar.vue,CrudStatCard.vue}`) to lighter surfaces, `rounded-2xl` containers, subtle borders, reduced/backdrop effects removal and adjusted typography for headings and descriptions.

### Testing
- Attempted to run `php artisan serve --host 0.0.0.0 --port 8000` as a quick smoke check, but it failed due to a missing `vendor/autoload.php` (no local Composer install in this environment).
- No automated unit/CI tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720631259883239e9296d05788b74f)