### PR TITLE
Refresh CRUD pages to use new Crud/UI components and minimal styles

### DIFF
--- a/resources/js/Pages/Budgets/Index.vue
+++ b/resources/js/Pages/Budgets/Index.vue
@@ -35,62 +35,49 @@
             </div>
         </transition>
 
-        <div class="min-h-screen bg-slate-900">
-            <div class="bg-gradient-to-r from-blue-600 via-indigo-600 to-slate-900 pb-20">
-                <div class="max-w-7xl mx-auto px-6 pt-12">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-                        <div>
-                            <p class="text-sm uppercase tracking-widest text-blue-200">Facturación</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white mt-2">Resumen de presupuestos</h1>
-                            <p class="text-sm text-blue-100 mt-3 max-w-2xl">Controla el rendimiento comercial y haz seguimiento de los presupuestos para convertir más oportunidades en ventas.</p>
-                        </div>
-                        <NavLink :href="route('budgets.create')" class="inline-flex items-center gap-2 rounded-2xl bg-white/15 px-5 py-3 text-sm font-semibold text-white shadow-lg ring-1 ring-white/20 hover:bg-white/25 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Resumen de presupuestos"
+                    description="Controla el rendimiento comercial y haz seguimiento de los presupuestos para convertir más oportunidades en ventas."
+                    :icon="MenuBudgetIcon"
+                >
+                    <template #actions>
+                        <NavLink :href="route('budgets.create')" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             <AddIcon class="w-5 h-5" />
                             Nuevo presupuesto
                         </NavLink>
-                    </div>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-blue-200">Presupuestos activos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ filteredBudgets.length }}</p>
-                            <p class="text-sm text-blue-100 mt-3">{{ budgets.length }} totales registrados</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-blue-200">Clientes</p>
-                            <p class="text-3xl font-semibold mt-2">{{ clients.length }}</p>
-                            <p class="text-sm text-blue-100 mt-3">Relacionados con presupuestos</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-blue-200">Tasa de conversión</p>
-                            <p class="text-3xl font-semibold mt-2">{{ PrecentAcceptedBudgets }}%</p>
-                            <p class="text-sm text-blue-100 mt-3">Presupuestos aceptados frente al total</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-blue-200">Importe filtrado</p>
-                            <p class="text-3xl font-semibold mt-2">{{ formatCurrency(filteredBudgetsTotal) }}</p>
-                            <p class="text-sm text-blue-100 mt-3">Suma de los presupuestos visibles</p>
-                        </div>
-                    </div>
+                <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
+                    <CrudStatCard label="Presupuestos activos" :value="filteredBudgets.length" :icon="MenuBudgetIcon" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ budgets.length }} totales registrados</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Clientes" :value="clients.length" :icon="InfoIcon" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Relacionados con presupuestos</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Tasa de conversión" :value="`${PrecentAcceptedBudgets}%`" :icon="AddIcon" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Presupuestos aceptados frente al total</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Importe filtrado" :value="formatCurrency(filteredBudgetsTotal)" :icon="EditIcon" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Suma de los presupuestos visibles</p>
+                        </template>
+                    </CrudStatCard>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="bg-white rounded-3xl shadow-xl p-6">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Filtros inteligentes</h2>
-                            <p class="text-sm text-slate-500 mt-1">Refina la información por estado, cliente o periodo de tiempo.</p>
-                        </div>
-                        <button @click="clearFilters" class="inline-flex items-center justify-center gap-2 rounded-xl border border-transparent bg-rose-500 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-600 transition">
-                            Limpiar filtros
-                        </button>
-                    </div>
-
-                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 pt-6">
+                <CrudFilterBar>
+                    <div class="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Estado</label>
-                            <select v-model="filters.state" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40">
+                            <select v-model="filters.state" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40">
                                 <option value="">Todos</option>
                                 <option value="accepted">Aceptado</option>
                                 <option value="in_process">En proceso</option>
@@ -100,7 +87,7 @@
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Cliente</label>
-                            <select v-model="filters.client_id" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40">
+                            <select v-model="filters.client_id" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40">
                                 <option value="">Todos</option>
                                 <option v-for="client in clients" :key="client.id" :value="client.id">{{ client.name }}</option>
                             </select>
@@ -108,79 +95,68 @@
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Fecha inicio</label>
-                            <input v-model="filters.start_date" type="date" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40"/>
+                            <input v-model="filters.start_date" type="date" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40"/>
                         </div>
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Fecha fin</label>
-                            <input v-model="filters.end_date" type="date" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40"/>
+                            <input v-model="filters.end_date" type="date" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40"/>
                         </div>
                     </div>
-                </div>
 
-                <div class="bg-white rounded-3xl shadow-xl">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 px-6 py-5">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Listado de presupuestos</h2>
-                            <p class="text-sm text-slate-500 mt-1">Consulta el detalle de cada propuesta y gestiona su ciclo de venta.</p>
-                        </div>
-                        <NavLink :href="route('budgets.create')" class="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition">
-                            <AddIcon class="w-5 h-5" />
-                            Nuevo presupuesto
-                        </NavLink>
-                    </div>
+                    <template #actions>
+                        <button @click="clearFilters" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50">
+                            Limpiar filtros
+                        </button>
+                    </template>
+                </CrudFilterBar>
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-slate-100 text-left">
-                            <thead>
-                                <tr class="text-xs uppercase tracking-widest text-slate-400">
-                                    <th class="px-6 py-3">Identificador</th>
-                                    <th class="px-6 py-3">Cliente</th>
-                                    <th class="px-6 py-3">Fecha</th>
-                                    <th class="px-6 py-3">Estado</th>
-                                    <th class="px-6 py-3">Total</th>
-                                    <th class="px-6 py-3 text-right">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
-                                <tr v-for="budget in filteredBudgets" :key="budget.id" class="hover:bg-slate-50/70 transition">
-                                    <td class="px-6 py-4 font-medium text-slate-700">{{ budget.name }}</td>
-                                    <td class="px-6 py-4">{{ getClientName(budget.client_id) || '—' }}</td>
-                                    <td class="px-6 py-4">{{ formatDate(budget.date) }}</td>
-                                    <td class="px-6 py-4">
-                                        <span
-                                            :class="[statusBadgeClasses(budget.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
-                                            role="button"
-                                            tabindex="0"
-                                            @click="openBudgetStatusModal(budget)"
-                                            @keydown.enter.prevent="openBudgetStatusModal(budget)"
-                                            @keydown.space.prevent="openBudgetStatusModal(budget)"
-                                        >
-                                            {{ statusCopy(budget.state) }}
-                                        </span>
-                                    </td>
-                                    <td class="px-6 py-4 font-semibold text-slate-700">{{ formatCurrency(budget.total) }}</td>
-                                    <td class="px-6 py-4">
-                                        <div class="flex items-center justify-end gap-3 text-slate-400">
-                                            <NavLink :href="route('budgets.show', budget.id)" class="hover:text-blue-500 transition" title="Ver detalles">
-                                                <InfoIcon class="w-5 h-5"/>
-                                            </NavLink>
-                                            <NavLink :href="route('budgets.edit', budget.id)" class="hover:text-amber-500 transition" title="Editar">
-                                                <EditIcon class="w-5 h-5"/>
-                                            </NavLink>
-                                            <button @click="deleteBudget(budget.id)" class="hover:text-rose-500 transition" title="Eliminar">
-                                                <DeleteIcon class="w-5 h-5"/>
-                                            </button>
-                                        </div>
-                                    </td>
-                                </tr>
-                                <tr v-if="filteredBudgets.length === 0">
-                                    <td colspan="6" class="px-6 py-12 text-center text-sm text-slate-400">No hay presupuestos que coincidan con los filtros seleccionados.</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                <CrudTable>
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Cliente</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Estado</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Total</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest text-slate-400">Acciones</th>
+                        </tr>
+                    </template>
+                    <tr v-for="budget in filteredBudgets" :key="budget.id" class="hover:bg-slate-50/70 transition">
+                        <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ budget.name }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-600">{{ getClientName(budget.client_id) || '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-600">{{ formatDate(budget.date) }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            <span
+                                :class="[statusBadgeClasses(budget.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
+                                role="button"
+                                tabindex="0"
+                                @click="openBudgetStatusModal(budget)"
+                                @keydown.enter.prevent="openBudgetStatusModal(budget)"
+                                @keydown.space.prevent="openBudgetStatusModal(budget)"
+                            >
+                                {{ statusCopy(budget.state) }}
+                            </span>
+                        </td>
+                        <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ formatCurrency(budget.total) }}</td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-3 text-slate-500">
+                                <NavLink :href="route('budgets.show', budget.id)" class="hover:text-blue-500 transition" title="Ver detalles">
+                                    <InfoIcon class="w-5 h-5"/>
+                                </NavLink>
+                                <NavLink :href="route('budgets.edit', budget.id)" class="hover:text-amber-500 transition" title="Editar">
+                                    <EditIcon class="w-5 h-5"/>
+                                </NavLink>
+                                <button @click="deleteBudget(budget.id)" class="hover:text-rose-500 transition" title="Eliminar">
+                                    <DeleteIcon class="w-5 h-5"/>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr v-if="filteredBudgets.length === 0">
+                        <td colspan="6" class="px-6 py-12 text-center text-sm text-slate-400">No hay presupuestos que coincidan con los filtros seleccionados.</td>
+                    </tr>
+                </CrudTable>
             </div>
         </div>
 
