### PR TITLE
Refresh minimalist styling for email and PDF templates

### DIFF
--- a/resources/views/emails/budget.blade.php
+++ b/resources/views/emails/budget.blade.php
@@ -1,21 +1,62 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Presupuesto</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            font-family: "Helvetica Neue", Arial, sans-serif;
             line-height: 1.6;
+            background-color: #f9fafb;
+            color: #111827;
+        }
+
+        .wrapper {
+            padding: 32px 16px;
+        }
+
+        .card {
+            max-width: 520px;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 32px;
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: 20px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+
+        p {
+            margin: 8px 0;
+            color: #374151;
+        }
+
+        .meta {
+            margin-top: 20px;
+            padding-top: 16px;
+            border-top: 1px solid #e5e7eb;
+            font-size: 13px;
+            color: #6b7280;
         }
     </style>
 </head>
 <body>
-<h1>Presupuesto</h1>
-<p>Cliente: {{ $budget->client->name }}</p>
-<p>Fecha: {{ $budget->date }}</p>
+<div class="wrapper">
+    <div class="card">
+        <h1>Presupuesto</h1>
+        <p><strong>Cliente:</strong> {{ $budget->client->name }}</p>
+        <p><strong>Fecha:</strong> {{ $budget->date }}</p>
 
-<p>Adjuntamos presupuesto</p>
+        <p class="meta">Adjuntamos el presupuesto en este correo.</p>
+    </div>
+</div>
 </body>
 </html>

--- a/resources/views/emails/invoice.blade.php
+++ b/resources/views/emails/invoice.blade.php
@@ -1,21 +1,62 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Factura</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            font-family: "Helvetica Neue", Arial, sans-serif;
             line-height: 1.6;
+            background-color: #f9fafb;
+            color: #111827;
+        }
+
+        .wrapper {
+            padding: 32px 16px;
+        }
+
+        .card {
+            max-width: 520px;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 32px;
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: 20px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+
+        p {
+            margin: 8px 0;
+            color: #374151;
+        }
+
+        .meta {
+            margin-top: 20px;
+            padding-top: 16px;
+            border-top: 1px solid #e5e7eb;
+            font-size: 13px;
+            color: #6b7280;
         }
     </style>
 </head>
 <body>
-<h1>Factura</h1>
-<p>Cliente: {{ $invoice->client->name }}</p>
-<p>Fecha: {{ $invoice->date }}</p>
+<div class="wrapper">
+    <div class="card">
+        <h1>Factura</h1>
+        <p><strong>Cliente:</strong> {{ $invoice->client->name }}</p>
+        <p><strong>Fecha:</strong> {{ $invoice->date }}</p>
 
-<p>Adjuntamos factura</p>
+        <p class="meta">Adjuntamos la factura en este correo.</p>
+    </div>
+</div>
 </body>
 </html>

--- a/resources/views/emails/payroll.blade.php
+++ b/resources/views/emails/payroll.blade.php
@@ -1,16 +1,77 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Payroll Details</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            background-color: #f9fafb;
+            color: #111827;
+        }
+
+        .wrapper {
+            padding: 32px 16px;
+        }
+
+        .card {
+            max-width: 520px;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 32px;
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: 20px;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 8px 0;
+            color: #374151;
+        }
+
+        ul {
+            margin: 16px 0 0;
+            padding: 0;
+            list-style: none;
+            color: #374151;
+        }
+
+        li {
+            padding: 6px 0;
+            border-bottom: 1px solid #e5e7eb;
+        }
+
+        li:last-child {
+            border-bottom: none;
+        }
+
+        .footer {
+            margin-top: 20px;
+            padding-top: 16px;
+            border-top: 1px solid #e5e7eb;
+            font-size: 13px;
+            color: #6b7280;
+        }
+    </style>
 </head>
 <body>
