### PR TITLE
Restyle authentication pages with light card layout

### DIFF
--- a/resources/js/Components/AuthenticationCard.vue
+++ b/resources/js/Components/AuthenticationCard.vue
@@ -1,19 +1,17 @@
-<template>
-    <div class="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#050915] via-[#0B1728] to-[#132235] px-6 py-12 sm:px-8">
-        <div class="pointer-events-none absolute inset-0">
-            <div class="absolute -top-32 -left-24 h-80 w-80 rounded-full bg-sky-500/20 blur-3xl" />
-            <div class="absolute -bottom-24 -right-16 h-96 w-96 rounded-full bg-blue-700/20 blur-3xl" />
-            <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.12),_transparent_55%)]" />
-        </div>
+<script setup>
+import Panel from '@/Components/UI/Panel.vue';
+</script>
 
-        <div class="relative mx-auto flex min-h-full w-full max-w-xl flex-col items-center justify-center">
+<template>
+    <div class="min-h-screen bg-slate-50 px-6 py-12 sm:px-8">
+        <div class="mx-auto flex min-h-full w-full max-w-xl flex-col items-center justify-center gap-8">
             <div class="flex flex-col items-center text-center">
                 <slot name="logo" />
             </div>
 
-            <div class="mt-10 w-full rounded-3xl border border-white/10 bg-white/5 p-10 shadow-2xl backdrop-blur-xl">
+            <Panel :headerBorder="false" class="w-full p-8 sm:p-10">
                 <slot />
-            </div>
+            </Panel>
         </div>
     </div>
 </template>