@@ -206,11 +182,16 @@
 import { Inertia } from '@inertiajs/inertia';
 import { router, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import NavLink from "@/Components/NavLink.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
+import MenuBudgetIcon from "@/Components/Icons/MenuBudgetIcon.vue";
 import StatusUpdateModal from '@/Components/StatusUpdateModal.vue';
 import { computed, reactive, ref } from 'vue';
 

--- a/resources/js/Pages/Categories/Create.vue
+++ b/resources/js/Pages/Categories/Create.vue
@@ -1,26 +1,27 @@
 <template>
     <AppLayout title="Crear categoría">
-        <div class="min-h-screen bg-slate-950">
-            <FinancePageHeader
-                eyebrow="Catálogo"
-                title="Nueva categoría contable"
-                description="Clasifica gastos o ingresos bajo etiquetas consistentes para facilitar la elaboración de informes."
-                :metrics-columns="3"
-            >
-                <template #metrics>
-                    <FinanceSummaryCard label="Nombre" :value="form.name || 'Sin definir'" :helper="`${form.name.length} caracteres`" />
-                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Texto preparado' : 'Añade una descripción'" />
-                    <FinanceSummaryCard label="Estado" value="Borrador" helper="Pendiente de guardar" />
-                </template>
-            </FinancePageHeader>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-4xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Nueva categoría contable"
+                    description="Clasifica gastos o ingresos bajo etiquetas consistentes para facilitar la elaboración de informes."
+                />
 
-            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
-                    <header class="mb-8 border-b border-slate-200 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Datos de la categoría</h2>
-                        <p class="mt-1 text-sm text-slate-500">Define un nombre representativo y una descripción clara para que el equipo contable identifique fácilmente la categoría.</p>
-                    </header>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Nombre" :value="form.name || 'Sin definir'" icon-background="bg-sky-500/10 text-sky-600" />
+                    <CrudStatCard label="Descripción" :value="`${descriptionLength} car.`" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ descriptionLength ? 'Texto preparado' : 'Añade una descripción' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Estado" value="Borrador" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Pendiente de guardar</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
 
+                <Panel title="Datos de la categoría" description="Define un nombre representativo y una descripción clara para que el equipo contable identifique fácilmente la categoría.">
                     <form @submit.prevent="submit" class="grid grid-cols-1 gap-6">
                         <div>
                             <InputLabel for="name" value="Nombre" />
@@ -46,8 +47,8 @@
                             </NavLink>
                         </div>
                     </form>
-                </section>
-            </main>
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -56,8 +57,9 @@
 import { computed } from 'vue';
 import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import TextareaInput from '@/Components/TextareaInput.vue';

--- a/resources/js/Pages/Categories/Edit.vue
+++ b/resources/js/Pages/Categories/Edit.vue
@@ -1,26 +1,27 @@
 <template>
     <AppLayout title="Editar categoría">
-        <div class="min-h-screen bg-slate-950">
-            <FinancePageHeader
-                eyebrow="Catálogo"
-                :title="`Editar ${form.name || 'categoría'}`"
-                description="Mantén tus etiquetas contables coherentes para comparar periodos y realizar auditorías con facilidad."
-                :metrics-columns="3"
-            >
-                <template #metrics>
-                    <FinanceSummaryCard label="Nombre" :value="form.name || 'Sin definir'" :helper="`${form.name.length} caracteres`" />
-                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Actualizada' : 'Añade contexto'" />
-                    <FinanceSummaryCard label="Creación" :value="formatDate(category.created_at)" :helper="`Última actualización: ${formatDate(category.updated_at)}`" />
-                </template>
-            </FinancePageHeader>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-4xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="`Editar ${form.name || 'categoría'}`"
+                    description="Mantén tus etiquetas contables coherentes para comparar periodos y realizar auditorías con facilidad."
+                />
 
-            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
-                    <header class="mb-8 border-b border-slate-200 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Datos de la categoría</h2>
-                        <p class="mt-1 text-sm text-slate-500">Los cambios se verán reflejados en el resto de vistas contables que utilizan esta categoría.</p>
-                    </header>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Nombre" :value="form.name || 'Sin definir'" icon-background="bg-sky-500/10 text-sky-600" />
+                    <CrudStatCard label="Descripción" :value="`${descriptionLength} car.`" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ descriptionLength ? 'Actualizada' : 'Añade contexto' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Creación" :value="formatDate(category.created_at)" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Última actualización: {{ formatDate(category.updated_at) }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
 
+                <Panel title="Datos de la categoría" description="Los cambios se verán reflejados en el resto de vistas contables que utilizan esta categoría.">
                     <form @submit.prevent="submit" class="grid grid-cols-1 gap-6">
                         <div>
                             <InputLabel for="name" value="Nombre" />
@@ -46,8 +47,8 @@
                             </NavLink>
                         </div>
                     </form>
-                </section>
-            </main>
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -56,8 +57,9 @@
 import { computed } from 'vue';
 import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import TextareaInput from '@/Components/TextareaInput.vue';

--- a/resources/js/Pages/Categories/Index.vue
+++ b/resources/js/Pages/Categories/Index.vue
@@ -3,19 +3,18 @@ import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
-import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
-import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
-import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
-import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
 import MenuProductIcon from '@/Components/Icons/MenuProductIcon.vue';
 import AddIcon from '@/Components/Icons/AddIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import InfoIcon from '@/Components/Icons/InfoIcon.vue';
-import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     categories: Array,
@@ -49,61 +48,43 @@ const deleteCategory = (id) => {
     }
 };
 
-const palette = inventoryPalette;
-const typography = inventoryTypography;
+const descriptionBadgeClass = (category) =>
+    category.description
+        ? 'inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700'
+        : 'inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500';
 </script>
 
 <template>
     <AppLayout>
-        <div :class="['min-h-screen pb-16', palette.background]">
-            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
-                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
-                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
-                        <div class="flex items-center gap-4">
-                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
-                                <MenuProductIcon class="h-8 w-8 text-white" />
-                            </div>
-                            <div class="space-y-2">
-                                <p :class="typography.heroKicker">Gestió de categories</p>
-                                <h1 :class="typography.heroTitle">Classifica el catàleg amb coherència</h1>
-                                <p :class="typography.heroSubtitle">
-                                    Organitza les línies de producte per facilitar la cerca i l'anàlisi de vendes.
-                                </p>
-                            </div>
-                        </div>
-                        <div class="flex justify-end">
-                            <Link
-                                :href="route('categories.create')"
-                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
-                            >
-                                <AddIcon class="h-5 w-5" />
-                                Nova categoria
-                            </Link>
-                        </div>
-                    </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Gestió de categories"
+                    description="Organitza les línies de producte per facilitar la cerca i l'anàlisi de vendes."
+                    :icon="MenuProductIcon"
+                >
+                    <template #actions>
+                        <Link
+                            :href="route('categories.create')"
+                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                        >
+                            <AddIcon class="h-5 w-5" />
+                            Nova categoria
+                        </Link>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid gap-6 md:grid-cols-3">
-                        <InventorySummaryCard label="Total categories" :value="totalCategories">
-                            <template #icon>
-                                <MenuProductIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="Amb descripció" :value="withDescription">
-                            <template #icon>
-                                <InfoIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="Sense descripció" :value="withoutDescription" description="Completa la fitxa per millorar el catàleg">
-                            <template #icon>
-                                <DeleteIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                    </div>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Total categories" :value="totalCategories" :icon="MenuProductIcon" />
+                    <CrudStatCard label="Amb descripció" :value="withDescription" :icon="InfoIcon" icon-background="bg-emerald-500/10 text-emerald-600" />
+                    <CrudStatCard label="Sense descripció" :value="withoutDescription" :icon="DeleteIcon" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Completa la fitxa per millorar el catàleg</p>
+                        </template>
+                    </CrudStatCard>
                 </div>
-            </div>
 
-            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
-                <InventoryFilterBar :columns="1">
+                <CrudFilterBar>
                     <div class="flex flex-1 flex-col gap-2">
                         <InputLabel for="category-search" value="Cerca" />
                         <TextInput
@@ -120,9 +101,9 @@ const typography = inventoryTypography;
                             Netejar filtres
                         </SecondaryButton>
                     </template>
-                </InventoryFilterBar>
+                </CrudFilterBar>
 
-                <InventoryResponsiveTable :is-empty="!filteredCategories.length">
+                <CrudTable>
                     <template #head>
                         <tr>
                             <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
@@ -136,21 +117,21 @@ const typography = inventoryTypography;
                         <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ category.name }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ category.description || '—' }}</td>
                         <td class="px-6 py-4 text-sm">
-                            <InventoryStatusBadge :status="category.description ? 'active' : 'inactive'">
+                            <span :class="descriptionBadgeClass(category)">
                                 {{ category.description ? 'Informació completa' : 'Pendents detalls' }}
-                            </InventoryStatusBadge>
+                            </span>
                         </td>
                         <td class="px-6 py-4">
                             <div class="flex items-center justify-end gap-2">
                                 <Link
                                     :href="route('categories.edit', category.id)"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-amber-200 text-amber-600 transition hover:bg-amber-50"
                                 >
                                     <EditIcon class="h-5 w-5" />
                                 </Link>
                                 <button
                                     type="button"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-rose-200 text-rose-600 transition hover:bg-rose-50"
                                     @click="deleteCategory(category.id)"
                                 >
                                     <DeleteIcon class="h-5 w-5" />
@@ -159,10 +140,12 @@ const typography = inventoryTypography;
                         </td>
                     </tr>
 
-                    <template #empty>
-                        Cap categoria coincideix amb la cerca actual.
-                    </template>
-                </InventoryResponsiveTable>
+                    <tr v-if="!filteredCategories.length">
+                        <td colspan="4" class="px-6 py-10 text-center text-sm text-slate-400">
+                            Cap categoria coincideix amb la cerca actual.
+                        </td>
+                    </tr>
+                </CrudTable>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/Pages/Categories/Show.vue
+++ b/resources/js/Pages/Categories/Show.vue
@@ -1,59 +1,64 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950 print:bg-white">
-            <FinancePageHeader
-                eyebrow="Categoría"
-                :title="category.name"
-                description="Consulta la información clave de la categoría y su uso dentro del catálogo contable."
-                :metrics-columns="3"
-            >
-                <template #actions>
-                    <NavLink
-                        :href="route('categories.edit', category.id)"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        Editar
-                    </NavLink>
-                    <NavLink
-                        :href="route('categories.index')"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        Volver al listado
-                    </NavLink>
-                </template>
-                <template #metrics>
-                    <FinanceSummaryCard label="Productos asociados" :value="productsCount" :helper="productsCount === 1 ? 'Producto' : 'Productos'" />
-                    <FinanceSummaryCard label="Descripción" :value="`${descriptionLength} car.`" :helper="descriptionLength ? 'Contenido disponible' : 'Sin descripción'" />
-                    <FinanceSummaryCard label="Creación" :value="formatDate(category.created_at)" :helper="`Actualizada: ${formatDate(category.updated_at)}`" />
-                </template>
-            </FinancePageHeader>
+        <div class="min-h-screen bg-slate-100/80 py-12 print:bg-white">
+            <div class="mx-auto flex max-w-4xl flex-col gap-10 px-6 print:px-0">
+                <CrudPageHeader
+                    :title="category.name"
+                    description="Consulta la información clave de la categoría y su uso dentro del catálogo contable."
+                >
+                    <template #actions>
+                        <NavLink
+                            :href="route('categories.edit', category.id)"
+                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                        >
+                            Editar
+                        </NavLink>
+                        <NavLink
+                            :href="route('categories.index')"
+                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
+                        >
+                            Volver al listado
+                        </NavLink>
+                    </template>
+                </CrudPageHeader>
 