-<h1>Dear {{ $employee['name'] }},</h1>
-<p>Please find your payroll details below:</p>
-<ul>
-    <li><strong>Amount:</strong> ${{ $payroll['net_pay'] }}</li>
-    <li><strong>Date:</strong> {{ $payroll['payment_date'] }}</li>
-</ul>
-<p>Thank you,</p>
-<p>Your Company</p>
+<div class="wrapper">
+    <div class="card">
+        <h1>Hello {{ $employee['name'] }},</h1>
+        <p>Please find your payroll details below:</p>
+        <ul>
+            <li><strong>Amount:</strong> ${{ $payroll['net_pay'] }}</li>
+            <li><strong>Date:</strong> {{ $payroll['payment_date'] }}</li>
+        </ul>
+        <p class="footer">Thank you,<br>Your Company</p>
+    </div>
+</div>
 </body>
 </html>

--- a/resources/views/emails/team-invitation.blade.php
+++ b/resources/views/emails/team-invitation.blade.php
@@ -1,23 +1,25 @@
 @component('mail::message')
-{{ __('You have been invited to join the :team team!', ['team' => $invitation->team->name]) }}
+<div style="font-family: 'Helvetica Neue', Arial, sans-serif; color: #111827; line-height: 1.6;">
+    <p style="margin: 0 0 16px;">{{ __('You have been invited to join the :team team!', ['team' => $invitation->team->name]) }}</p>
 