--- a/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/resources/js/Pages/Auth/ForgotPassword.vue
@@ -25,32 +25,32 @@ const submit = () => {
 
     <AuthenticationCard>
         <template #logo>
-            <div class="flex flex-col items-center gap-4 text-slate-200">
+            <div class="flex flex-col items-center gap-4 text-slate-700">
                 <AuthenticationCardLogo />
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-sky-200/80">Recuperació d'accés</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Recuperació d'accés</p>
             </div>
         </template>
 
-        <div class="space-y-6 text-slate-200">
+        <div class="space-y-6 text-slate-700">
             <div class="space-y-3 text-center">
-                <h1 class="text-2xl font-semibold">Restableix la teva contrasenya</h1>
-                <p class="text-sm leading-relaxed text-slate-300">
+                <h1 class="text-2xl font-semibold text-slate-800">Restableix la teva contrasenya</h1>
+                <p class="text-sm leading-relaxed text-slate-500">
                     Introdueix el teu correu corporatiu i t'enviarem un enllaç segur per crear una nova contrasenya per a la suite JCT Agency.
                 </p>
             </div>
 
-            <div v-if="status" class="rounded-xl border border-sky-400/40 bg-sky-500/10 px-4 py-3 text-sm font-medium text-sky-200">
+            <div v-if="status" class="rounded-2xl border border-sky-200 bg-sky-50 px-4 py-3 text-sm font-medium text-sky-700">
                 {{ status }}
             </div>
 
             <form class="space-y-6" @submit.prevent="submit">
                 <div>
-                    <InputLabel for="email" value="Correu electrònic" class="text-slate-200" />
+                    <InputLabel for="email" value="Correu electrònic" />
                     <TextInput
                         id="email"
                         v-model="form.email"
                         type="email"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autofocus
                         autocomplete="username"

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -34,32 +34,32 @@ const submit = () => {
 
     <AuthenticationCard>
         <template #logo>
-            <div class="flex flex-col items-center gap-4 text-slate-200">
+            <div class="flex flex-col items-center gap-4 text-slate-700">
                 <AuthenticationCardLogo />
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-sky-200/80">JCT Agency · Accés Intern</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">JCT Agency · Accés Intern</p>
             </div>
         </template>
 
-        <div class="space-y-6 text-slate-200">
+        <div class="space-y-6 text-slate-700">
             <div class="space-y-2 text-center">
-                <h1 class="text-2xl font-semibold tracking-tight">Inicia sessió a la suite corporativa</h1>
-                <p class="text-sm leading-relaxed text-slate-300">
+                <h1 class="text-2xl font-semibold tracking-tight text-slate-800">Inicia sessió a la suite corporativa</h1>
+                <p class="text-sm leading-relaxed text-slate-500">
                     Accedeix a les eines internes de JCT Agency per coordinar projectes, equips i clients amb seguretat reforçada.
                 </p>
             </div>
 
-            <div v-if="status" class="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm font-medium text-emerald-200">
+            <div v-if="status" class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-700">
                 {{ status }}
             </div>
 
             <form class="space-y-6" @submit.prevent="submit">
                 <div>
-                    <InputLabel for="email" value="Correu electrònic" class="text-slate-200" />
+                    <InputLabel for="email" value="Correu electrònic" />
                     <TextInput
                         id="email"
                         v-model="form.email"
                         type="email"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autofocus
                         autocomplete="username"
@@ -69,12 +69,12 @@ const submit = () => {
                 </div>
 
                 <div>
-                    <InputLabel for="password" value="Contrasenya" class="text-slate-200" />
+                    <InputLabel for="password" value="Contrasenya" />
                     <TextInput
                         id="password"
                         v-model="form.password"
                         type="password"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autocomplete="current-password"
                         placeholder="••••••••"
@@ -82,16 +82,16 @@ const submit = () => {
                     <InputError class="mt-2" :message="form.errors.password" />
                 </div>
 
-                <div class="flex items-center justify-between">
-                    <label class="flex items-center gap-2 text-sm text-slate-300">
-                        <Checkbox v-model:checked="form.remember" name="remember" class="rounded border-slate-500 bg-slate-900/60 text-sky-400 focus:ring-sky-400" />
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <label class="flex items-center gap-2 text-sm text-slate-500">
+                        <Checkbox v-model:checked="form.remember" name="remember" class="rounded border-slate-300 text-sky-600 focus:ring-sky-500" />
                         Recorda'm
                     </label>
 
                     <Link
                         v-if="canResetPassword"
                         :href="route('password.request')"
-                        class="text-sm font-medium text-sky-200 transition hover:text-sky-100"
+                        class="text-sm font-medium text-slate-500 transition hover:text-sky-600"
                     >
                         Has oblidat la contrasenya?
                     </Link>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -1,102 +1,100 @@
 <template>
-    <div class="flex items-center justify-center min-h-screen py-10 bg-gradient-to-bl from-cyan-400 via-blue-500 to-blue-800">
-        <div class="w-full max-w-5xl p-8 bg-white rounded-xl shadow-lg">
-            <h1 class="mb-8 text-3xl font-extrabold text-center text-blue-600">Registro de Compañía</h1>
-            <form @submit.prevent="submitForm">
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                    <!-- Datos de la Compañía -->
-                    <div>
-                        <h2 class="mb-6 text-xl font-bold text-gray-700">Datos de la Compañía</h2>
-                        <div v-for="(field, key) in companyFields" :key="key" class="mb-6">
-                            <label :for="key" class="block text-sm font-semibold text-gray-600">{{ field.label }}</label>
-                            <input
-                                v-model="form[key]"
-                                :type="field.type"
-                                :id="key"
-                                :placeholder="field.placeholder"
-                                class="w-full px-5 py-3 mt-2 text-sm border rounded-lg focus:ring-2 focus:ring-blue-400 focus:outline-none"
-                                :required="field.required"
-                            />
+    <div class="min-h-screen bg-slate-50 px-6 py-12">
+        <div class="mx-auto w-full max-w-6xl">
+            <Panel
+                title="Registro de Compañía"
+                description="Completa la informació per crear l'espai corporatiu i activar el pla."
+                :headerBorder="false"
+                class="p-8 sm:p-10"
+            >
+                <form @submit.prevent="submitForm" class="space-y-10">
+                    <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
+                        <div class="rounded-2xl border border-slate-100 bg-slate-50/80 p-6">
+                            <h2 class="mb-6 text-lg font-semibold text-slate-700">Datos de la Compañía</h2>
+                            <div v-for="(field, key) in companyFields" :key="key" class="mb-5">
+                                <InputLabel :for="key" :value="field.label" />
+                                <TextInput
+                                    v-model="form[key]"
+                                    :type="field.type"
+                                    :id="key"
+                                    :placeholder="field.placeholder"
+                                    class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
+                                    :required="field.required"
+                                />
+                            </div>
                         </div>
 
-                    </div>
-
-
-
-                    <!-- Datos del Usuario -->
-                    <div>
-                        <h2 class="mb-6 text-xl font-bold text-gray-700">Datos del Usuario</h2>
-                        <div v-for="(field, key) in userFields" :key="key" class="mb-6">
-                            <label :for="key" class="block text-sm font-semibold text-gray-600">{{ field.label }}</label>
-                            <input
-                                v-model="form[key]"
-                                :type="field.type"
-                                :id="key"
-                                :placeholder="field.placeholder"
-                                class="w-full px-5 py-3 mt-2 text-sm border rounded-lg focus:ring-2 focus:ring-blue-400 focus:outline-none"
-                                :required="field.required"
-                            />
+                        <div class="rounded-2xl border border-slate-100 bg-slate-50/80 p-6">
+                            <h2 class="mb-6 text-lg font-semibold text-slate-700">Datos del Usuario</h2>
+                            <div v-for="(field, key) in userFields" :key="key" class="mb-5">
+                                <InputLabel :for="key" :value="field.label" />
+                                <TextInput
+                                    v-model="form[key]"
+                                    :type="field.type"
+                                    :id="key"
+                                    :placeholder="field.placeholder"
+                                    class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
+                                    :required="field.required"
+                                />
+                            </div>
                         </div>
                     </div>
-                </div>
 
-            <!--Seleccion del plan-->
-
-                <div class="mb-6">
-                    <h2 class="mb-6 text-xl font-bold text-gray-700">Selecciona un Plan</h2>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                        <div
-                            v-for="plan in props.plans"
-                            :key="plan.id"
-                            class="bg-white shadow-md rounded-lg p-6 relative"
-                            :class="{ 'border-4 border-blue-500': form.plan_id === plan.id }"
-                        >
-                            <h2 class="text-xl text-blue-600 font-semibold mb-4">{{ plan.name }}</h2>
-                            <p class="text-gray-600 mb-2">Precio: {{ plan.price }} €/ mes</p>
-                            <p class="text-gray-500 text-sm mb-4">{{ plan.description }}</p>
-                            <h3 class="text-lg font-semibold mb-2">Características</h3>
-                            <ul class="mb-6">
-                                <li v-for="feature in feturesByPlan(plan)" :key="feature.id" class="text-gray-700 flex items-center gap-2">
-                                    <p>✔</p> {{ feature.name }}
-                                </li>
-                            </ul>
-                            <button
-                                v-if="form.plan_id !== plan.id"
-                                @click="selectPlan(plan.id)"
-                                type="button"
-                                class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+                    <div class="space-y-6">
+                        <div>
+                            <h2 class="text-lg font-semibold text-slate-700">Selecciona un Plan</h2>
+                            <p class="mt-1 text-sm text-slate-500">Escull el paquet que millor s'adapti a la teva organització.</p>
+                        </div>
+                        <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+                            <div
+                                v-for="plan in props.plans"
+                                :key="plan.id"
+                                class="relative rounded-2xl border border-slate-100 bg-white p-6 shadow-sm transition hover:border-sky-200 hover:shadow-md"
+                                :class="{ 'border-sky-200 ring-2 ring-sky-500': form.plan_id === plan.id }"
                             >
-                                Seleccionar
-                            </button>
-                            <span
-                                v-else
-                                class="absolute top-2 right-2 bg-green-100 text-green-600 px-2 py-1 rounded text-sm"
-                            >
-                                Plan actual
-                            </span>
+                                <h3 class="text-lg font-semibold text-slate-800 mb-2">{{ plan.name }}</h3>
+                                <p class="text-sm text-slate-500 mb-1">Precio: <span class="font-semibold text-slate-700">{{ plan.price }} €</span> / mes</p>
+                                <p class="text-sm text-slate-500 mb-4">{{ plan.description }}</p>
+                                <h4 class="text-sm font-semibold text-slate-600 mb-2">Características</h4>
+                                <ul class="mb-6 space-y-2 text-sm text-slate-600">
+                                    <li v-for="feature in feturesByPlan(plan)" :key="feature.id" class="flex items-center gap-2">
+                                        <span class="text-sky-500">✔</span>
+                                        <span>{{ feature.name }}</span>
+                                    </li>
+                                </ul>
+                                <SecondaryButton
+                                    v-if="form.plan_id !== plan.id"
+                                    @click="selectPlan(plan.id)"
+                                    type="button"
+                                    class="w-full justify-center"
+                                >
+                                    Seleccionar
+                                </SecondaryButton>
+                                <span
+                                    v-else
+                                    class="absolute top-4 right-4 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700"
+                                >
+                                    Plan actual
+                                </span>
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                <!-- Resumen del Pago -->
-                <div class="mt-6">
-                    <p class="text-lg font-semibold text-gray-800">Total a Pagar: <span class="text-blue-600">{{ price }}€</span></p>
-                </div>
+                    <div class="flex flex-col items-start gap-4 border-t border-slate-100 pt-6 md:flex-row md:items-center md:justify-between">
+                        <p class="text-base font-semibold text-slate-700">
+                            Total a Pagar: <span class="text-sky-600">{{ price }}€</span>
+                        </p>
+                        <PrimaryButton type="submit" class="w-full justify-center md:w-auto">
+                            Registrarse y Pagar
+                        </PrimaryButton>
+                    </div>
+                </form>
+            </Panel>
 
-                <!-- Botón de envío -->
-                <div class="mt-8">
-                    <button
-                        type="submit"
-                        class="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg"
-                    >
-                        Registrarse y Pagar
-                    </button>
-                </div>
-            </form>
-
-            <div class="mt-10">
-                <NavLink :href="route('login')" class="text-sm text-gray-400">Ya tengo una cuenta, quiero iniciar sesion.</NavLink>
-
+            <div class="mt-6 text-center">
+                <NavLink :href="route('login')" class="text-sm text-slate-500 hover:text-sky-600">
+                    Ya tengo una cuenta, quiero iniciar sesion.
+                </NavLink>
             </div>
         </div>
     </div>
@@ -104,9 +102,14 @@
 
 
 <script setup>
-import {reactive, ref, onMounted} from 'vue';
+import { reactive, ref } from 'vue';
 import { loadStripe } from '@stripe/stripe-js';
-import NavLink from "../../Components/NavLink.vue";
+import InputLabel from '@/Components/InputLabel.vue';
+import NavLink from '@/Components/NavLink.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import Panel from '@/Components/UI/Panel.vue';
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
 
@@ -162,10 +165,6 @@ const updatePlanPrice = () => {
     const selectedPlan = props.plans.find(plan => plan.id === parseInt(form.plan_id));
     price.value = selectedPlan ? selectedPlan.price : 0;
 };
-
-onMounted(() => {
-
-});
 
 // Método para seleccionar un plan
 const selectPlan = (planId) => {

--- a/resources/js/Pages/Auth/ResetPassword.vue
+++ b/resources/js/Pages/Auth/ResetPassword.vue
@@ -31,28 +31,28 @@ const submit = () => {
 
     <AuthenticationCard>
         <template #logo>
-            <div class="flex flex-col items-center gap-4 text-slate-200">
+            <div class="flex flex-col items-center gap-4 text-slate-700">
                 <AuthenticationCardLogo />
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-sky-200/80">Seguretat reforçada</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Seguretat reforçada</p>
             </div>
         </template>
 
-        <div class="space-y-6 text-slate-200">
+        <div class="space-y-6 text-slate-700">
             <div class="space-y-3 text-center">
-                <h1 class="text-2xl font-semibold">Crea una nova contrasenya</h1>
-                <p class="text-sm leading-relaxed text-slate-300">
+                <h1 class="text-2xl font-semibold text-slate-800">Crea una nova contrasenya</h1>
+                <p class="text-sm leading-relaxed text-slate-500">
                     Defineix una nova credencial robusta per assegurar l'accés als entorns interns de JCT Agency.
                 </p>
             </div>
 
             <form class="space-y-6" @submit.prevent="submit">
                 <div>
-                    <InputLabel for="email" value="Correu electrònic" class="text-slate-200" />
+                    <InputLabel for="email" value="Correu electrònic" />
                     <TextInput
                         id="email"
                         v-model="form.email"
                         type="email"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autofocus
                         autocomplete="username"
@@ -61,12 +61,12 @@ const submit = () => {
                 </div>
 
                 <div>
-                    <InputLabel for="password" value="Nova contrasenya" class="text-slate-200" />
+                    <InputLabel for="password" value="Nova contrasenya" />
                     <TextInput
                         id="password"
                         v-model="form.password"
                         type="password"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autocomplete="new-password"
                         placeholder="••••••••"
@@ -75,12 +75,12 @@ const submit = () => {
                 </div>
 
                 <div>
-                    <InputLabel for="password_confirmation" value="Confirma la contrasenya" class="text-slate-200" />
+                    <InputLabel for="password_confirmation" value="Confirma la contrasenya" />
                     <TextInput
                         id="password_confirmation"
                         v-model="form.password_confirmation"
                         type="password"
-                        class="mt-2 block w-full rounded-2xl border-slate-600/70 bg-slate-900/40 px-4 py-3 text-slate-100 placeholder-slate-500 focus:border-sky-400 focus:ring-sky-400"
+                        class="mt-2 block w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-800 shadow-sm placeholder-slate-400 focus:border-sky-500 focus:ring-sky-500"
                         required
                         autocomplete="new-password"
                         placeholder="Repeteix la contrasenya"

--- a/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/resources/js/Pages/Auth/VerifyEmail.vue
@@ -23,21 +23,21 @@ const verificationLinkSent = computed(() => props.status === 'verification-link-
 
     <AuthenticationCard>
         <template #logo>
-            <div class="flex flex-col items-center gap-4 text-slate-200">
+            <div class="flex flex-col items-center gap-4 text-slate-700">
                 <AuthenticationCardLogo />
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-sky-200/80">Verificació corporativa</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Verificació corporativa</p>
             </div>
         </template>
 
-        <div class="space-y-6 text-slate-200">
+        <div class="space-y-6 text-slate-700">
             <div class="space-y-3 text-center">
-                <h1 class="text-2xl font-semibold">Confirma el teu correu JCT</h1>
-                <p class="text-sm leading-relaxed text-slate-300">
+                <h1 class="text-2xl font-semibold text-slate-800">Confirma el teu correu JCT</h1>
+                <p class="text-sm leading-relaxed text-slate-500">
                     Hem enviat un enllaç de verificació al teu correu corporatiu. Revisa la safata d'entrada i segueix les instruccions per validar l'accés.
                 </p>
             </div>
 
-            <div v-if="verificationLinkSent" class="rounded-xl border border-sky-400/40 bg-sky-500/10 px-4 py-3 text-sm font-medium text-sky-200">
+            <div v-if="verificationLinkSent" class="rounded-2xl border border-sky-200 bg-sky-50 px-4 py-3 text-sm font-medium text-sky-700">
                 Hem reenviat l'enllaç de verificació a l'adreça registrada.
             </div>
 
@@ -49,7 +49,7 @@ const verificationLinkSent = computed(() => props.status === 'verification-link-
                 <div class="flex flex-wrap justify-center gap-4 text-sm font-medium">
                     <Link
                         :href="route('profile.show')"
-                        class="text-slate-200 underline-offset-4 transition hover:text-sky-200 hover:underline"
+                        class="text-slate-500 underline-offset-4 transition hover:text-sky-600 hover:underline"
                     >
                         Actualitzar dades de perfil
                     </Link>
@@ -58,7 +58,7 @@ const verificationLinkSent = computed(() => props.status === 'verification-link-
                         :href="route('logout')"
                         method="post"
                         as="button"
-                        class="text-slate-200 underline-offset-4 transition hover:text-sky-200 hover:underline"
+                        class="text-slate-500 underline-offset-4 transition hover:text-sky-600 hover:underline"
                     >
                         Tancar sessió
                     </Link>


### PR DESCRIPTION
### Motivation
- Unify authentication screens under a minimal, light card layout to match the new UI system and provide a consistent visual language for login/registration flows.
- Replace the previous dark gradient auth wrapper with a shared, accessible `Panel`-based layout (clear card, subtle borders, shadow) for improved readability.
- Apply coherent input, button and status styles across auth views to reduce visual noise and align with existing UI components.

### Description
- Replaced the dark gradient wrapper in `resources/js/Components/AuthenticationCard.vue` with a `Panel`-based, minimal light layout and exported the new wrapper for auth pages.
- Restyled the login, forgot password, reset password and verify-email pages (`resources/js/Pages/Auth/Login.vue`, `ForgotPassword.vue`, `ResetPassword.vue`, `VerifyEmail.vue`) to use lighter typography, white inputs, updated status cards and consistent spacing while keeping existing behaviour and form handling.
- Reworked the register page (`resources/js/Pages/Auth/Register.vue`) to use the `Panel` layout, split company and user sections into rounded cards, convert native inputs to shared `TextInput`/`InputLabel` components, and restyled plan-selection cards with `SecondaryButton` and clearer selected state.
- Updated component imports where needed (e.g. `Panel`, `PrimaryButton`, `SecondaryButton`, `TextInput`, `InputLabel`, `NavLink`) and removed unused `onMounted` from the register script.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720633d87c83238999c240566040ba)