-            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="border-b border-slate-100 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Descripción</h2>
-                        <p class="text-sm text-slate-500">Texto utilizado en informes y paneles para explicar el alcance de la categoría.</p>
-                    </header>
-                    <p class="mt-4 whitespace-pre-line text-slate-700">{{ category.description || 'Esta categoría todavía no tiene descripción.' }}</p>
-                </section>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Productos asociados" :value="productsCount" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ productsCount === 1 ? 'Producto' : 'Productos' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Descripción" :value="`${descriptionLength} car.`" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ descriptionLength ? 'Contenido disponible' : 'Sin descripción' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Creación" :value="formatDate(category.created_at)" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Actualizada: {{ formatDate(category.updated_at) }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
 
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="border-b border-slate-100 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Metadatos</h2>
-                        <p class="text-sm text-slate-500">Información adicional sobre la empresa asociada y los identificadores internos.</p>
-                    </header>
-                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Empresa</dt>
-                            <dd class="mt-2">{{ companyName }}</dd>
-                        </div>
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</dt>
-                            <dd class="mt-2">{{ category.id }}</dd>
-                        </div>
-                    </dl>
-                </section>
-            </main>
+                <div class="space-y-10 print:space-y-6">
+                    <Panel title="Descripción" description="Texto utilizado en informes y paneles para explicar el alcance de la categoría." :header-border="true">
+                        <p class="whitespace-pre-line text-slate-700">{{ category.description || 'Esta categoría todavía no tiene descripción.' }}</p>
+                    </Panel>
+
+                    <Panel title="Metadatos" description="Información adicional sobre la empresa asociada y los identificadores internos." :header-border="true">
+                        <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Empresa</dt>
+                                <dd class="mt-2">{{ companyName }}</dd>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</dt>
+                                <dd class="mt-2">{{ category.id }}</dd>
+                            </div>
+                        </dl>
+                    </Panel>
+                </div>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -61,8 +66,9 @@
 <script setup>
 import { computed } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import NavLink from '@/Components/NavLink.vue';
 
 const props = defineProps({

--- a/resources/js/Pages/Clients/Create.vue
+++ b/resources/js/Pages/Clients/Create.vue
@@ -1,22 +1,18 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
-                <div class="max-w-5xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Nuevo cliente</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Crear cliente</h1>
-                            <p class="text-sm text-emerald-200 mt-2">Completa los datos para sumar un nuevo cliente a tu cartera.</p>
-                        </div>
-                        <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Crear cliente"
+                    description="Completa los datos para sumar un nuevo cliente a tu cartera."
+                >
+                    <template #actions>
+                        <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             Volver al listado
                         </NavLink>
-                    </div>
-                </div>
-            </div>
+                    </template>
+                </CrudPageHeader>
 
-            <div class="max-w-5xl mx-auto px-6 -mt-16 pb-16">
                 <Panel title="Datos del cliente" description="Los campos marcados como obligatorios garantizan una facturación sin incidencias.">
                     <ClientForm
                         :form="form"
@@ -35,6 +31,7 @@
 
 <script setup>
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 import Panel from '@/Components/UI/Panel.vue';
 import ClientForm from '@/Components/Clients/ClientForm.vue';
 import NavLink from '@/Components/NavLink.vue';

--- a/resources/js/Pages/Clients/Edit.vue
+++ b/resources/js/Pages/Clients/Edit.vue
@@ -1,22 +1,18 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
-                <div class="max-w-5xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Editar cliente</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Actualiza la información</h1>
-                            <p class="text-sm text-emerald-200 mt-2">Mantén los datos al día para garantizar una comunicación fluida.</p>
-                        </div>
-                        <NavLink :href="route('clients.show', props.client.id)" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Actualiza la información"
+                    description="Mantén los datos al día para garantizar una comunicación fluida."
+                >
+                    <template #actions>
+                        <NavLink :href="route('clients.show', props.client.id)" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             Ver ficha
                         </NavLink>
-                    </div>
-                </div>
-            </div>
+                    </template>
+                </CrudPageHeader>
 
-            <div class="max-w-5xl mx-auto px-6 -mt-16 pb-16">
                 <Panel title="Datos del cliente" description="Revisa y confirma que toda la información sea correcta.">
                     <ClientForm
                         :form="form"
@@ -35,6 +31,7 @@
 
 <script setup>
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 import Panel from '@/Components/UI/Panel.vue';
 import ClientForm from '@/Components/Clients/ClientForm.vue';
 import NavLink from '@/Components/NavLink.vue';

--- a/resources/js/Pages/Clients/Index.vue
+++ b/resources/js/Pages/Clients/Index.vue
@@ -1,54 +1,68 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Gestión de clientes</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Clientes de la compañía</h1>
-                            <p class="text-sm text-emerald-200 mt-2">Consulta, filtra y administra tu cartera de clientes desde un único lugar.</p>
-                        </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Clientes de la compañía"
+                    description="Consulta, filtra y administra tu cartera de clientes desde un único lugar."
+                    :icon="DashboardIcon"
+                    accent="from-emerald-500 to-sky-500"
+                >
+                    <template #actions>
                         <div class="flex flex-wrap gap-3">
-                            <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                                 <AddIcon class="w-4 h-4" /> Nuevo cliente
                             </NavLink>
-                            <NavLink :href="route('dashboard.clients')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('dashboard.clients')" class="inline-flex items-center gap-2 rounded-2xl border border-white/40 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-white/20">
                                 <DashboardIcon class="w-4 h-4" /> Ver dashboard
                             </NavLink>
                         </div>
-                    </div>
-
-                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <SummaryCard v-for="card in summaryCards" :key="card.eyebrow" :eyebrow="card.eyebrow" :value="card.value" :description="card.description" />
-                    </div>
-                </div>
-            </div>
-
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <Panel title="Filtros" description="Refina la lista aplicando varios criterios.">
-                    <template #actions>
-                        <button @click="resetFilters" class="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
-                            Reiniciar filtros
-                        </button>
                     </template>
-                    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-                        <div v-for="field in filterFields" :key="field.id">
-                            <label :for="field.id" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">{{ field.label }}</label>
-                            <component
-                                :is="field.component"
-                                :id="field.id"
-                                v-model="field.model.value"
-                                v-bind="field.props"
-                                class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
-                            >
-                                <option v-for="option in field.options" :key="option.value" :value="option.value">
-                                    {{ option.label }}
-                                </option>
-                            </component>
-                        </div>
+                </CrudPageHeader>
+
+                <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4">
+                    <CrudStatCard
+                        v-for="card in summaryCards"
+                        :key="card.eyebrow"
+                        :label="card.eyebrow"
+                        :value="card.value"
+                        icon-background="bg-emerald-500/10 text-emerald-600"
+                    >
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ card.description }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
+
+                <div class="space-y-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-slate-800">Filtros</h2>
+                        <p class="text-sm text-slate-500">Refina la lista aplicando varios criterios.</p>
                     </div>
-                </Panel>
+                    <CrudFilterBar>
+                        <div class="grid flex-1 grid-cols-1 gap-6 md:grid-cols-4">
+                            <div v-for="field in filterFields" :key="field.id">
+                                <label :for="field.id" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">{{ field.label }}</label>
+                                <component
+                                    :is="field.component"
+                                    :id="field.id"
+                                    v-model="field.model.value"
+                                    v-bind="field.props"
+                                    class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                                >
+                                    <option v-for="option in field.options" :key="option.value" :value="option.value">
+                                        {{ option.label }}
+                                    </option>
+                                </component>
+                            </div>
+                        </div>
+                        <template #actions>
+                            <button @click="resetFilters" class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
+                                Reiniciar filtros
+                            </button>
+                        </template>
+                    </CrudFilterBar>
+                </div>
 
                 <Panel title="Listado de clientes" description="Accede rápidamente al detalle, edición y eliminación." :header-border="true">
                     <DataTable
@@ -91,8 +105,10 @@
 import { computed, ref } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
 import NavLink from '@/Components/NavLink.vue';
-import SummaryCard from '@/Components/UI/SummaryCard.vue';
 import Panel from '@/Components/UI/Panel.vue';
 import DataTable from '@/Components/UI/DataTable.vue';
 import InfoIcon from '@/Components/Icons/InfoIcon.vue';

--- a/resources/js/Pages/Clients/Show.vue
+++ b/resources/js/Pages/Clients/Show.vue
@@ -1,34 +1,32 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-blue-700 to-slate-900 pb-24">
-                <div class="max-w-6xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-200 text-sm uppercase tracking-widest">Ficha de cliente</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">{{ client.name }}</h1>
-                            <p class="text-sm text-emerald-200 mt-2">Visualiza la información clave y el historial de presupuestos y facturas.</p>
-                        </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="client.name"
+                    description="Visualiza la información clave y el historial de presupuestos y facturas."
+                    accent="from-emerald-500 to-sky-500"
+                >
+                    <template #actions>
                         <div class="flex flex-wrap gap-3">
-                            <NavLink :href="route('clients.edit', client.id)" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('clients.edit', client.id)" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                                 Editar cliente
                             </NavLink>
-                            <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow ring-1 ring-white/20 hover:bg-white/20 transition">
+                            <NavLink :href="route('clients.index')" class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50">
                                 Volver al listado
                             </NavLink>
                         </div>
-                    </div>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 mt-10">
-                        <SummaryCard eyebrow="Presupuestos" :value="filteredBudgets.length" :description="`Importe total €${totalBudgetAmount}`" />
-                        <SummaryCard eyebrow="Facturas" :value="filteredInvoices.length" :description="`Importe total €${totalInvoiceAmount}`" />
-                        <SummaryCard eyebrow="Estado del cliente" :value="statusCopy(client.status)" description="Situación actual" />
-                        <SummaryCard eyebrow="Última actividad" :value="lastActivity" description="Último documento registrado" />
-                    </div>
+                <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+                    <SummaryCard eyebrow="Presupuestos" :value="filteredBudgets.length" :description="`Importe total €${totalBudgetAmount}`" />
+                    <SummaryCard eyebrow="Facturas" :value="filteredInvoices.length" :description="`Importe total €${totalInvoiceAmount}`" />
+                    <SummaryCard eyebrow="Estado del cliente" :value="statusCopy(client.status)" description="Situación actual" />
+                    <SummaryCard eyebrow="Última actividad" :value="lastActivity" description="Último documento registrado" />
                 </div>
-            </div>
 
-            <div class="max-w-6xl mx-auto px-6 -mt-16 pb-16 space-y-10">
+                <div class="space-y-10">
                 <Panel title="Datos generales" description="Información de contacto y datos fiscales del cliente.">
                     <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-6">
                         <div v-for="detail in clientDetails" :key="detail.label" class="rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
@@ -131,6 +129,7 @@
 <script setup>
 import { computed, ref } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 import NavLink from '@/Components/NavLink.vue';
 import SummaryCard from '@/Components/UI/SummaryCard.vue';
 import Panel from '@/Components/UI/Panel.vue';

--- a/resources/js/Pages/Expenses/Create.vue
+++ b/resources/js/Pages/Expenses/Create.vue
@@ -1,40 +1,31 @@
 <template>
     <AppLayout title="Registrar gasto">
-        <div class="min-h-screen bg-slate-950">
-            <FinancePageHeader
-                eyebrow="Contabilidad"
-                title="Registrar nuevo gasto"
-                description="Introduce el gasto con el mismo diseño que el resto del módulo y obtén el cálculo automático de impuestos."
-                :metrics-columns="3"
-            >
-                <template #metrics>
-                    <FinanceSummaryCard
-                        label="Base imponible"
-                        :value="formatCurrency(form.amount)"
-                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
-                    />
-                    <FinanceSummaryCard
-                        label="IVA estimado"
-                        :value="formatCurrency(taxAmount)"
-                        :helper="`${form.iva || 0}% aplicado`"
-                    />
-                    <FinanceSummaryCard
-                        label="Total previsto"
-                        :value="formatCurrency(totalAmount)"
-                        :helper="form.payment_method_id ? paymentMethodName : 'Método pendiente'"
-                    />
-                </template>
-            </FinancePageHeader>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Registrar nuevo gasto"
+                    description="Introduce el gasto con el mismo diseño que el resto del módulo y obtén el cálculo automático de impuestos."
+                />
 
-            <main class="max-w-5xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
-                    <header class="mb-8 border-b border-slate-200 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Detalles del gasto</h2>
-                        <p class="mt-1 text-sm text-slate-500">
-                            Organiza la información en bloques claros: importe, clasificación y documentación adjunta.
-                        </p>
-                    </header>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Base imponible" :value="formatCurrency(form.amount)" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ form.date ? formatDate(form.date) : 'Fecha pendiente' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="IVA estimado" :value="formatCurrency(taxAmount)" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ `${form.iva || 0}% aplicado` }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Total previsto" :value="formatCurrency(totalAmount)" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ form.payment_method_id ? paymentMethodName : 'Método pendiente' }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
 