-@if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::registration()))
-{{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:') }}
+    @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::registration()))
+        <p style="margin: 0 0 16px;">{{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:') }}</p>
 
-@component('mail::button', ['url' => route('login')])
-{{ __('Access JCT Agency Suite') }}
-@endcomponent
+        @component('mail::button', ['url' => route('login')])
+            {{ __('Access JCT Agency Suite') }}
+        @endcomponent
 
-{{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
+        <p style="margin: 16px 0;">{{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}</p>
 
-@else
-{{ __('Access to the JCT Agency suite is managed internally. If you require credentials, please contact your JCT administrator. Once your account is active you can accept this invitation using the button below:') }}
-@endif
+    @else
+        <p style="margin: 0 0 16px;">{{ __('Access to the JCT Agency suite is managed internally. If you require credentials, please contact your JCT administrator. Once your account is active you can accept this invitation using the button below:') }}</p>
+    @endif
 
 
-@component('mail::button', ['url' => $acceptUrl])
-{{ __('Accept Invitation') }}
-@endcomponent
+    @component('mail::button', ['url' => $acceptUrl])
+        {{ __('Accept Invitation') }}
+    @endcomponent
 
-{{ __('If you did not expect to receive an invitation to this team, you may discard this email.') }}
+    <p style="margin: 16px 0 0; color: #6b7280;">{{ __('If you did not expect to receive an invitation to this team, you may discard this email.') }}</p>
+</div>
 @endcomponent

--- a/resources/views/pdfs/budget.blade.php
+++ b/resources/views/pdfs/budget.blade.php
@@ -14,9 +14,9 @@
         body {
             font-family: 'DejaVu Sans', Arial, sans-serif;
             font-size: 10px;
-            color: #2f3542;
-            background-color: #f5f6fa;
-            margin: 24px;
+            color: #111827;
+            background-color: #f9fafb;
+            margin: 32px;
         }
 
         header, footer {
@@ -28,20 +28,25 @@
             margin: 4px 0;
         }
 
+        h1 {
+            font-size: 18px;
+            font-weight: 600;
+        }
+
         .container {
             width: 100%;
             max-width: 850px;
             margin: 0 auto;
             background: #ffffff;
-            padding: 24px;
+            padding: 28px;
             border-radius: 12px;
-            box-shadow: 0 6px 24px rgba(15, 31, 53, 0.08);
+            border: 1px solid #e5e7eb;
         }
 
         .details {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            gap: 16px;
+            gap: 20px;
             margin-bottom: 24px;
         }
 
@@ -50,9 +55,8 @@
         }
 
         .panel {
-            border: 1px solid #e5e9f2;
-            border-left: 4px solid #2563eb;
-            padding: 16px;
+            border: 1px solid #e5e7eb;
+            padding: 14px;
             border-radius: 10px;
             background: #fff;
         }
@@ -60,10 +64,10 @@
         .panel-heading {
             font-weight: 600;
             margin-bottom: 8px;
-            color: #1f2937;
+            color: #6b7280;
             text-transform: uppercase;
-            letter-spacing: 0.08em;
-            font-size: 9px;
+            letter-spacing: 0.12em;
+            font-size: 8px;
         }
 
         table {
@@ -74,16 +78,16 @@
 
         th, td {
             padding: 10px 12px;
-            border-bottom: 1px solid #e5e9f2;
+            border-bottom: 1px solid #e5e7eb;
             text-align: left;
         }
 
         th {
             font-weight: 600;
-            font-size: 9px;
+            font-size: 8px;
             text-transform: uppercase;
-            letter-spacing: 0.06em;
-            color: #2563eb;
+            letter-spacing: 0.1em;
+            color: #6b7280;
             background: transparent;
         }
 
@@ -97,7 +101,7 @@
         }
 
         .totals table th {
-            color: #4b5563;
+            color: #6b7280;
             width: 55%;
         }
 

--- a/resources/views/pdfs/invoice.blade.php
+++ b/resources/views/pdfs/invoice.blade.php
@@ -11,10 +11,10 @@
 
         body {
             margin: 0;
-            padding: 28px;
+            padding: 32px;
             font-family: 'Inter', 'DejaVu Sans', 'Helvetica Neue', Arial, sans-serif;
-            background: #f8fafc;
-            color: #0f172a;
+            background: #f9fafb;
+            color: #111827;
             line-height: 1.6;
         }
 
@@ -40,23 +40,22 @@
             max-width: 960px;
             margin: 0 auto;
             background: #ffffff;
-            border: 1px solid #e2e8f0;
-            border-radius: 24px;
+            border: 1px solid #e5e7eb;
+            border-radius: 16px;
             padding: 32px;
-            box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
             page-break-inside: avoid;
         }
 
         header {
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid #e5e7eb;
             padding-bottom: 16px;
         }
 
         h1 {
             margin: 0;
-            font-size: 22px;
+            font-size: 20px;
             font-weight: 600;
-            color: #0f172a;
+            color: #111827;
         }
 
         .meta {
@@ -65,7 +64,7 @@
             gap: 12px;
             flex-wrap: wrap;
             font-size: 12px;
-            color: #475569;
+            color: #6b7280;
         }
 
         .meta span {
@@ -78,33 +77,32 @@
             display: grid;
             gap: 16px;
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            margin-top: 32px;
+            margin-top: 28px;
             page-break-inside: avoid;
         }
 
         .card {
-            border: 1px solid #e2e8f0;
-            border-radius: 18px;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
             padding: 18px 20px;
-            box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
             page-break-inside: avoid;
         }
 
         .eyebrow {
             margin: 0;
-            font-size: 10px;
-            letter-spacing: 0.28em;
+            font-size: 9px;
+            letter-spacing: 0.2em;
             text-transform: uppercase;
-            color: #1d4ed8;
-            font-weight: 700;
+            color: #6b7280;
+            font-weight: 600;
         }
 
         .card ul {
             list-style: none;
             padding: 0;
             margin: 12px 0 0;
-            color: #475569;
-            font-size: 13px;
+            color: #6b7280;
+            font-size: 12px;
         }
 
         .card ul li + li {
@@ -112,27 +110,27 @@
         }
 
         .card .title {
-            font-size: 15px;
-            font-weight: 700;
-            color: #0f172a;
+            font-size: 14px;
+            font-weight: 600;
+            color: #111827;
             margin: 0 0 6px;
         }
 
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 28px;
-            border-radius: 16px;
+            margin-top: 24px;
+            border-radius: 12px;
             overflow: hidden;
             font-size: 12px;
             page-break-inside: auto;
         }
 
         thead {
-            background: #e2e8f0;
-            color: #1d4ed8;
+            background: #f3f4f6;
+            color: #6b7280;
             text-transform: uppercase;
-            letter-spacing: 0.2em;
+            letter-spacing: 0.16em;
             display: table-header-group;
         }
 
@@ -142,12 +140,12 @@
         }
 
         th {
-            font-size: 11px;
-            font-weight: 700;
+            font-size: 10px;
+            font-weight: 600;
         }
 
         tbody tr {
-            border-top: 1px solid #e2e8f0;
+            border-top: 1px solid #e5e7eb;
             page-break-inside: avoid;
         }
 
@@ -156,11 +154,11 @@
         }
 
         tbody tr:nth-child(even) {
-            background: #f8fafc;
+            background: #f9fafb;
         }
 
         td {
-            color: #334155;
+            color: #374151;
             vertical-align: top;
         }
 
