### PR TITLE
Adopt minimalist dashboard visuals and neutral chart containers

### DIFF
--- a/resources/js/Components/AreaChart.vue
+++ b/resources/js/Components/AreaChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="areaChart"></canvas>
     </div>
 </template>

--- a/resources/js/Components/BarChart.vue
+++ b/resources/js/Components/BarChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="barChart"></canvas>
     </div>
 </template>

--- a/resources/js/Components/DoughnutChart.vue
+++ b/resources/js/Components/DoughnutChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="doughnutCanvas"></canvas>
     </div>
 </template>

--- a/resources/js/Components/Inventory/InventoryChartCard.vue
+++ b/resources/js/Components/Inventory/InventoryChartCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="flex h-full flex-col rounded-3xl bg-white p-6 shadow-xl shadow-amber-900/10 ring-1 ring-amber-500/10">
+    <section class="flex h-full flex-col rounded-3xl border border-amber-200/30 bg-white/80 p-6 shadow-sm">
         <header class="space-y-1">
             <p v-if="kicker" class="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500/80">{{ kicker }}</p>
             <h2 class="text-xl font-semibold text-slate-900">{{ title }}</h2>

--- a/resources/js/Components/Inventory/InventoryKpiCard.vue
+++ b/resources/js/Components/Inventory/InventoryKpiCard.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="rounded-3xl border border-amber-500/30 bg-white/10 backdrop-blur p-6 text-white shadow-lg shadow-amber-900/20 transition duration-200 hover:-translate-y-1 hover:shadow-2xl">
-        <p class="text-xs uppercase tracking-[0.3em] text-amber-200/90">{{ label }}</p>
+    <div class="rounded-2xl border border-amber-200/30 bg-white/5 p-5 text-white shadow-sm">
+        <p class="text-xs uppercase tracking-[0.3em] text-amber-100/80">{{ label }}</p>
         <p class="mt-2 text-3xl font-semibold text-white">{{ value }}</p>
-        <p v-if="subtitle || hasSubtitleSlot" class="mt-3 text-sm text-amber-100/80">
+        <p v-if="subtitle || hasSubtitleSlot" class="mt-3 text-sm text-amber-100/70">
             <slot name="subtitle">{{ subtitle }}</slot>
         </p>
         <slot />