+                <Panel title="Detalles del gasto" description="Organiza la información en bloques claros: importe, clasificación y documentación adjunta.">
                     <form @submit.prevent="submitForm" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
                         <div>
                             <InputLabel for="date" value="Fecha" />
@@ -146,8 +137,8 @@
                             </NavLink>
                         </div>
                     </form>
-                </section>
-            </main>
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -156,8 +147,9 @@
 import { computed, ref } from 'vue';
 import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import TextareaInput from '@/Components/TextareaInput.vue';

--- a/resources/js/Pages/Expenses/Edit.vue
+++ b/resources/js/Pages/Expenses/Edit.vue
@@ -1,40 +1,31 @@
 <template>
     <AppLayout title="Editar gasto">
-        <div class="min-h-screen bg-slate-950">
-            <FinancePageHeader
-                eyebrow="Contabilidad"
-                :title="`Editar ${form.name || 'gasto'}`"
-                description="Actualiza los datos del gasto con una interfaz alineada al resto de la suite contable."
-                :metrics-columns="3"
-            >
-                <template #metrics>
-                    <FinanceSummaryCard
-                        label="Base imponible"
-                        :value="formatCurrency(form.amount)"
-                        :helper="form.date ? formatDate(form.date) : 'Fecha pendiente'"
-                    />
-                    <FinanceSummaryCard
-                        label="IVA recalculado"
-                        :value="formatCurrency(taxAmount)"
-                        :helper="`${form.iva || 0}% aplicado`"
-                    />
-                    <FinanceSummaryCard
-                        label="Total actualizado"
-                        :value="formatCurrency(totalAmount)"
-                        :helper="form.payment_method_id ? paymentMethodName : 'Método pendiente'"
-                    />
-                </template>
-            </FinancePageHeader>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-5xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="`Editar ${form.name || 'gasto'}`"
+                    description="Actualiza los datos del gasto con una interfaz alineada al resto de la suite contable."
+                />
 
-            <main class="max-w-5xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <section class="rounded-3xl border border-white/10 bg-white/95 p-8 shadow-xl">
-                    <header class="mb-8 border-b border-slate-200 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Detalles del gasto</h2>
-                        <p class="mt-1 text-sm text-slate-500">
-                            Los cambios se reflejarán en informes, dashboards y en la ficha del gasto inmediatamente.
-                        </p>
-                    </header>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Base imponible" :value="formatCurrency(form.amount)" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ form.date ? formatDate(form.date) : 'Fecha pendiente' }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="IVA recalculado" :value="formatCurrency(taxAmount)" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ `${form.iva || 0}% aplicado` }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Total actualizado" :value="formatCurrency(totalAmount)" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ form.payment_method_id ? paymentMethodName : 'Método pendiente' }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
 
+                <Panel title="Detalles del gasto" description="Los cambios se reflejarán en informes, dashboards y en la ficha del gasto inmediatamente.">
                     <form @submit.prevent="submitForm" class="grid grid-cols-1 gap-6 sm:grid-cols-2">
                         <div>
                             <InputLabel for="date" value="Fecha" />
@@ -124,8 +115,8 @@
                             </NavLink>
                         </div>
                     </form>
-                </section>
-            </main>
+                </Panel>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -134,8 +125,9 @@
 import { computed, ref } from 'vue';
 import { useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import TextareaInput from '@/Components/TextareaInput.vue';

--- a/resources/js/Pages/Expenses/Index.vue
+++ b/resources/js/Pages/Expenses/Index.vue
@@ -1,52 +1,62 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950 print:bg-white">
-            <FinancePageHeader
-                eyebrow="Control financiero"
-                title="Gastos operativos"
-                description="Visualiza los gastos con filtros dinámicos, gráficas comparables y tarjetas en línea con el panel contable."
-            >
-                <template #actions>
-                    <NavLink
-                        :href="route('expenses.create')"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        <AddIcon class="h-4 w-4" />
-                        <span>Registrar gasto</span>
-                    </NavLink>
-                    <button
-                        type="button"
-                        @click="printPage"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        Imprimir informe
-                    </button>
-                </template>
-
-                <template #metrics>
-                    <FinanceSummaryCard label="Gasto total" :value="formatCurrency(totalGrossAmount)" :helper="totalGrossHelper" />
-                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(totalNetAmount)" :helper="totalNetHelper" />
-                    <FinanceSummaryCard label="Ticket medio" :value="formatCurrency(averageGrossAmount)" :helper="averageHelper" />
-                    <FinanceSummaryCard label="Mayor gasto" :value="formatCurrency(highestExpenseGross)" :helper="highestExpenseHelper" />
-                </template>
-            </FinancePageHeader>
-
-            <main class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="flex flex-col gap-2 border-b border-slate-100 pb-4 sm:flex-row sm:items-end sm:justify-between">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Filtrar gastos</h2>
-                            <p class="text-sm text-slate-500">Combina filtros para focalizar tus análisis. Las gráficas y totales se recalculan al instante.</p>
+        <div class="min-h-screen bg-slate-100/80 py-12 print:bg-white">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 print:px-0">
+                <CrudPageHeader
+                    title="Gastos operativos"
+                    description="Visualiza los gastos con filtros dinámicos, gráficas comparables y tarjetas en línea con el panel contable."
+                    :icon="MenuExpenseIcon"
+                >
+                    <template #actions>
+                        <div class="flex flex-wrap gap-3">
+                            <NavLink
+                                :href="route('expenses.create')"
+                                class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                            >
+                                <AddIcon class="h-4 w-4" />
+                                <span>Registrar gasto</span>
+                            </NavLink>
+                            <button
+                                type="button"
+                                @click="printPage"
+                                class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
+                            >
+                                Imprimir informe
+                            </button>
                         </div>
-                        <button
-                            type="button"
-                            class="inline-flex items-center gap-2 rounded-xl bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-200"
-                            @click="resetFilters"
-                        >
-                            Limpiar filtros
-                        </button>
-                    </header>
-                    <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
+                    <CrudStatCard label="Gasto total" :value="formatCurrency(totalGrossAmount)" :icon="MenuExpenseIcon">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ totalGrossHelper }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Base imponible" :value="formatCurrency(totalNetAmount)" :icon="MenuExpenseIcon" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ totalNetHelper }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Ticket medio" :value="formatCurrency(averageGrossAmount)" :icon="MenuExpenseIcon" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ averageHelper }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Mayor gasto" :value="formatCurrency(highestExpenseGross)" :icon="MenuExpenseIcon" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ highestExpenseHelper }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
+
+                <div class="space-y-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-slate-800">Filtrar gastos</h2>
+                        <p class="text-sm text-slate-500">Combina filtros para focalizar tus análisis. Las gráficas y totales se recalculan al instante.</p>
+                    </div>
+                    <CrudFilterBar>
+                        <div class="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
                         <label class="flex flex-col text-sm font-medium text-slate-600">
                             Periodo
                             <select
@@ -139,7 +149,7 @@
                             </select>
                         </label>
 
-                        <label class="flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-600">
+                        <label class="flex items-center gap-3 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-sm font-medium text-slate-600 shadow-sm">
                             <input
                                 type="checkbox"
                                 v-model="showRecurringOnly"
@@ -148,7 +158,17 @@
                             Solo recurrentes
                         </label>
                     </div>
-                </section>
+                        <template #actions>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-50"
+                                @click="resetFilters"
+                            >
+                                Limpiar filtros
+                            </button>
+                        </template>
+                    </CrudFilterBar>
+                </div>
 
                 <section class="grid grid-cols-1 gap-8 xl:grid-cols-2">
                     <article class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
@@ -178,85 +198,83 @@
                     </article>
                 </section>
 
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-0">
-                    <header class="flex flex-col gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-center sm:justify-between">
+                <div class="space-y-4">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Relación detallada de gastos</h2>
+                            <h2 class="text-lg font-semibold text-slate-800">Relación detallada de gastos</h2>
                             <p class="text-sm text-slate-500">Información preparada para manejar grandes volúmenes y exportar en papel.</p>
                         </div>
                         <div class="text-right text-sm text-slate-500">
                             {{ filteredCountMessage }}
                         </div>