@@ -173,16 +171,16 @@
         }
 
         .muted {
-            color: #94a3b8;
+            color: #9ca3af;
         }
 
         .subtotal {
-            font-weight: 700;
-            color: #0f172a;
+            font-weight: 600;
+            color: #111827;
         }
 
         .totals-grid {
-            margin-top: 28px;
+            margin-top: 24px;
             display: grid;
             gap: 16px;
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -190,10 +188,9 @@
         }
 
         .totals-card {
-            border: 1px solid #e2e8f0;
-            border-radius: 18px;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
             padding: 20px;
-            box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
             height: 100%;
             page-break-inside: avoid;
         }
@@ -205,13 +202,13 @@
 
         .totals-card dt,
         .totals-card dd {
-            font-size: 13px;
+            font-size: 12px;
             margin: 0;
             padding: 8px 0;
             display: flex;
             align-items: center;
             justify-content: space-between;
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid #e5e7eb;
         }
 
         .totals-card dt:last-of-type,
@@ -220,51 +217,51 @@
         }
 
         .totals-card dd {
-            font-weight: 700;
-            color: #0f172a;
+            font-weight: 600;
+            color: #111827;
         }
 
         .badge {
             display: inline-block;
             padding: 6px 10px;
-            border-radius: 12px;
-            background: #eff6ff;
-            color: #1d4ed8;
+            border-radius: 999px;
+            background: #f3f4f6;
+            color: #111827;
             font-weight: 600;
-            font-size: 11px;
+            font-size: 10px;
         }
 
         .notes {
-            border: 1px dashed #cbd5e1;
-            border-radius: 16px;
+            border: 1px dashed #e5e7eb;
+            border-radius: 12px;
             padding: 18px 20px;
-            color: #475569;
-            font-size: 13px;
+            color: #6b7280;
+            font-size: 12px;
             line-height: 1.5;
             page-break-inside: avoid;
         }
 
         .notes h3 {
             margin: 0 0 8px;
-            font-size: 11px;
+            font-size: 10px;
             letter-spacing: 0.3em;
             text-transform: uppercase;
-            color: #94a3b8;
+            color: #9ca3af;
         }
 
         footer {
-            margin-top: 32px;
+            margin-top: 28px;
             padding-top: 16px;
-            border-top: 1px solid #e2e8f0;
+            border-top: 1px solid #e5e7eb;
             text-align: center;
             font-size: 11px;
-            color: #94a3b8;
+            color: #9ca3af;
         }
 
         .no-data {
             padding: 18px;
             text-align: center;
-            color: #94a3b8;
+            color: #9ca3af;
         }
     </style>
 </head>
@@ -345,12 +342,12 @@
     </section>
 
     <section>
-        <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 28px;">
-            <p class="eyebrow" style="color: #64748b;">Detall de línies</p>
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 24px;">
+            <p class="eyebrow" style="color: #9ca3af;">Detall de línies</p>
             <span class="badge">{{ count($items) }} productes</span>
         </div>
 
-        <div style="border: 1px solid #e2e8f0; border-radius: 18px; overflow: hidden; margin-top: 12px;">
+        <div style="border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; margin-top: 12px;">
             <table>
                 <thead>
                     <tr>
@@ -366,7 +363,7 @@
                 @forelse($items as $item)
                     <tr>
                         <td>
-                            <div style="font-weight: 600; color: #0f172a;">{{ optional($item->product)->name ?? '—' }}</div>
+                            <div style="font-weight: 600; color: #111827;">{{ optional($item->product)->name ?? '—' }}</div>
                             @if(!empty($item->description))
                                 <div class="muted" style="font-size: 11px; margin-top: 4px;">{{ $item->description }}</div>
                             @endif