--- a/resources/js/Components/Inventory/inventoryTheme.js
+++ b/resources/js/Components/Inventory/inventoryTheme.js
@@ -1,10 +1,10 @@
 export const inventoryPalette = {
     background: 'bg-slate-950',
     gradient: 'from-amber-500 via-orange-600 to-slate-950',
-    surface: 'bg-white',
-    surfaceMuted: 'bg-white/80 backdrop-blur',
-    border: 'border-amber-500/20',
-    shadow: 'shadow-xl shadow-amber-900/20',
+    surface: 'bg-white/80',
+    surfaceMuted: 'bg-white/70',
+    border: 'border-amber-200/30',
+    shadow: 'shadow-sm',
     text: {
         overGradient: 'text-amber-200',
         hero: 'text-white',
@@ -35,9 +35,9 @@ export const inventoryTypography = {
 export const inventoryLayout = {
     heroWrapper: 'bg-gradient-to-r pb-24 rounded-b-[2.5rem] md:rounded-b-[3rem]',
     heroContainer: 'max-w-7xl mx-auto px-6 pt-10',
-    kpiGrid: 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10',
-    bodyWrapper: 'max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10',
-    sectionGrid: 'grid grid-cols-1 xl:grid-cols-3 gap-8',
+    kpiGrid: 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10',
+    bodyWrapper: 'max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8',
+    sectionGrid: 'grid grid-cols-1 xl:grid-cols-3 gap-6',
 };
 
 export const inventoryStatusMap = {

--- a/resources/js/Components/KpiCard.vue
+++ b/resources/js/Components/KpiCard.vue
@@ -1,9 +1,9 @@
 <template>
     <div
         :class="[
-            'rounded-2xl border shadow-lg transition-transform duration-200',
-            bordered ? 'border-white/15' : 'border-slate-200/50',
-            gradient ? 'bg-white/10 backdrop-blur text-white' : 'bg-white text-slate-900',
+            'rounded-2xl border shadow-sm transition-transform duration-200',
+            bordered ? 'border-white/15' : 'border-slate-200/70',
+            gradient ? 'bg-white/5 text-white' : 'bg-white/80 text-slate-900',
             padding,
         ]"
     >
@@ -44,11 +44,11 @@ const props = defineProps({
     },
     padding: {
         type: String,
-        default: 'p-6',
+        default: 'p-5',
     },
 });
 
-const subtitleClass = computed(() => props.gradient ? 'text-fuchsia-200' : 'text-slate-500');
+const subtitleClass = computed(() => props.gradient ? 'text-fuchsia-100/80' : 'text-slate-500');
 const valueClass = computed(() => props.gradient ? 'text-white' : 'text-slate-900');
-const descriptionClass = computed(() => props.gradient ? 'text-fuchsia-200' : 'text-slate-500');
+const descriptionClass = computed(() => props.gradient ? 'text-fuchsia-100/70' : 'text-slate-500');
 </script>

--- a/resources/js/Components/LineChart.vue
+++ b/resources/js/Components/LineChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="canvas"></canvas>
     </div>
 </template>

--- a/resources/js/Components/PieChart.vue
+++ b/resources/js/Components/PieChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="pieChart"></canvas>
     </div>
 </template>
@@ -51,4 +51,3 @@ canvas {
     height: 300px;
 }
 </style>
-

--- a/resources/js/Components/PolarChart.vue
+++ b/resources/js/Components/PolarChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="polarCanvas"></canvas>
     </div>
 </template>

--- a/resources/js/Components/RadarChart.vue
+++ b/resources/js/Components/RadarChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4">
         <canvas ref="radarChart"></canvas>
     </div>
 </template>

--- a/resources/js/Components/UI/Panel.vue
+++ b/resources/js/Components/UI/Panel.vue
@@ -1,6 +1,6 @@
 <template>
-    <section :aria-labelledby="headingId" class="bg-white rounded-3xl shadow-xl p-6" role="region">
-        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4" :class="headerBorder ? 'border-b border-slate-100 pb-5' : ''">
+    <section :aria-labelledby="headingId" class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm" role="region">
+        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4" :class="headerBorder ? 'border-b border-slate-200/70 pb-5' : ''">
             <div>
                 <h2 v-if="title" :id="headingId" class="text-xl font-semibold text-slate-800">{{ title }}</h2>
                 <p v-if="description" class="text-sm text-slate-500 mt-1">{{ description }}</p>

--- a/resources/js/Components/UI/SummaryCard.vue
+++ b/resources/js/Components/UI/SummaryCard.vue
@@ -34,12 +34,12 @@ const props = defineProps({
 
 const variantStyles = {
     glass: {
-        wrapper: 'rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg',
-        eyebrow: 'text-emerald-200',
-        description: 'text-emerald-200',
+        wrapper: 'rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm',
+        eyebrow: 'text-emerald-100/80',
+        description: 'text-emerald-100/80',
     },
     light: {
-        wrapper: 'rounded-2xl border border-slate-200 bg-white p-6 text-slate-800 shadow-lg',
+        wrapper: 'rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm',
         eyebrow: 'text-emerald-500',
         description: 'text-slate-500',
     },

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -8,27 +8,27 @@
                             <p class="text-blue-200 text-sm uppercase tracking-widest">Panel personal</p>
                             <h1 class="text-3xl sm:text-4xl font-semibold text-white mt-2">Hola {{ user.name }}, esto es lo que está pasando hoy</h1>
                         </div>
-                        <NavLink :href="route('user_tasks.create')" class="inline-flex items-center justify-center rounded-xl bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg ring-1 ring-white/20 hover:bg-white/20 transition">
+                        <NavLink :href="route('user_tasks.create')" class="inline-flex items-center justify-center rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white hover:bg-white/20 transition">
                             Crear nueva tarea
                         </NavLink>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-widest text-blue-200">Tareas abiertas</p>
                             <p class="text-3xl font-semibold mt-2">{{ openTasks }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ inProgressTasks }} en progreso • {{ pendingTasks }} pendientes</p>
                         </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-widest text-blue-200">Entregas de hoy</p>
                             <p class="text-3xl font-semibold mt-2">{{ tasksDueToday }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ overdueTasks }} atrasadas sin finalizar</p>
                         </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-widest text-blue-200">Tareas finalizadas</p>
                             <p class="text-3xl font-semibold mt-2">{{ completedTasks }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ completionRate }}% de avance</p>
                         </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-widest text-blue-200">Alertas</p>
                             <p class="text-3xl font-semibold mt-2">{{ unreadNotifications }}</p>
                             <p class="text-sm text-blue-200 mt-3">Notificaciones pendientes por revisar</p>
@@ -37,11 +37,11 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="xl:col-span-2 space-y-8">
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="xl:col-span-2 space-y-6">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                                 <div>
                                     <h2 class="text-xl font-semibold text-slate-800">Agenda y prioridades</h2>
                                     <p class="text-sm text-slate-500 mt-1">Consulta tu calendario y organiza tus próximos compromisos</p>
@@ -52,13 +52,13 @@
                                 </div>
                             </div>
                             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 pt-6">
-                                <div class="rounded-2xl border border-dashed border-slate-200 p-4">
+                                <div class="rounded-2xl border border-dashed border-slate-200/80 bg-white/60 p-4">
                                     <Calendar id="calendar" class="w-full" />
                                 </div>
                                 <div class="flex flex-col">
                                     <h3 class="text-sm font-semibold text-slate-600 mb-3">Próximas entregas</h3>
                                     <ul class="flex-1 space-y-3 overflow-y-auto pr-2">
-                                        <li v-for="task in upcomingTasks" :key="`upcoming-${task.id}`" class="flex items-start gap-3 rounded-2xl border border-slate-200/60 p-4">
+                                        <li v-for="task in upcomingTasks" :key="`upcoming-${task.id}`" class="flex items-start gap-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4">
                                             <div :class="['mt-1 h-2.5 w-2.5 rounded-full', task.status === 'completed' ? 'bg-emerald-500' : task.status === 'in_progress' ? 'bg-blue-500' : 'bg-amber-500']"></div>
                                             <div>
                                                 <p class="text-sm font-semibold text-slate-700">{{ task.title }}</p>
@@ -72,8 +72,8 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                                 <div>
                                     <h2 class="text-xl font-semibold text-slate-800">Panel de tareas</h2>
                                     <p class="text-sm text-slate-500 mt-1">Gestiona tus pendientes, cambia estados y mantén el foco</p>
@@ -89,8 +89,8 @@
                                             <th class="pb-3 text-right">Acciones</th>
                                         </tr>
                                     </thead>
-                                    <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
-                                        <tr v-for="task in orderedTasks" :key="task.id" class="hover:bg-slate-50/80 transition">
+                                    <tbody class="divide-y divide-slate-200/70 text-sm text-slate-600">
+                                        <tr v-for="task in orderedTasks" :key="task.id" class="hover:bg-slate-50/70 transition">
                                             <td class="py-4">
                                                 <p class="font-medium text-slate-700">{{ task.title }}</p>
                                                 <p v-if="task.description" class="text-xs text-slate-400 mt-1 line-clamp-2">{{ task.description }}</p>
@@ -124,8 +124,8 @@
                         </div>
                     </div>
 
-                    <div class="space-y-8">
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                             <h2 class="text-xl font-semibold text-slate-800">Resumen visual</h2>
                             <p class="text-sm text-slate-500 mb-4">Estado de tus tareas y carga mensual</p>
                             <div class="space-y-8">
@@ -140,11 +140,11 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                             <h2 class="text-xl font-semibold text-slate-800">Notificaciones</h2>
                             <p class="text-sm text-slate-500 mb-4">Actualizaciones relevantes para mantenerte al día</p>
                             <ul class="space-y-4 max-h-80 overflow-y-auto pr-2">
-                                <li v-for="notification in notifications" :key="notification.id" class="rounded-2xl border border-slate-200/70 p-4">
+                                <li v-for="notification in notifications" :key="notification.id" class="rounded-2xl border border-slate-200/70 bg-white/70 p-4">
                                     <div class="flex items-start justify-between gap-3">
                                         <div>
                                             <p class="text-sm font-semibold text-slate-700">{{ notification.title }}</p>

--- a/resources/js/Pages/DashboardAdmin.vue
+++ b/resources/js/Pages/DashboardAdmin.vue
@@ -10,33 +10,33 @@
                             <p class="text-sm text-blue-200">Gestiona la cuenta, usuarios y configuración corporativa desde un único lugar.</p>
                         </div>
                         <div class="flex flex-wrap gap-4">
-                            <NavLink :href="route('companies.edit', company.id)" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('companies.edit', company.id)" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 transition">
                                 <EditIcon class="w-4 h-4" /> Editar compañía
                             </NavLink>
-                            <NavLink :href="route('email-configurations.edit', emailConfig.id)" v-if="emailConfig" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('email-configurations.edit', emailConfig.id)" v-if="emailConfig" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 transition">
                                 <EditIcon class="w-4 h-4" /> Editar correo
                             </NavLink>
                         </div>
                     </div>
 
 
-                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-blue-200">Usuarios</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalUsers }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ activeRoles }} roles disponibles</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-blue-200">Plan actual</p>
                             <p class="text-3xl font-semibold mt-2">{{ plan.name }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ plan.description }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-blue-200">Características activas</p>
                             <p class="text-3xl font-semibold mt-2">{{ features.length }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ highlightedFeature }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-blue-200">Estado de correo</p>
                             <p class="text-3xl font-semibold mt-2">{{ emailConfig ? 'Configurado' : 'Pendiente' }}</p>
                             <p class="text-sm text-blue-200 mt-3">{{ emailConfig ? emailConfig.from_email : 'Sin configuración SMTP' }}</p>
@@ -45,11 +45,11 @@
                     </div>
                 </div>
             </div>
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="space-y-8 xl:col-span-2">
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="space-y-6 xl:col-span-2">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                                 <div>
                                     <h2 class="text-xl font-semibold text-slate-800">Resumen corporativo</h2>
                                     <p class="text-sm text-slate-500 mt-1">Información clave de la empresa y del plan contratado.</p>
@@ -60,14 +60,14 @@
                             </div>
                             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 pt-6">
                                 <div class="space-y-3 text-sm text-slate-600">
-                                    <div class="rounded-2xl border border-slate-200/80 p-4">
+                                    <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-4">
                                         <p class="text-xs uppercase tracking-widest text-slate-400">Datos de la empresa</p>
                                         <p class="font-semibold text-slate-700 mt-2">{{ company.name }}</p>
                                         <p class="mt-1">NIF: <span class="font-medium">{{ company.nif }}</span></p>
                                         <p class="mt-1">Teléfono: <span class="font-medium">{{ company.phone }}</span></p>
                                         <p class="mt-1">Dirección: <span class="font-medium">{{ company.address }}</span></p>
                                     </div>
-                                    <div class="rounded-2xl border border-slate-200/80 p-4">
+                                    <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-4">
                                         <p class="text-xs uppercase tracking-widest text-slate-400">Claves API</p>
                                         <p class="mt-2 text-xs text-slate-500 break-all">Public: {{ company.public_key ?? 'No generada' }}</p>
                                         <p class="mt-2 text-xs text-slate-500 break-all">Private: {{ company.private_key ?? 'No generada' }}</p>
@@ -77,7 +77,7 @@
                                     </div>
                                 </div>
                                 <div class="space-y-3 text-sm text-slate-600">
-                                    <div class="rounded-2xl border border-slate-200/80 p-4">
+                                    <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-4">
                                         <p class="text-xs uppercase tracking-widest text-slate-400">Plan actual</p>
                                         <p class="font-semibold text-slate-700 mt-2">{{ plan.name }}</p>
                                         <p class="text-slate-500 text-sm mt-1">{{ plan.description }}</p>
@@ -89,7 +89,7 @@
                                             <li v-if="features.length > 4" class="text-blue-600 font-medium">+ {{ features.length - 4 }} características más</li>
                                         </ul>
                                     </div>
-                                    <div class="rounded-2xl border border-slate-200/80 p-4">
+                                    <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-4">
                                         <p class="text-xs uppercase tracking-widest text-slate-400">Correo transaccional</p>
                                         <p class="mt-2">Remitente: <span class="font-medium">{{ emailConfig?.from_name ?? 'Sin definir' }}</span></p>
                                         <p class="mt-1">SMTP host: <span class="font-medium">{{ emailConfig?.smtp_host ?? '—' }}</span></p>
@@ -99,8 +99,8 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
-                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                                 <div>
                                     <h2 class="text-xl font-semibold text-slate-800">Usuarios y actividad</h2>
                                     <p class="text-sm text-slate-500 mt-1">Evolución de la base de usuarios y distribución por roles.</p>
@@ -119,12 +119,12 @@
                         </div>
                     </div>
 
-                    <div class="space-y-8">
-                        <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                             <h2 class="text-xl font-semibold text-slate-800">Roles disponibles</h2>
                             <p class="text-sm text-slate-500">Organiza los permisos del equipo y asigna accesos clave.</p>
                             <ul class="mt-4 space-y-3 text-sm text-slate-600 max-h-72 overflow-y-auto pr-2">
-                                <li v-for="role in roles" :key="role.id" class="flex items-start gap-3 rounded-2xl border border-slate-200/80 p-3">
+                                <li v-for="role in roles" :key="role.id" class="flex items-start gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-3">
                                     <span class="mt-1 h-2 w-2 rounded-full bg-indigo-500"></span>
                                     <div>
                                         <p class="font-semibold text-slate-700">{{ role.name }}</p>
@@ -135,7 +135,7 @@
                             </ul>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6 space-y-4">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm space-y-4">
                             <div>
                                 <h2 class="text-xl font-semibold text-slate-800">Acciones rápidas</h2>
                                 <p class="text-sm text-slate-500">Simplifica la gestión del equipo y la compañía.</p>
@@ -152,7 +152,7 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-xl p-6 space-y-4">
+                        <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm space-y-4">
                             <div>
                                 <h2 class="text-xl font-semibold text-rose-600">Dar de baja la empresa</h2>
                                 <p class="text-sm text-slate-500">Esta acción elimina todos los datos asociados a la compañía de forma irreversible.</p>

--- a/resources/js/Pages/DashboardClientes.vue
+++ b/resources/js/Pages/DashboardClientes.vue
@@ -9,12 +9,12 @@
                             <h1 class="text-3xl sm:text-4xl font-semibold text-white">Visión 360º de tu cartera</h1>
                             <p class="text-sm text-emerald-200 mt-2">Segmenta, analiza y toma decisiones informadas sobre tus relaciones comerciales.</p>
                         </div>
-                        <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                        <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 transition">
                             <AddIcon class="w-4 h-4" /> Nuevo cliente
                         </NavLink>
                     </div>
 
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
                         <SummaryCard
                             v-for="card in summaryCards"
                             :key="card.eyebrow"
@@ -26,7 +26,7 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <Panel title="Filtrado inteligente" description="Encuentra el cliente ideal combinando filtros avanzados.">
                     <template #actions>
                         <button @click="clearFilters" class="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
@@ -47,7 +47,7 @@
                     </div>
                 </Panel>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <Panel
                         class="xl:col-span-2"
                         title="Clientes"
@@ -97,7 +97,7 @@
                         </DataTable>
                     </Panel>
 
-                    <div class="space-y-8">
+                    <div class="space-y-6">
                         <Panel title="Estado de la cartera" description="Visualiza la salud actual de tus relaciones comerciales." :header-border="false">
                             <div class="mt-5">
                                 <DoughnutChart :data="clientStatusChart" />

--- a/resources/js/Pages/DashboardContabilidad.vue
+++ b/resources/js/Pages/DashboardContabilidad.vue
@@ -8,23 +8,23 @@
                         <h1 class="text-3xl sm:text-4xl font-semibold text-white">Resumen contable integral</h1>
                         <p class="text-sm text-emerald-200">Comprende la evolución de ingresos, gastos y rentabilidad en un vistazo.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Ingresos</p>
                             <p class="text-3xl font-semibold mt-2">€{{ totalIncomes }}</p>
                             <p class="text-sm text-emerald-200 mt-3">Promedio mensual €{{ averageIncome }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Gastos</p>
                             <p class="text-3xl font-semibold mt-2">€{{ totalExpenses }}</p>
                             <p class="text-sm text-emerald-200 mt-3">Coste medio €{{ averageExpense }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Beneficio neto</p>
                             <p class="text-3xl font-semibold mt-2">€{{ profit }}</p>
                             <p class="text-sm text-emerald-200 mt-3">Margen {{ profitMargin }}%</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-emerald-200">Transacciones</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalTransactions }}</p>
                             <p class="text-sm text-emerald-200 mt-3">{{ incomes.length }} ingresos • {{ expenses.length }} gastos</p>
@@ -33,9 +33,9 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="bg-white rounded-3xl shadow-xl p-6">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-800">Ingresos acumulados</h2>
                             <p class="text-sm text-slate-500 mt-1">Sigue la evolución mensual filtrando por el año deseado.</p>
@@ -52,15 +52,15 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Balance mensual</h2>
                         <p class="text-sm text-slate-500">Comparativa entre ingresos y gastos con resultado neto.</p>
                         <div class="mt-6">
                             <AreaChart :data="monthlyBalanceChart" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Indicadores clave</h2>
                         <p class="text-sm text-slate-500">Analiza métricas estratégicas de rentabilidad y actividad.</p>
                         <div class="mt-6">
@@ -69,7 +69,7 @@
                     </div>
                 </div>
 
-                <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                     <h2 class="text-xl font-semibold text-slate-800">Gastos mensuales</h2>
                     <p class="text-sm text-slate-500">Controla la distribución de costes a lo largo del año.</p>
                     <div class="mt-6">

--- a/resources/js/Pages/DashboardCrm.vue
+++ b/resources/js/Pages/DashboardCrm.vue
@@ -8,23 +8,23 @@
                         <h1 class="text-3xl sm:text-4xl font-semibold text-white">Rendimiento comercial en tiempo real</h1>
                         <p class="text-sm text-violet-200">Mide el pulso de tus leads, oportunidades y actividades clave para acelerar ventas.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-violet-200">Leads</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalLeads }}</p>
                             <p class="text-sm text-violet-200 mt-3">Tasa de conversión {{ conversionRate }}%</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-violet-200">Oportunidades</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalOpportunities }}</p>
                             <p class="text-sm text-violet-200 mt-3">{{ wonOpportunities }} ganadas</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-violet-200">Notas</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalNotes }}</p>
                             <p class="text-sm text-violet-200 mt-3">Última nota {{ latestNoteDate }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-violet-200">Actividades</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalActivities }}</p>
                             <p class="text-sm text-violet-200 mt-3">{{ upcomingActivities.length }} próximas</p>
@@ -33,10 +33,10 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="xl:col-span-2 bg-white rounded-3xl shadow-xl p-6">
-                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="xl:col-span-2 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
+                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                             <div>
                                 <h2 class="text-xl font-semibold text-slate-800">Actividad mensual</h2>
                                 <p class="text-sm text-slate-500">Seguimiento de reuniones, llamadas y tareas registradas.</p>
@@ -46,11 +46,11 @@
                             <LineChart :data="monthlyActivitiesData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Próximas acciones</h2>
                         <p class="text-sm text-slate-500">Organiza tu agenda comercial a corto plazo.</p>
                         <ul class="mt-6 space-y-4 max-h-80 overflow-y-auto pr-2 text-sm text-slate-600">
-                            <li v-for="activity in upcomingActivities" :key="activity.id" class="flex items-start gap-3 rounded-2xl border border-slate-200/70 p-4">
+                            <li v-for="activity in upcomingActivities" :key="activity.id" class="flex items-start gap-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4">
                                 <span class="mt-1 h-2 w-2 rounded-full bg-violet-500"></span>
                                 <div>
                                     <p class="font-semibold text-slate-700">{{ activity.title ?? 'Actividad sin título' }}</p>
@@ -63,22 +63,22 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Origen de leads</h2>
                         <p class="text-sm text-slate-500">Identifica los canales con mejor rendimiento.</p>
                         <div class="mt-6">
                             <PieChart :data="leadSourceData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Conversión de oportunidades</h2>
                         <p class="text-sm text-slate-500">Analiza el estado actual del pipeline comercial.</p>
                         <div class="mt-6">
                             <BarChart :data="opportunityConversionData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Embudo de progreso</h2>
                         <p class="text-sm text-slate-500">Comprende la transición de lead a oportunidad ganada.</p>
                         <div class="mt-6">

--- a/resources/js/Pages/DashboardFacturacion.vue
+++ b/resources/js/Pages/DashboardFacturacion.vue
@@ -8,28 +8,28 @@
                         <h1 class="text-3xl sm:text-4xl font-semibold text-white">Control total de presupuestos e ingresos</h1>
                         <p class="text-sm text-sky-200">Identifica tendencias, clientes clave y oportunidades para acelerar los cobros.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg xl:col-span-1">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
                             <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Presupuestos</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalBudgets }}</p>
                             <p class="text-sm text-sky-200 mt-3">Importe medio €{{ averageBudget }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg xl:col-span-1">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
                             <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Facturas</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalInvoices }}</p>
                             <p class="text-sm text-sky-200 mt-3">Ticket medio €{{ averageInvoice }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg xl:col-span-1">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
                             <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Clientes</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalClients }}</p>
                             <p class="text-sm text-sky-200 mt-3">Top cliente {{ topClientName }}</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg xl:col-span-1">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
                             <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Cobros pendientes</p>
                             <p class="text-3xl font-semibold mt-2">€{{ outstandingAmount }}</p>
                             <p class="text-sm text-sky-200 mt-3">{{ outstandingInvoices }} facturas en trámite</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg xl:col-span-1">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
                             <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Cobrado</p>
                             <p class="text-3xl font-semibold mt-2">€{{ totalIncome }}</p>
                             <p class="text-sm text-sky-200 mt-3">{{ paidPercentage }}% facturas cobradas</p>
@@ -38,16 +38,16 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Distribución de presupuestos</h2>
                         <p class="text-sm text-slate-500">Mira qué clientes concentran mayor inversión estimada.</p>
                         <div class="mt-6">
                             <PieChart :data="budgetClientData" class="h-48" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Ingresos mensuales</h2>
                         <p class="text-sm text-slate-500">Evolución de la facturación cobrada a lo largo del año.</p>
                         <div class="mt-6">
@@ -56,16 +56,16 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
-                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm xl:col-span-2">
+                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                             <div>
                                 <h2 class="text-xl font-semibold text-slate-800">Presupuestos recientes</h2>
                                 <p class="text-sm text-slate-500">Últimas propuestas emitidas y su valor estimado.</p>
                             </div>
                             <NavLink href="/budgets" class="text-sm font-semibold text-blue-600 hover:text-blue-800">Ver todos</NavLink>
                         </div>
-                        <ul class="divide-y divide-slate-100 text-sm text-slate-600">
+                        <ul class="divide-y divide-slate-200/70 text-sm text-slate-600">
                             <li v-for="budget in recentBudgets" :key="budget.id" class="flex items-center justify-between py-4">
                                 <div>
                                     <p class="font-semibold text-slate-700">{{ getClientName(budget.client_id) }}</p>
@@ -76,7 +76,7 @@
                             <li v-if="recentBudgets.length === 0" class="py-4 text-center text-slate-400">No hay presupuestos registrados.</li>
                         </ul>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Estado de facturas</h2>
                         <p class="text-sm text-slate-500">Controla qué porcentaje está cobrado, pendiente o vencido.</p>
                         <div class="mt-6">
@@ -85,16 +85,16 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
-                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm xl:col-span-2">
+                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                             <div>
                                 <h2 class="text-xl font-semibold text-slate-800">Facturas recientes</h2>
                                 <p class="text-sm text-slate-500">Seguimiento de cobros generados en las últimas semanas.</p>
                             </div>
                             <NavLink href="/invoices" class="text-sm font-semibold text-blue-600 hover:text-blue-800">Ver todos</NavLink>
                         </div>
-                        <ul class="divide-y divide-slate-100 text-sm text-slate-600">
+                        <ul class="divide-y divide-slate-200/70 text-sm text-slate-600">
                             <li v-for="invoice in recentInvoices" :key="invoice.id" class="flex items-center justify-between py-4">
                                 <div>
                                     <p class="font-semibold text-slate-700">{{ getClientName(invoice.client_id) }}</p>
@@ -108,7 +108,7 @@
                             <li v-if="recentInvoices.length === 0" class="py-4 text-center text-slate-400">No hay facturas registradas.</li>
                         </ul>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Comparativa presupuestos vs facturación</h2>
                         <p class="text-sm text-slate-500">Evalúa la conversión de propuestas en ventas efectivas.</p>
                         <div class="mt-6">

--- a/resources/js/Pages/DashboardProductos.vue
+++ b/resources/js/Pages/DashboardProductos.vue
@@ -49,7 +49,7 @@
                     </InventoryChartCard>
                     <InventoryChartCard title="Alertes d'estoc crític" subtitle="Prioritza reposicions amb major impacte comercial." kicker="Prioritat">
                         <ul class="mt-6 space-y-3 max-h-80 overflow-y-auto pr-2 text-sm text-slate-600">
-                            <li v-for="product in lowStockProducts" :key="product.id" class="flex items-center justify-between rounded-2xl border border-slate-200/70 p-4">
+                            <li v-for="product in lowStockProducts" :key="product.id" class="flex items-center justify-between rounded-2xl border border-slate-200/70 bg-white/70 p-4">
                                 <div>
                                     <p class="font-semibold text-slate-700">{{ product.name }}</p>
                                     <p class="text-xs text-slate-400">Estoc actual: {{ product.stock ?? product.quantity ?? 0 }}</p>
@@ -58,7 +58,7 @@
                                     {{ product.category?.name ?? 'Sense categoria' }}
                                 </InventoryStatusBadge>
                             </li>
-                            <li v-if="lowStockProducts.length === 0" class="rounded-2xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-400">
+                            <li v-if="lowStockProducts.length === 0" class="rounded-2xl border border-dashed border-slate-200/80 bg-white/60 p-6 text-center text-sm text-slate-400">
                                 No hi ha productes amb estoc crític.
                             </li>
                         </ul>

--- a/resources/js/Pages/DashboardRRHH.vue
+++ b/resources/js/Pages/DashboardRRHH.vue
@@ -8,23 +8,23 @@
                         <h1 class="text-3xl sm:text-4xl font-semibold text-white">Radiografía del equipo humano</h1>
                         <p class="text-sm text-cyan-200">Analiza la composición, crecimiento y distribución de tu organización.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-cyan-200">Empleados</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalEmployees }}</p>
                             <p class="text-sm text-cyan-200 mt-3">{{ headcountGrowth }}% crecimiento anual</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-cyan-200">Departamentos</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalDepartments }}</p>
                             <p class="text-sm text-cyan-200 mt-3">{{ averageTeamSize }} personas promedio</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-cyan-200">Salario medio</p>
                             <p class="text-3xl font-semibold mt-2">€{{ averageSalary.toFixed(2) }}</p>
                             <p class="text-sm text-cyan-200 mt-3">Brecha interdepartamental {{ salaryVariance }}%</p>
                         </div>
-                        <div class="rounded-2xl border border-white/20 bg-white/10 backdrop-blur p-6 text-white shadow-lg">
+                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
                             <p class="text-xs uppercase tracking-[0.3em] text-cyan-200">Activos</p>
                             <p class="text-3xl font-semibold mt-2">{{ totalEmployeesActive }}</p>
                             <p class="text-sm text-cyan-200 mt-3">{{ inactiveEmployees }} en pausa</p>
@@ -33,23 +33,23 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Empleados por departamento</h2>
                         <p class="text-sm text-slate-500">Balancea cargas de trabajo y dimensiona cada área.</p>
                         <div class="mt-6">
                             <PieChart :data="employeeDepartmentData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Contrataciones por año</h2>
                         <p class="text-sm text-slate-500">Evalúa el ritmo de incorporación de talento.</p>
                         <div class="mt-6">
                             <BarChart :data="employeeHiringYearData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Salario medio por departamento</h2>
                         <p class="text-sm text-slate-500">Identifica áreas con mayor inversión salarial.</p>
                         <div class="mt-6">
@@ -58,22 +58,22 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Distribución de talento</h2>
                         <p class="text-sm text-slate-500">Relación de headcount por áreas funcionales.</p>
                         <div class="mt-6">
                             <PieChart :data="departmentEmployeeData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Departamentos por ubicación</h2>
                         <p class="text-sm text-slate-500">Comprende la huella geográfica del equipo.</p>
                         <div class="mt-6">
                             <BarChart :data="departmentLocationData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Proyectos activos por departamento</h2>
                         <p class="text-sm text-slate-500">Detecta áreas con mayor carga operativa.</p>
                         <div class="mt-6">

--- a/resources/js/Pages/DashboardTPV.vue
+++ b/resources/js/Pages/DashboardTPV.vue
@@ -8,7 +8,7 @@
                         <h1 class="text-3xl sm:text-4xl font-semibold text-white">Actividad en punto de venta</h1>
                         <p class="text-sm text-fuchsia-200">Monitoriza ventas, tickets y categorías para optimizar tu estrategia comercial.</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-5 mt-10">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6 mt-10">
                         <KpiCard
                             v-for="card in kpiCards"
                             :key="card.key"
@@ -22,7 +22,7 @@
                 </div>
             </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <section class="sr-only" aria-label="Documentación visual del panel TPV">
                     <h2 class="text-base font-semibold">Resumen de elementos visuales</h2>
                     <p>{{ visualDocumentation.summary }}</p>
@@ -44,15 +44,15 @@
                     </div>
                 </section>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm xl:col-span-2">
                         <h2 class="text-xl font-semibold text-slate-800">Ventas mensuales</h2>
                         <p class="text-sm text-slate-500">Evolución del volumen de tickets y facturación.</p>
                         <div class="mt-6">
                             <LineChart :data="ticketMonthlyData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Distribución por productos</h2>
                         <p class="text-sm text-slate-500">Ventas agrupadas según cada referencia.</p>
                         <div class="mt-6">
@@ -61,15 +61,15 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
-                    <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Ventas por categoría</h2>
                         <p class="text-sm text-slate-500">Comparativa entre familias de productos.</p>
                         <div class="mt-6">
                             <PieChart :data="productCategoryData" />
                         </div>
                     </div>
-                    <div class="bg-white rounded-3xl shadow-xl p-6 xl:col-span-2">
+                    <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm xl:col-span-2">
                         <h2 class="text-xl font-semibold text-slate-800">Top productos vendidos</h2>
                         <p class="text-sm text-slate-500">Ranking de artículos con mayor rotación.</p>
                         <div class="mt-6">
@@ -78,7 +78,7 @@
                     </div>
                 </div>
 
-                <div class="bg-white rounded-3xl shadow-xl p-6">
+                <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                     <h2 class="text-xl font-semibold text-slate-800">Tendencia de ingresos acumulados</h2>
                     <p class="text-sm text-slate-500">Sigue cómo evolucionan los ingresos en el tiempo.</p>
                     <div class="mt-6">

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -37,7 +37,7 @@ defineProps({
             </Link>
         </div>
 
-        <div class="relative z-10 mx-auto flex max-w-6xl flex-col gap-24 px-6 pb-24 pt-12 sm:px-10 lg:px-16">
+        <div class="relative z-10 mx-auto flex max-w-6xl flex-col gap-20 px-6 pb-24 pt-12 sm:px-10 lg:px-16">
             <section class="grid grid-cols-1 items-center gap-12 lg:grid-cols-[1.1fr_0.9fr]">
                 <div class="space-y-8">
                     <ApplicationLogo class="w-full max-w-md" />
@@ -62,7 +62,7 @@ defineProps({
                 </div>
                 <div class="relative">
                     <div class="pointer-events-none absolute inset-0 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent blur-md" />
-                    <div class="relative rounded-3xl border border-white/10 bg-white/10 p-8 backdrop-blur-xl shadow-2xl shadow-black/30">
+                    <div class="relative rounded-3xl border border-white/10 bg-white/5 p-8 shadow-sm">
                         <h2 class="text-xl font-semibold uppercase tracking-[0.3em] text-sky-200">Visió 360º</h2>
                         <p class="mt-4 text-base leading-relaxed text-slate-200">
                             Dashboards unificats, analítica en temps real i fluxos aprovats per JCT Agency per coordinar equips de màrqueting, vendes i operacions amb garanties de seguretat empresarial.
@@ -85,20 +85,20 @@ defineProps({
                 </div>
             </section>
 
-            <section class="grid gap-10 md:grid-cols-2 xl:grid-cols-3">
-                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl shadow-lg shadow-black/30">
+            <section class="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-sm">
                     <h3 class="text-lg font-semibold text-slate-50">Identitat Corporativa</h3>
                     <p class="mt-3 text-sm leading-relaxed text-slate-300">
                         Cada detall visual reflecteix l'ADN de JCT Agency. El nostre equip opera amb una interfície coherent que reforça la marca a cada interacció.
                     </p>
                 </div>
-                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl shadow-lg shadow-black/30">
+                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-sm">
                     <h3 class="text-lg font-semibold text-slate-50">Control Total Intern</h3>
                     <p class="mt-3 text-sm leading-relaxed text-slate-300">
                         Accés restringit i sense autroregistre extern. Gestionem equips i permisos des del nucli de l'agència per garantir confidencialitat i governança.
                     </p>
                 </div>
-                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl shadow-lg shadow-black/30 md:col-span-2 xl:col-span-1">
+                <div class="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-sm md:col-span-2 xl:col-span-1">
                     <h3 class="text-lg font-semibold text-slate-50">Tecnologia de confiança</h3>
                     <p class="mt-3 text-sm leading-relaxed text-slate-300">
                         Construïda sobre Laravel {{ laravelVersion }} i PHP {{ phpVersion }}, amb processos optimitzats per desplegar evolucions ràpides sense comprometre l'estabilitat.
@@ -108,4 +108,3 @@ defineProps({
         </div>
     </div>
 </template>
-


### PR DESCRIPTION
### Motivation
- Unify dashboards under a new minimal visual system with simpler cards, consistent spacing and neutral chart surfaces for clarity. 
- Align area-specific dashboards (CRM, Productos, RRHH, Contabilidad, Facturación, TPV, Clientes, Admin, etc.) with shared UI primitives to ensure a coherent look. 
- Provide neutral containers around chart canvases so visualizations sit on consistent, muted surfaces across pages.

### Description
- Wrapped chart canvases in neutral, rounded containers across all chart components (`LineChart.vue`, `BarChart.vue`, `PieChart.vue`, `DoughnutChart.vue`, `AreaChart.vue`, `RadarChart.vue`, `PolarChart.vue`) to standardize presentation. 
- Updated shared UI primitives and KPI components (`UI/Panel.vue`, `UI/SummaryCard.vue`, `KpiCard.vue`, `Inventory/*` components and `inventoryTheme.js`) to use simplified borders, muted backgrounds and reduced shadows for a minimalist surface system. 
- Applied the new visual tokens and spacing (grid gaps, card padding, section spacing) across many dashboards and pages (`Dashboard*.vue`, `DashboardCrm.vue`, `DashboardAdmin.vue`, `DashboardClientes.vue`, `DashboardContabilidad.vue`, `DashboardFacturacion.vue`, `DashboardProductos.vue`, `DashboardRRHH.vue`, `DashboardTPV.vue`, `Welcome.vue`) to ensure consistent layout and card styling. 
- Minor tweaks to component defaults (e.g. `KpiCard` padding) and inventory layout tokens to align spacing with the new design language.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720631f814832388315f73d1d1ef87)