-                    </header>
-                    <div class="mt-6 overflow-x-auto print:overflow-visible">
-                        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-600">
-                            <thead class="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">
-                                <tr>
-                                    <th scope="col" class="px-4 py-3">Identificador</th>
-                                    <th scope="col" class="px-4 py-3">Nombre</th>
-                                    <th scope="col" class="px-4 py-3">Descripción</th>
-                                    <th scope="col" class="px-4 py-3 text-right">Base imponible</th>
-                                    <th scope="col" class="px-4 py-3 text-right">IVA</th>
-                                    <th scope="col" class="px-4 py-3 text-right">Total</th>
-                                    <th scope="col" class="px-4 py-3">Fecha</th>
-                                    <th scope="col" class="px-4 py-3">Método</th>
-                                    <th scope="col" class="px-4 py-3">Categoría</th>
-                                    <th scope="col" class="px-4 py-3 text-center print:hidden">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-slate-100">
-                                <tr
-                                    v-for="expense in visibleExpenses"
-                                    :key="expense.id"
-                                    class="bg-white/60 transition hover:bg-rose-50/60"
-                                >
-                                    <td class="px-4 py-3 font-medium text-slate-700">{{ expense.id }}</td>
-                                    <td class="px-4 py-3">
-                                        <div class="flex flex-col gap-1">
-                                            <div class="flex items-center gap-2">
-                                                <span>{{ expense.name }}</span>
-                                                <span
-                                                    v-if="expense.is_recurring"
-                                                    class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700"
-                                                >
-                                                    Recurrente
-                                                </span>
-                                            </div>
-                                            <p
-                                                v-if="expense.is_recurring && expense.next_run_at"
-                                                class="text-xs text-slate-500"
-                                            >
-                                                Próxima ejecución: {{ formatDate(expense.next_run_at) }} · {{ recurringStatusLabel(expense.recurring_status) }}
-                                            </p>
-                                        </div>
-                                    </td>
-                                    <td class="px-4 py-3 max-w-xs truncate" :title="expense.description">{{ expense.description || '—' }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount ?? 0) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(taxAmount(expense)) }}</td>
-                                    <td class="px-4 py-3 text-right">{{ formatCurrency(grossAmount(expense)) }}</td>
-                                    <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
-                                    <td class="px-4 py-3">{{ paymentMethodName(expense.payment_method_id) }}</td>
-                                    <td class="px-4 py-3">{{ categoryName(expense.expense_category_id) }}</td>
-                                    <td class="px-4 py-3 text-center print:hidden">
-                                        <div class="flex justify-center gap-3">
-                                            <NavLink :href="route('expenses.show', expense.id)" class="text-slate-500 hover:text-slate-700" title="Ver detalle">
-                                                <InfoIcon class="w-5 h-5" />
-                                            </NavLink>
-                                            <NavLink :href="route('expenses.edit', expense.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
-                                                <EditIcon class="w-5 h-5" />
-                                            </NavLink>
-                                            <button
-                                                type="button"
-                                                @click="deleteExpense(expense.id)"
-                                                class="text-rose-500 hover:text-rose-700"
-                                                title="Eliminar"
-                                            >
-                                                <DeleteIcon class="w-5 h-5" />
-                                            </button>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tbody>
+                    </div>
+                    <CrudTable>
+                        <template #head>
+                            <tr>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Identificador</th>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Nombre</th>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Descripción</th>
+                                <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-widest text-slate-500">Base imponible</th>
+                                <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-widest text-slate-500">IVA</th>
+                                <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-widest text-slate-500">Total</th>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Fecha</th>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Método</th>
+                                <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-500">Categoría</th>
+                                <th scope="col" class="px-4 py-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-500 print:hidden">Acciones</th>
+                            </tr>
+                        </template>
+                        <tr
+                            v-for="expense in visibleExpenses"
+                            :key="expense.id"
+                            class="bg-white/60 transition hover:bg-rose-50/60"
+                        >
+                            <td class="px-4 py-3 font-medium text-slate-700">{{ expense.id }}</td>
+                            <td class="px-4 py-3">
+                                <div class="flex flex-col gap-1">
+                                    <div class="flex items-center gap-2">
+                                        <span>{{ expense.name }}</span>
+                                        <span
+                                            v-if="expense.is_recurring"
+                                            class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700"
+                                        >
+                                            Recurrente
+                                        </span>
+                                    </div>
+                                    <p
+                                        v-if="expense.is_recurring && expense.next_run_at"
+                                        class="text-xs text-slate-500"
+                                    >
+                                        Próxima ejecución: {{ formatDate(expense.next_run_at) }} · {{ recurringStatusLabel(expense.recurring_status) }}
+                                    </p>
+                                </div>
+                            </td>
+                            <td class="px-4 py-3 max-w-xs truncate" :title="expense.description">{{ expense.description || '—' }}</td>
+                            <td class="px-4 py-3 text-right">{{ formatCurrency(expense.amount ?? 0) }}</td>
+                            <td class="px-4 py-3 text-right">{{ formatCurrency(taxAmount(expense)) }}</td>
+                            <td class="px-4 py-3 text-right">{{ formatCurrency(grossAmount(expense)) }}</td>
+                            <td class="px-4 py-3 whitespace-nowrap">{{ formatDate(expense.date) }}</td>
+                            <td class="px-4 py-3">{{ paymentMethodName(expense.payment_method_id) }}</td>
+                            <td class="px-4 py-3">{{ categoryName(expense.expense_category_id) }}</td>
+                            <td class="px-4 py-3 text-center print:hidden">
+                                <div class="flex justify-center gap-3">
+                                    <NavLink :href="route('expenses.show', expense.id)" class="text-slate-500 hover:text-slate-700" title="Ver detalle">
+                                        <InfoIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <NavLink :href="route('expenses.edit', expense.id)" class="text-emerald-600 hover:text-emerald-800" title="Editar">
+                                        <EditIcon class="w-5 h-5" />
+                                    </NavLink>
+                                    <button
+                                        type="button"
+                                        @click="deleteExpense(expense.id)"
+                                        class="text-rose-500 hover:text-rose-700"
+                                        title="Eliminar"
+                                    >
+                                        <DeleteIcon class="w-5 h-5" />
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <template #footer>
                             <tfoot class="bg-slate-50/80 text-xs uppercase tracking-widest text-slate-500">
                                 <tr>
                                     <td class="px-4 py-3" colspan="3">Totales</td>
@@ -266,10 +284,10 @@
                                     <td class="px-4 py-3" colspan="4"></td>
                                 </tr>
                             </tfoot>
-                        </table>
-                    </div>
-                </section>
-            </main>
+                        </template>
+                    </CrudTable>
+                </div>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -278,8 +296,10 @@
 import { computed, ref, watch } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import BarChart from '@/Components/BarChart.vue';
 import DoughnutChart from '@/Components/DoughnutChart.vue';
 import NavLink from '@/Components/NavLink.vue';