@@ -381,7 +378,7 @@
                             @endif
                         </td>
                         <td class="text-center">
-                            <div style="font-weight: 600; color: #0f172a;">{{ $formatRate($item->iva) }}</div>
+                            <div style="font-weight: 600; color: #111827;">{{ $formatRate($item->iva) }}</div>
                             <div class="muted" style="font-size: 11px;">{{ $formatCurrency(($item->total ?? 0) * ($item->iva ?? 0) / 100) }}</div>
                         </td>
                         <td class="text-right subtotal">{{ $formatCurrency($item->total) }}</td>
@@ -398,7 +395,7 @@
 
     <section class="totals-grid">
         <article class="totals-card">
-            <p class="eyebrow" style="color: #64748b;">Resum econòmic</p>
+            <p class="eyebrow" style="color: #9ca3af;">Resum econòmic</p>
             <dl>
                 <dt>Base imposable</dt>
                 <dd>{{ $formatCurrency($invoice->base_imponible ?? 0) }}</dd>
@@ -407,8 +404,8 @@
                 <dd style="border-bottom: none; justify-content: flex-start; display: block; padding: 0;">
                     @if(count($taxBreakdown))
                         @foreach($taxBreakdown as $tier)
-                            <div style="margin: 10px 0; padding: 10px 12px; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc;">
-                                <div style="display: flex; justify-content: space-between; font-weight: 700; color: #0f172a;">
+                            <div style="margin: 10px 0; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 12px; background: #f9fafb;">
+                                <div style="display: flex; justify-content: space-between; font-weight: 600; color: #111827;">
                                     <span>IVA {{ $formatRate($tier['rate']) }}</span>
                                     <span>{{ $formatCurrency($tier['tax']) }}</span>
                                 </div>
@@ -422,11 +419,11 @@
 
                 @if(($retencionIrpf ?? 0) > 0)
                     <dt>Retenció IRPF ({{ $formatRate($irpfRate) }})</dt>
-                    <dd style="color: #e11d48;">− {{ $formatCurrency($retencionIrpf) }}</dd>
+                    <dd style="color: #9ca3af;">− {{ $formatCurrency($retencionIrpf) }}</dd>
                 @endif
 
-                <dt style="border-bottom: none; font-size: 15px; font-weight: 700;">Total a pagar</dt>
-                <dd style="border-bottom: none; font-size: 15px;">{{ $formatCurrency($invoice->total ?? $totalFinal) }}</dd>
+                <dt style="border-bottom: none; font-size: 14px; font-weight: 600;">Total a pagar</dt>
+                <dd style="border-bottom: none; font-size: 14px;">{{ $formatCurrency($invoice->total ?? $totalFinal) }}</dd>
             </dl>
         </article>
 