@@ -287,6 +307,7 @@ import InfoIcon from '@/Components/Icons/InfoIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import AddIcon from '@/Components/Icons/AddIcon.vue';
+import MenuExpenseIcon from '@/Components/Icons/MenuExpenseIcon.vue';
 
 const props = defineProps({
     expenses: {

--- a/resources/js/Pages/Expenses/Show.vue
+++ b/resources/js/Pages/Expenses/Show.vue
@@ -1,94 +1,92 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950 print:bg-white">
-            <FinancePageHeader
-                eyebrow="Detalle de gasto"
-                :title="expense.name || 'Gasto'"
-                :description="`Consulta la trazabilidad completa del gasto y su impacto en los indicadores del panel contable.`"
-                :metrics-columns="3"
-            >
-                <template #actions>
-                    <NavLink
-                        :href="route('expenses.edit', expense.id)"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        <EditIcon class="h-4 w-4" />
-                        <span>Editar</span>
-                    </NavLink>
-                    <button
-                        type="button"
-                        @click="confirmDelete"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        Eliminar
-                    </button>
-                    <button
-                        type="button"
-                        @click="printPage"
-                        class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        Imprimir ficha
-                    </button>
-                </template>
+        <div class="min-h-screen bg-slate-100/80 py-12 print:bg-white">
+            <div class="mx-auto flex max-w-4xl flex-col gap-10 px-6 print:px-0">
+                <CrudPageHeader
+                    :title="expense.name || 'Gasto'"
+                    :description="`Consulta la trazabilidad completa del gasto y su impacto en los indicadores del panel contable.`"
+                >
+                    <template #actions>
+                        <NavLink
+                            :href="route('expenses.edit', expense.id)"
+                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                        >
+                            <EditIcon class="h-4 w-4" />
+                            <span>Editar</span>
+                        </NavLink>
+                        <button
+                            type="button"
+                            @click="confirmDelete"
+                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
+                        >
+                            Eliminar
+                        </button>
+                        <button
+                            type="button"
+                            @click="printPage"
+                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
+                        >
+                            Imprimir ficha
+                        </button>
+                    </template>
+                </CrudPageHeader>
 
-                <template #metrics>
-                    <FinanceSummaryCard label="Base imponible" :value="formatCurrency(netAmount)" :helper="formatDate(expense.date)" />
-                    <FinanceSummaryCard label="IVA" :value="formatCurrency(taxAmount)" :helper="`${expense.iva ?? 0}% aplicado`" />
-                    <FinanceSummaryCard label="Total" :value="formatCurrency(grossAmount)" :helper="`${paymentMethodName} · ${categoryName}`" />
-                </template>
-            </FinancePageHeader>
-
-            <main class="max-w-4xl mx-auto px-6 -mt-16 pb-16 space-y-10 print:mt-0 print:space-y-6 print:px-0">
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="border-b border-slate-100 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Información principal</h2>
-                        <p class="text-sm text-slate-500">Datos esenciales del gasto armonizados con la tipografía y estilo del dashboard.</p>
-                    </header>
-                    <dl class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Descripción</dt>
-                            <dd class="mt-2 whitespace-pre-line">{{ expense.description || 'Sin descripción' }}</dd>
-                        </div>
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</dt>
-                            <dd class="mt-2">{{ formatDate(expense.date) }}</dd>
-                        </div>
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Método de pago</dt>
-                            <dd class="mt-2">{{ paymentMethodName }}</dd>
-                        </div>
-                        <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
-                            <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Categoría</dt>
-                            <dd class="mt-2">{{ categoryName }}</dd>
-                        </div>
-                    </dl>
-                </section>
-
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="border-b border-slate-100 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Desglose económico</h2>
-                        <p class="text-sm text-slate-500">Visualiza la proporción entre base imponible e impuestos.</p>
-                    </header>
-                    <div class="mt-6">
-                        <DoughnutChart :data="breakdownChart" />
-                    </div>
-                </section>
-
-                <section class="bg-white rounded-3xl shadow-xl p-6 print:shadow-none print:rounded-none print:border print:border-slate-200 print:p-4">
-                    <header class="border-b border-slate-100 pb-4">
-                        <h2 class="text-xl font-semibold text-slate-800">Documentación</h2>
-                        <p class="text-sm text-slate-500">Archivos listos para auditoría o consulta por terceros.</p>
-                    </header>
-                    <div class="mt-6 text-sm text-slate-600">
-                        <template v-if="expense.file">
-                            <a :href="`/storage/${expense.file}`" target="_blank" class="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 font-semibold text-emerald-700 transition hover:bg-emerald-100">
-                                Ver archivo adjunto
-                            </a>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Base imponible" :value="formatCurrency(netAmount)" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ formatDate(expense.date) }}</p>
                         </template>
-                        <p v-else class="text-slate-400">No hay archivo adjunto.</p>
-                    </div>
-                </section>
-            </main>
+                    </CrudStatCard>
+                    <CrudStatCard label="IVA" :value="formatCurrency(taxAmount)" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ `${expense.iva ?? 0}% aplicado` }}</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Total" :value="formatCurrency(grossAmount)" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ `${paymentMethodName} · ${categoryName}` }}</p>
+                        </template>
+                    </CrudStatCard>
+                </div>
+
+                <div class="space-y-10 print:space-y-6">
+                    <Panel title="Información principal" description="Datos esenciales del gasto armonizados con la tipografía y estilo del dashboard.">
+                        <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Descripción</dt>
+                                <dd class="mt-2 whitespace-pre-line">{{ expense.description || 'Sin descripción' }}</dd>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</dt>
+                                <dd class="mt-2">{{ formatDate(expense.date) }}</dd>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Método de pago</dt>
+                                <dd class="mt-2">{{ paymentMethodName }}</dd>
+                            </div>
+                            <div class="rounded-2xl bg-slate-50 p-4 text-slate-700">
+                                <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">Categoría</dt>
+                                <dd class="mt-2">{{ categoryName }}</dd>
+                            </div>
+                        </dl>
+                    </Panel>
+
+                    <Panel title="Desglose económico" description="Visualiza la proporción entre base imponible e impuestos.">
+                        <DoughnutChart :data="breakdownChart" />
+                    </Panel>
+
+                    <Panel title="Documentación" description="Archivos listos para auditoría o consulta por terceros.">
+                        <div class="mt-6 text-sm text-slate-600">
+                            <template v-if="expense.file">
+                                <a :href="`/storage/${expense.file}`" target="_blank" class="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 font-semibold text-emerald-700 transition hover:bg-emerald-100">
+                                    Ver archivo adjunto
+                                </a>
+                            </template>
+                            <p v-else class="text-slate-400">No hay archivo adjunto.</p>
+                        </div>
+                    </Panel>
+                </div>
+            </div>
         </div>
     </AppLayout>
 </template>
@@ -97,8 +95,9 @@
 import { computed } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import FinancePageHeader from '@/Components/Finance/FinancePageHeader.vue';
-import FinanceSummaryCard from '@/Components/Finance/FinanceSummaryCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import DoughnutChart from '@/Components/DoughnutChart.vue';
 import NavLink from '@/Components/NavLink.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';

--- a/resources/js/Pages/Invoices/Index.vue
+++ b/resources/js/Pages/Invoices/Index.vue
@@ -35,62 +35,49 @@
             </div>
         </transition>
 
-        <div class="min-h-screen bg-slate-900">
-            <div class="bg-gradient-to-r from-sky-600 via-blue-600 to-slate-900 pb-20">
-                <div class="max-w-7xl mx-auto px-6 pt-12">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-                        <div>
-                            <p class="text-sm uppercase tracking-widest text-sky-200">Facturación</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white mt-2">Gestión de facturas</h1>
-                            <p class="text-sm text-sky-100 mt-3 max-w-2xl">Visualiza el estado de cobros, consulta tendencias y toma decisiones rápidas sobre tu cartera de clientes.</p>
-                        </div>
-                        <NavLink :href="route('invoices.create')" class="inline-flex items-center gap-2 rounded-2xl bg-white/15 px-5 py-3 text-sm font-semibold text-white shadow-lg ring-1 ring-white/20 hover:bg-white/25 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Gestión de facturas"
+                    description="Visualiza el estado de cobros, consulta tendencias y toma decisiones rápidas sobre tu cartera de clientes."
+                    :icon="MenuInvoiceIcon"
+                >
+                    <template #actions>
+                        <NavLink :href="route('invoices.create')" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             <AddIcon class="w-5 h-5" />
                             Nueva factura
                         </NavLink>
-                    </div>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mt-10">
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-sky-200">Facturas visibles</p>
-                            <p class="text-3xl font-semibold mt-2">{{ filteredInvoices.length }}</p>
-                            <p class="text-sm text-sky-100 mt-3">{{ invoices.length }} registradas en total</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-sky-200">Clientes facturados</p>
-                            <p class="text-3xl font-semibold mt-2">{{ clients.length }}</p>
-                            <p class="text-sm text-sky-100 mt-3">Con facturas activas</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-sky-200">Pagadas a tiempo</p>
-                            <p class="text-3xl font-semibold mt-2">{{ PrecentPaidInvoices }}%</p>
-                            <p class="text-sm text-sky-100 mt-3">Facturas en estado pagado</p>
-                        </div>
-                        <div class="bg-white/10 backdrop-blur rounded-2xl p-5 text-white shadow-lg">
-                            <p class="text-xs uppercase tracking-widest text-sky-200">Importe filtrado</p>
-                            <p class="text-3xl font-semibold mt-2">{{ formatCurrency(filteredInvoicesTotal) }}</p>
-                            <p class="text-sm text-sky-100 mt-3">Suma de las facturas visibles</p>
-                        </div>
-                    </div>
+                <div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
+                    <CrudStatCard label="Facturas visibles" :value="filteredInvoices.length" :icon="MenuInvoiceIcon" icon-background="bg-sky-500/10 text-sky-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">{{ invoices.length }} registradas en total</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Clientes facturados" :value="clients.length" :icon="InfoIcon" icon-background="bg-indigo-500/10 text-indigo-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Con facturas activas</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Pagadas a tiempo" :value="`${PrecentPaidInvoices}%`" :icon="AddIcon" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Facturas en estado pagado</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Importe filtrado" :value="formatCurrency(filteredInvoicesTotal)" :icon="EditIcon" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Suma de las facturas visibles</p>
+                        </template>
+                    </CrudStatCard>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-10">
-                <div class="bg-white rounded-3xl shadow-xl p-6">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 pb-5">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Filtros avanzados</h2>
-                            <p class="text-sm text-slate-500 mt-1">Encuentra facturas concretas según cliente, estado o periodo de emisión.</p>
-                        </div>
-                        <button @click="clearFilters" class="inline-flex items-center justify-center gap-2 rounded-xl border border-transparent bg-rose-500 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-600 transition">
-                            Limpiar filtros
-                        </button>
-                    </div>
-
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 pt-6">
+                <CrudFilterBar>
+                    <div class="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Cliente</label>
-                            <select v-model="selectedClient" id="clientFilter" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40">
+                            <select v-model="selectedClient" id="clientFilter" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40">
                                 <option value="">Todos</option>
                                 <option v-for="client in clients" :key="client.id" :value="client.id">{{ client.name }}</option>
                             </select>
@@ -98,7 +85,7 @@
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Estado</label>
-                            <select v-model="selectedStatus" id="statusFilter" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40">
+                            <select v-model="selectedStatus" id="statusFilter" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40">
                                 <option value="">Todos</option>
                                 <option value="paid">Pagado</option>
                                 <option value="pending">Pendiente</option>
@@ -108,84 +95,73 @@
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Fecha de inicio</label>
-                            <input type="date" v-model="startDate" id="startDateFilter" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40" />
+                            <input type="date" v-model="startDate" id="startDateFilter" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40" />
                         </div>
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Fecha de fin</label>
-                            <input type="date" v-model="endDate" id="endDateFilter" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40" />
+                            <input type="date" v-model="endDate" id="endDateFilter" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40" />
                         </div>
 
                         <div class="space-y-2">
                             <label class="text-xs font-semibold uppercase tracking-widest text-slate-500">Importe mínimo</label>
-                            <input type="number" min="0" step="0.01" v-model.number="minTotal" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600 focus:border-blue-400 focus:ring focus:ring-blue-200/40" placeholder="0,00 €" />
+                            <input type="number" min="0" step="0.01" v-model.number="minTotal" class="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:ring focus:ring-blue-200/40" placeholder="0,00 €" />
                         </div>
                     </div>
-                </div>
 
-                <div class="bg-white rounded-3xl shadow-xl">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-100 px-6 py-5">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-800">Histórico de facturas</h2>
-                            <p class="text-sm text-slate-500 mt-1">Monitoriza tus cobros y accede a cada documento en cuestión de segundos.</p>
-                        </div>
-                        <NavLink :href="route('invoices.create')" class="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition">
-                            <AddIcon class="w-5 h-5" />
-                            Nueva factura
-                        </NavLink>
-                    </div>
+                    <template #actions>
+                        <button @click="clearFilters" class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50">
+                            Limpiar filtros
+                        </button>
+                    </template>
+                </CrudFilterBar>
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-slate-100 text-left">
-                            <thead>
-                                <tr class="text-xs uppercase tracking-widest text-slate-400">
-                                    <th class="px-6 py-3">Identificador</th>
-                                    <th class="px-6 py-3">Cliente</th>
-                                    <th class="px-6 py-3">Fecha</th>
-                                    <th class="px-6 py-3">Estado</th>
-                                    <th class="px-6 py-3">Total</th>
-                                    <th class="px-6 py-3 text-right">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-slate-100 text-sm text-slate-600">
-                                <tr v-for="invoice in filteredInvoices" :key="invoice.id" class="hover:bg-slate-50/70 transition">
-                                    <td class="px-6 py-4 font-medium text-slate-700">{{ invoice.name }}</td>
-                                    <td class="px-6 py-4">{{ getClientName(invoice.client_id) || '—' }}</td>
-                                    <td class="px-6 py-4">{{ formatDate(invoice.date) }}</td>
-                                    <td class="px-6 py-4">
-                                        <span
-                                            :class="[statusBadgeClasses(invoice.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
-                                            role="button"
-                                            tabindex="0"
-                                            @click="openInvoiceStatusModal(invoice)"
-                                            @keydown.enter.prevent="openInvoiceStatusModal(invoice)"
-                                            @keydown.space.prevent="openInvoiceStatusModal(invoice)"
-                                        >
-                                            {{ statusCopy(invoice.state) }}
-                                        </span>
-                                    </td>
-                                    <td class="px-6 py-4 font-semibold text-slate-700">{{ formatCurrency(invoice.total) }}</td>
-                                    <td class="px-6 py-4">
-                                        <div class="flex items-center justify-end gap-3 text-slate-400">
-                                            <NavLink :href="route('invoices.show', invoice.id)" class="hover:text-blue-500 transition" title="Ver detalles">
-                                                <InfoIcon class="w-5 h-5"/>
-                                            </NavLink>
-                                            <NavLink :href="route('invoices.edit', invoice.id)" class="hover:text-amber-500 transition" title="Editar">
-                                                <EditIcon class="w-5 h-5"/>
-                                            </NavLink>
-                                            <button @click="deleteInvoice(invoice.id)" class="hover:text-rose-500 transition" title="Eliminar">
-                                                <DeleteIcon class="w-5 h-5"/>
-                                            </button>
-                                        </div>
-                                    </td>
-                                </tr>
-                                <tr v-if="filteredInvoices.length === 0">
-                                    <td colspan="6" class="px-6 py-12 text-center text-sm text-slate-400">No hay facturas que coincidan con los filtros seleccionados.</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                <CrudTable>
+                    <template #head>
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Identificador</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Cliente</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Estado</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest text-slate-400">Total</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest text-slate-400">Acciones</th>
+                        </tr>
+                    </template>
+                    <tr v-for="invoice in filteredInvoices" :key="invoice.id" class="hover:bg-slate-50/70 transition">
+                        <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ invoice.name }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-600">{{ getClientName(invoice.client_id) || '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-slate-600">{{ formatDate(invoice.date) }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            <span
+                                :class="[statusBadgeClasses(invoice.state), 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500 transition']"
+                                role="button"
+                                tabindex="0"
+                                @click="openInvoiceStatusModal(invoice)"
+                                @keydown.enter.prevent="openInvoiceStatusModal(invoice)"
+                                @keydown.space.prevent="openInvoiceStatusModal(invoice)"
+                            >
+                                {{ statusCopy(invoice.state) }}
+                            </span>
+                        </td>
+                        <td class="px-6 py-4 text-sm font-semibold text-slate-700">{{ formatCurrency(invoice.total) }}</td>
+                        <td class="px-6 py-4">
+                            <div class="flex items-center justify-end gap-3 text-slate-500">
+                                <NavLink :href="route('invoices.show', invoice.id)" class="hover:text-blue-500 transition" title="Ver detalles">
+                                    <InfoIcon class="w-5 h-5"/>
+                                </NavLink>
+                                <NavLink :href="route('invoices.edit', invoice.id)" class="hover:text-amber-500 transition" title="Editar">
+                                    <EditIcon class="w-5 h-5"/>
+                                </NavLink>
+                                <button @click="deleteInvoice(invoice.id)" class="hover:text-rose-500 transition" title="Eliminar">
+                                    <DeleteIcon class="w-5 h-5"/>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr v-if="filteredInvoices.length === 0">
+                        <td colspan="6" class="px-6 py-12 text-center text-sm text-slate-400">No hay facturas que coincidan con los filtros seleccionados.</td>
+                    </tr>
+                </CrudTable>
             </div>
         </div>
 
@@ -211,11 +187,16 @@
 import { Inertia } from '@inertiajs/inertia';
 import { router, useForm } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import NavLink from "@/Components/NavLink.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";
 import DeleteIcon from "@/Components/Icons/DeleteIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
+import MenuInvoiceIcon from "@/Components/Icons/MenuInvoiceIcon.vue";
 import StatusUpdateModal from '@/Components/StatusUpdateModal.vue';
 import { computed, reactive, ref } from "vue";
 

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -3,6 +3,10 @@ import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import SelectInput from '@/Components/SelectInput.vue';
@@ -12,11 +16,6 @@ import AddProductIcon from '@/Components/Icons/AddProductIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import MenuExpenseIcon from '@/Components/Icons/MenuExpenseIcon.vue';
-import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
-import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
-import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
-import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
-import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     products: {
@@ -77,66 +76,47 @@ const downloadLabel = (labelPath) => {
 const categoryName = (categoryId) =>
     props.categories.find((category) => Number(category.id) === Number(categoryId))?.name ?? '—';
 
-const palette = inventoryPalette;
-const typography = inventoryTypography;
-
-const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_of_stock');
+const stockBadgeClasses = (product) =>
+    Number(product.stock) > 0
+        ? 'inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700'
+        : 'inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600';
 </script>
 
 <template>
     <AppLayout title="Catàleg de productes">
-        <div :class="['min-h-screen pb-16', palette.background]">
-            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
-                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
-                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
-                        <div class="flex items-center gap-4">
-                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
-                                <MenuProductIcon class="h-8 w-8 text-white" />
-                            </div>
-                            <div class="space-y-2">
-                                <p :class="typography.heroKicker">Catàleg de productes</p>
-                                <h1 :class="typography.heroTitle">Control integral del portfoli</h1>
-                                <p :class="typography.heroSubtitle">
-                                    Consulta, filtra i gestiona els productes disponibles per a la venda i el control d'estoc.
-                                </p>
-                            </div>
-                        </div>
-                        <div class="flex justify-end">
-                            <Link
-                                :href="route('products.create')"
-                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
-                            >
-                                <AddProductIcon class="h-5 w-5" />
-                                Nou producte
-                            </Link>
-                        </div>
-                    </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Catàleg de productes"
+                    description="Consulta, filtra i gestiona els productes disponibles per a la venda i el control d'estoc."
+                    :icon="MenuProductIcon"
+                >
+                    <template #actions>
+                        <Link
+                            :href="route('products.create')"
+                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                        >
+                            <AddProductIcon class="h-5 w-5" />
+                            Nou producte
+                        </Link>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid gap-6 md:grid-cols-3">
-                        <InventorySummaryCard label="Total de productes" :value="totalProducts">
-                            <template #icon>
-                                <MenuProductIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="En estoc" :value="inStock">
-                            <template #icon>
-                                <AddProductIcon class="h-6 w-6" />
-                            </template>
-                            <template #description>
-                                Disponibles immediatament
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="Sense estoc" :value="outOfStock" description="Revisa les reposicions pendents">
-                            <template #icon>
-                                <MenuExpenseIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                    </div>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Total de productes" :value="totalProducts" :icon="MenuProductIcon" />
+                    <CrudStatCard label="En estoc" :value="inStock" :icon="AddProductIcon" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Disponibles immediatament</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Sense estoc" :value="outOfStock" :icon="MenuExpenseIcon" icon-background="bg-rose-500/10 text-rose-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Revisa les reposicions pendents</p>
+                        </template>
+                    </CrudStatCard>
                 </div>
-            </div>
 
-            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
-                <InventoryFilterBar>
+                <CrudFilterBar>
                     <div class="flex flex-1 flex-col gap-2">
                         <InputLabel for="search" value="Cerca" />
                         <TextInput
@@ -172,9 +152,9 @@ const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_
                             Netejar filtres
                         </SecondaryButton>
                     </template>
-                </InventoryFilterBar>
+                </CrudFilterBar>
 
-                <InventoryResponsiveTable :is-empty="!filteredProducts.length">
+                <CrudTable>
                     <template #head>
                         <tr>
                             <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
@@ -190,21 +170,21 @@ const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_
                         <td class="px-6 py-4 text-sm text-slate-500">{{ categoryName(product.category_id) }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ Number(product.price).toFixed(2) }}</td>
                         <td class="px-6 py-4 text-sm font-semibold">
-                            <InventoryStatusBadge :status="stockStatus(product)">
+                            <span :class="stockBadgeClasses(product)">
                                 {{ Number(product.stock ?? 0) }}
-                            </InventoryStatusBadge>
+                            </span>
                         </td>
                         <td class="px-6 py-4">
                             <div class="flex items-center justify-end gap-2">
                                 <Link
                                     :href="route('products.edit', product.id)"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-amber-200 text-amber-600 transition hover:bg-amber-50"
                                 >
                                     <EditIcon class="h-5 w-5" />
                                 </Link>
                                 <button
                                     type="button"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/20 text-white transition hover:bg-slate-900/40"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-600 transition hover:bg-slate-100"
                                     @click="downloadLabel(product.label_path)"
                                     :title="product.label_path ? 'Descarregar etiqueta' : 'Sense etiqueta disponible'"
                                 >
@@ -212,7 +192,7 @@ const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_
                                 </button>
                                 <button
                                     type="button"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-rose-200 text-rose-600 transition hover:bg-rose-50"
                                     @click="deleteProduct(product.id)"
                                 >
                                     <DeleteIcon class="h-5 w-5" />
@@ -221,10 +201,12 @@ const stockStatus = (product) => (Number(product.stock) > 0 ? 'in_stock' : 'out_
                         </td>
                     </tr>
 
-                    <template #empty>
-                        Cap resultat coincideix amb els filtres actuals.
-                    </template>
-                </InventoryResponsiveTable>
+                    <tr v-if="!filteredProducts.length">
+                        <td colspan="5" class="px-6 py-10 text-center text-sm text-slate-400">
+                            Cap resultat coincideix amb els filtres actuals.
+                        </td>
+                    </tr>
+                </CrudTable>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/Pages/Suppliers/Index.vue
+++ b/resources/js/Pages/Suppliers/Index.vue
@@ -3,6 +3,10 @@ import { computed, reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
 import { Link } from '@inertiajs/inertia-vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudStatCard from '@/Components/Crud/CrudStatCard.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
 import SelectInput from '@/Components/SelectInput.vue';
@@ -12,11 +16,6 @@ import AddIcon from '@/Components/Icons/AddIcon.vue';
 import EditIcon from '@/Components/Icons/EditIcon.vue';
 import DeleteIcon from '@/Components/Icons/DeleteIcon.vue';
 import InfoIcon from '@/Components/Icons/InfoIcon.vue';
-import InventoryFilterBar from '@/Components/Inventory/InventoryFilterBar.vue';
-import InventoryResponsiveTable from '@/Components/Inventory/InventoryResponsiveTable.vue';
-import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
-import InventorySummaryCard from '@/Components/Inventory/InventorySummaryCard.vue';
-import { inventoryPalette, inventoryTypography } from '@/Components/Inventory/inventoryTheme';
 
 const props = defineProps({
     suppliers: {
@@ -63,61 +62,47 @@ const deleteSupplier = (supplierId) => {
     }
 };
 
-const palette = inventoryPalette;
-const typography = inventoryTypography;
+const contactStatusBadge = (supplier) =>
+    supplier.email
+        ? 'inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700'
+        : 'inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500';
 </script>
 
 <template>
     <AppLayout title="Proveïdors">
-        <div :class="['min-h-screen pb-16', palette.background]">
-            <div :class="['bg-gradient-to-r', palette.gradient, 'pb-24']">
-                <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6 pt-10">
-                    <div class="flex flex-col gap-6 text-white md:flex-row md:items-center md:justify-between">
-                        <div class="flex items-center gap-4">
-                            <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-white/10">
-                                <MenuBillingIcon class="h-8 w-8 text-white" />
-                            </div>
-                            <div class="space-y-2">
-                                <p :class="typography.heroKicker">Xarxa de proveïdors</p>
-                                <h1 :class="typography.heroTitle">Sincronitza relacions clau</h1>
-                                <p :class="typography.heroSubtitle">
-                                    Mantén la relació comercial alineada amb la resta de departaments i detecta ràpidament punts de millora.
-                                </p>
-                            </div>
-                        </div>
-                        <div class="flex justify-end">
-                            <Link
-                                :href="route('suppliers.create')"
-                                class="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-amber-900/10 transition hover:bg-white/20"
-                            >
-                                <AddIcon class="h-5 w-5" />
-                                Nou proveïdor
-                            </Link>
-                        </div>
-                    </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Xarxa de proveïdors"
+                    description="Mantén la relació comercial alineada amb la resta de departaments i detecta ràpidament punts de millora."
+                    :icon="MenuBillingIcon"
+                >
+                    <template #actions>
+                        <Link
+                            :href="route('suppliers.create')"
+                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+                        >
+                            <AddIcon class="h-5 w-5" />
+                            Nou proveïdor
+                        </Link>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid gap-6 md:grid-cols-3">
-                        <InventorySummaryCard label="Total proveïdors" :value="totalSuppliers">
-                            <template #icon>
-                                <MenuBillingIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="Amb correu" :value="suppliersWithEmail" description="Contacte immediat">
-                            <template #icon>
-                                <AddIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                        <InventorySummaryCard label="Sense telèfon" :value="suppliersWithoutPhone" description="Requereix seguiment">
-                            <template #icon>
-                                <InfoIcon class="h-6 w-6" />
-                            </template>
-                        </InventorySummaryCard>
-                    </div>
+                <div class="grid gap-6 md:grid-cols-3">
+                    <CrudStatCard label="Total proveïdors" :value="totalSuppliers" :icon="MenuBillingIcon" />
+                    <CrudStatCard label="Amb correu" :value="suppliersWithEmail" :icon="AddIcon" icon-background="bg-emerald-500/10 text-emerald-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Contacte immediat</p>
+                        </template>
+                    </CrudStatCard>
+                    <CrudStatCard label="Sense telèfon" :value="suppliersWithoutPhone" :icon="InfoIcon" icon-background="bg-amber-500/10 text-amber-600">
+                        <template #description>
+                            <p class="text-xs text-slate-500">Requereix seguiment</p>
+                        </template>
+                    </CrudStatCard>
                 </div>
-            </div>
 
-            <div class="mx-auto flex max-w-7xl flex-col gap-8 px-6 -mt-16">
-                <InventoryFilterBar :columns="2">
+                <CrudFilterBar>
                     <div class="flex flex-1 flex-col gap-2">
                         <InputLabel for="supplier-search" value="Cerca" />
                         <TextInput
@@ -143,9 +128,9 @@ const typography = inventoryTypography;
                             Netejar filtres
                         </SecondaryButton>
                     </template>
-                </InventoryFilterBar>
+                </CrudFilterBar>
 
-                <InventoryResponsiveTable :is-empty="!filteredSuppliers.length">
+                <CrudTable>
                     <template #head>
                         <tr>
                             <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Nom</th>
@@ -161,27 +146,27 @@ const typography = inventoryTypography;
                         <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.email || '—' }}</td>
                         <td class="px-6 py-4 text-sm text-slate-500">{{ supplier.phone || '—' }}</td>
                         <td class="px-6 py-4 text-sm">
-                            <InventoryStatusBadge :status="supplier.email ? 'active' : 'inactive'">
+                            <span :class="contactStatusBadge(supplier)">
                                 {{ supplier.email ? 'Contacte directe' : 'Sense correu' }}
-                            </InventoryStatusBadge>
+                            </span>
                         </td>
                         <td class="px-6 py-4">
                             <div class="flex items-center justify-end gap-2">
                                 <Link
                                     :href="route('suppliers.show', supplier.id)"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/20 text-white transition hover:bg-slate-900/40"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-600 transition hover:bg-slate-100"
                                 >
                                     <InfoIcon class="h-5 w-5" />
                                 </Link>
                                 <Link
                                     :href="route('suppliers.edit', supplier.id)"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 transition hover:bg-amber-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-amber-200 text-amber-600 transition hover:bg-amber-50"
                                 >
                                     <EditIcon class="h-5 w-5" />
                                 </Link>
                                 <button
                                     type="button"
-                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20"
+                                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-rose-200 text-rose-600 transition hover:bg-rose-50"
                                     @click="deleteSupplier(supplier.id)"
                                 >
                                     <DeleteIcon class="h-5 w-5" />
@@ -190,10 +175,12 @@ const typography = inventoryTypography;
                         </td>
                     </tr>
 
-                    <template #empty>
-                        Cap proveïdor compleix els filtres actuals.
-                    </template>
-                </InventoryResponsiveTable>
+                    <tr v-if="!filteredSuppliers.length">
+                        <td colspan="5" class="px-6 py-10 text-center text-sm text-slate-400">
+                            Cap proveïdor compleix els filtres actuals.
+                        </td>
+                    </tr>
+                </CrudTable>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/Pages/Suppliers/Show.vue
+++ b/resources/js/Pages/Suppliers/Show.vue
@@ -1,73 +1,87 @@
 <template>
     <AppLayout>
-        <div class="w-full min-h-screen bg-gray-100 p-6">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="supplier.name"
+                    description="Consulta la información principal del proveedor y las entradas de stock asociadas."
+                >
+                    <template #actions>
+                        <NavLink :href="route('stockEntries.create', supplier.id)" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
+                            <AddIcon class="w-5 h-5"/>
+                            Nueva entrada de stock
+                        </NavLink>
+                    </template>
+                </CrudPageHeader>
 
-            <!-- Información del proveedor -->
-            <div class="bg-white p-6 rounded-lg shadow-md mb-6">
-                <h2 class="text-2xl text-blue-500 font-bold">Detalles del Proveedor</h2>
-                <div class="grid grid-cols-2 gap-4 mt-4">
-                    <p><strong>Nombre:</strong> {{ supplier.name }}</p>
-                    <p><strong>Email:</strong> {{ supplier.email || 'N/A' }}</p>
-                    <p><strong>Teléfono:</strong> {{ supplier.phone || 'N/A' }}</p>
-                    <p><strong>Dirección:</strong> {{ supplier.address || 'N/A' }}</p>
-                </div>
-                <div class="mt-6">
-                    <NavLink :href="route('stockEntries.create',supplier.id)" class="bg-blue-500 items-center justify-center pt-2 flex space-x-5 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-600">
-                        <AddIcon class="w-5 "/>
-                        <p>Nueva Entrada de Stock</p>
-                    </NavLink>
-                </div>
-            </div>
+                <Panel title="Detalles del proveedor" description="Información de contacto y datos administrativos del proveedor.">
+                    <dl class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                            <dt class="text-xs uppercase tracking-widest text-slate-400">Nombre</dt>
+                            <dd class="mt-2 text-sm font-semibold text-slate-700">{{ supplier.name }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                            <dt class="text-xs uppercase tracking-widest text-slate-400">Email</dt>
+                            <dd class="mt-2 text-sm font-semibold text-slate-700">{{ supplier.email || 'N/A' }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                            <dt class="text-xs uppercase tracking-widest text-slate-400">Teléfono</dt>
+                            <dd class="mt-2 text-sm font-semibold text-slate-700">{{ supplier.phone || 'N/A' }}</dd>
+                        </div>
+                        <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                            <dt class="text-xs uppercase tracking-widest text-slate-400">Dirección</dt>
+                            <dd class="mt-2 text-sm font-semibold text-slate-700">{{ supplier.address || 'N/A' }}</dd>
+                        </div>
+                    </dl>
+                </Panel>
 
-            <!-- Sección de entradas de stock -->
-            <div class="">
-                <!-- Sección de entradas de stock -->
-                <div>
-                    <h3 class="text-xl font-semibold mb-4">Entradas de Stock</h3>
-                    <div class="bg-white p-4 rounded-lg shadow-md mb-6">
-                        <!-- Filtro de entradas -->
-                        <div class="flex flex-wrap gap-4 mb-4">
+                <div class="space-y-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-slate-800">Entradas de stock</h2>
+                        <p class="text-sm text-slate-500">Filtra y consulta las entradas registradas para este proveedor.</p>
+                    </div>
+                    <CrudFilterBar>
+                        <div class="flex flex-wrap gap-4">
                             <div>
-                                <label for="entryStartDate" class="block text-sm text-blue-500 font-semibold">Fecha de Inicio</label>
-                                <input type="date" v-model="entryStartDate" id="entryStartDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
+                                <label for="entryStartDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha de inicio</label>
+                                <input type="date" v-model="entryStartDate" id="entryStartDate" class="mt-2 block w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-500 focus:ring focus:ring-slate-200/60" />
                             </div>
 
                             <div>
-                                <label for="entryEndDate" class="block text-sm text-blue-500 font-semibold">Fecha de Finalización</label>
-                                <input type="date" v-model="entryEndDate" id="entryEndDate" class="mt-1 block w-full bg-gray-50 text-gray-500 border-gray-300 rounded-md shadow-sm" />
-                            </div>
-                            <div>
-                                <button class="bg-red-500 p-2 rounded-md block text-gray-50 font-bold mt-6" @click="deleteFilters()">
-                                    Limpiar Filtros
-                                </button>
+                                <label for="entryEndDate" class="block text-xs font-semibold uppercase tracking-widest text-slate-400">Fecha de finalización</label>
+                                <input type="date" v-model="entryEndDate" id="entryEndDate" class="mt-2 block w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-500 focus:ring focus:ring-slate-200/60" />
                             </div>
                         </div>
+                        <template #actions>
+                            <button class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50" @click="deleteFilters()">
+                                Limpiar filtros
+                            </button>
+                        </template>
+                    </CrudFilterBar>
 
-                        <!-- Tabla de entradas de stock -->
-                        <table class="w-full table-auto">
-                            <thead class="bg-gray-100">
+                    <CrudTable>
+                        <template #head>
                             <tr>
-                                <th class="px-4 py-2 text-left">Referencia</th>
-                                <th class="px-4 py-2 text-left">Fecha de Entrada</th>
-                                <th class="px-4 py-2 text-left">Acciones</th>
+                                <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Referencia</th>
+                                <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Fecha de entrada</th>
+                                <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Acciones</th>
                             </tr>
-                            </thead>
-                            <tbody>
-                            <tr v-for="entry in filteredStockEntries" :key="entry.id" class="border-t">
-                                <td class="px-4 py-2">{{ entry.reference }}</td>
-                                <td class="px-4 py-2">{{ entry.entry_date }}</td>
-                                <td class="px-4 py-2">
-                                    <NavLink :href="route('stockEntries.show', entry.id)" class="text-blue-500">
-                                        <InfoIcon class="w-5 h-5" />
-                                    </NavLink>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-
-
-
-                    </div>
+                        </template>
+                        <tr v-for="entry in filteredStockEntries" :key="entry.id" class="hover:bg-slate-50/60">
+                            <td class="px-6 py-4 text-sm font-medium text-slate-700">{{ entry.reference }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-500">{{ entry.entry_date }}</td>
+                            <td class="px-6 py-4 text-sm">
+                                <NavLink :href="route('stockEntries.show', entry.id)" class="text-slate-500 hover:text-slate-700">
+                                    <InfoIcon class="w-5 h-5" />
+                                </NavLink>
+                            </td>
+                        </tr>
+                        <tr v-if="!filteredStockEntries.length">
+                            <td colspan="3" class="px-6 py-10 text-center text-sm text-slate-400">
+                                No hay entradas de stock para los filtros seleccionados.
+                            </td>
+                        </tr>
+                    </CrudTable>
                 </div>
             </div>
         </div>
@@ -77,6 +91,10 @@
 <script setup>
 import { ref, computed } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import CrudFilterBar from '@/Components/Crud/CrudFilterBar.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
+import CrudTable from '@/Components/Crud/CrudTable.vue';
+import Panel from '@/Components/UI/Panel.vue';
 import NavLink from "@/Components/NavLink.vue";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
@@ -98,9 +116,8 @@ const filteredStockEntries = computed(() => {
     });
 });
 
-const deleteFilters = () =>{
-    entryEndDate.value='';
-    entryStartDate.value='';
-
-}
+const deleteFilters = () => {
+    entryEndDate.value = '';
+    entryStartDate.value = '';
+};
 </script>


### PR DESCRIPTION
### Motivation
- Unificar l'estètica CRUD amb la nova paleta i components minimalistes per millorar coherència i mantenibilitat. 
- Substituir capçaleres, barres de filtre i taules específiques per components reutilitzables per reduir duplicació de classes i variants visuals. 
- Millorar l'accessibilitat i la consistència d'accions (botons, badges, estats) en llistats i formularis.

### Description
- S'han substituït les capçaleres i controls principals per `CrudPageHeader`, `CrudFilterBar`, `CrudStatCard` i `CrudTable` a les vistes d'índex de `Clients`, `Products`, `Suppliers`, `Categories`, `Invoices`, `Budgets` i `Expenses`. 
- Les vistes `Create`, `Edit` i `Show` de `Clients`, `Categories`, `Suppliers` i `Expenses` s'han refet per utilitzar `CrudPageHeader`, `CrudStatCard` i `Panel` i per portar formularis i targetes a la nova estètica. 
- S'han eliminat imports/úss d'antics components específics (`Inventory*`, `FinancePageHeader`, `FinanceSummaryCard`, etc.) i s'han reconfigurat botons/accions per usar classes i utilitats minimalistes (ex.: `rounded-2xl`, `border`, `shadow-sm`). 
- Afegits petits helpers visuals i classes reutilitzables com `stockBadgeClasses`, `contactStatusBadge` i `descriptionBadgeClass` per renderitzar badges d'estat coherents a les files.

### Testing
- No s'han executat proves automatitzades sobre aquest canvi (`npm`/`phpunit` no s'han llançat en aquest rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972063307888323a99cd320879c54e2)