--- a/resources/views/pdfs/payroll.blade.php
+++ b/resources/views/pdfs/payroll.blade.php
@@ -8,27 +8,29 @@
         body {
             font-family: 'DejaVu Sans', Arial, sans-serif;
             margin: 0;
-            padding: 24px;
-            background-color: #f5f6fa;
-            color: #2f3542;
+            padding: 32px;
+            background-color: #f9fafb;
+            color: #111827;
+            line-height: 1.6;
         }
         .container {
-            width: 90%;
+            width: 100%;
+            max-width: 860px;
             margin: 0 auto;
             background: #fff;
             padding: 32px;
             border-radius: 12px;
-            box-shadow: 0 6px 24px rgba(15, 31, 53, 0.08);
+            border: 1px solid #e5e7eb;
         }
         .header, .footer {
             text-align: center;
-            margin: 24px 0;
+            margin: 20px 0;
         }
         .header h1 {
             margin: 0;
-            color: #1f2937;
-            font-size: 20px;
-            letter-spacing: 0.04em;
+            color: #111827;
+            font-size: 18px;
+            letter-spacing: 0.02em;
         }
         .header p {
             margin: 4px 0;
@@ -36,30 +38,30 @@
         }
         .section-title {
             margin-top: 24px;
-            padding-left: 12px;
-            border-left: 4px solid #2563eb;
-            font-size: 12px;
+            padding-left: 10px;
+            border-left: 2px solid #e5e7eb;
+            font-size: 10px;
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: #1f2937;
+            color: #6b7280;
         }
         table {
             width: 100%;
             border-collapse: collapse;
-            margin: 16px 0 0;
+            margin: 12px 0 0;
         }
         table th, table td {
-            border-bottom: 1px solid #e5e9f2;
+            border-bottom: 1px solid #e5e7eb;
             padding: 10px 12px;
             text-align: left;
         }
         table th {
             font-weight: 600;
-            font-size: 10px;
+            font-size: 9px;
             text-transform: uppercase;
-            letter-spacing: 0.06em;
-            color: #2563eb;
+            letter-spacing: 0.08em;
+            color: #6b7280;
             background: transparent;
         }
         table tr:last-child td {
@@ -207,5 +209,3 @@
 </div>
 </body>
 </html>
-
-

--- a/resources/views/pdfs/product_label.blade.php
+++ b/resources/views/pdfs/product_label.blade.php
@@ -6,11 +6,11 @@
     <title>Etiqueta de Producto</title>
     <style>
         @page {
-            size: 60mm 30mm; /* Tamaño de etiqueta (ajústalo según tu impresora) */
+            size: 60mm 30mm;
             margin: 0;
         }
         body {
-            font-family: Arial, sans-serif;
+            font-family: "Helvetica Neue", Arial, sans-serif;
             text-align: center;
             width: 55mm;
             height: 30mm;
@@ -20,28 +20,30 @@
             flex-direction: column;
             justify-content: center;
             align-content: center;
-
+            color: #111827;
+            background: #ffffff;
         }
         .container {
-            border: 1px dashed black; /* Guía de impresión (quitar en producción) */
-            padding: 2px;
+            border: 1px solid #e5e7eb;
+            padding: 4px;
         }
         h2 {
-            font-size: 12px;
+            font-size: 11px;
             margin: 0;
-            font-weight: bold;
+            font-weight: 600;
         }
         p {
-            font-size: 10px;
+            font-size: 9px;
             margin: 2px 0;
+            color: #6b7280;
         }
         .barcode {
-            margin-top: 3px;
+            margin-top: 4px;
             text-align: center;
         }
         .barcode img {
             width: 100%;
-            max-height: 20px; /* Ajustar la altura según necesidad */
+            max-height: 20px;
         }
     </style>
 </head>


### PR DESCRIPTION
### Motivation
- Modernize the visual presentation of transactional messages and printable documents to a minimal, neutral, and professional style. 
- Apply consistent typography, spacing and muted color accents across email and PDF templates for improved readability and print fidelity. 
- Target the templates under `resources/views/emails/*.blade.php` and `resources/views/pdfs/*.blade.php` (including the product label) to ensure a cohesive look. 

### Description
- Restyled email templates (`resources/views/emails/budget.blade.php`, `resources/views/emails/invoice.blade.php`, `resources/views/emails/payroll.blade.php`, `resources/views/emails/team-invitation.blade.php`) to use `"Helvetica Neue"`/Arial, a centered card layout with `.wrapper` and `.card`, increased whitespace, and neutral color tokens. 
- Updated PDF templates (`resources/views/pdfs/budget.blade.php`, `resources/views/pdfs/invoice.blade.php`, `resources/views/pdfs/payroll.blade.php`) to use unified font stacks, larger page padding, subtle borders instead of heavy shadows, muted accents, refined table typography, and consistent radii and spacing. 
- Simplified the printable product label (`resources/views/pdfs/product_label.blade.php`) to a compact, neutral print layout with clear typography and a light border for printing. 
- Removed bright brand accents and heavy shadows, normalized color variables and sizes, and kept templates minimal while preserving existing data bindings and tax/line calculations. 

### Testing
- No automated tests were executed for these visual/template changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697206352a388323b08258c1d62fe88c)