### PR TITLE
Restyle dashboard pages to light create-view layout

### DIFF
--- a/resources/js/Components/Inventory/InventoryKpiCard.vue
+++ b/resources/js/Components/Inventory/InventoryKpiCard.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="rounded-2xl border border-amber-200/30 bg-white/5 p-5 text-white shadow-sm">
-        <p class="text-xs uppercase tracking-[0.3em] text-amber-100/80">{{ label }}</p>
-        <p class="mt-2 text-3xl font-semibold text-white">{{ value }}</p>
-        <p v-if="subtitle || hasSubtitleSlot" class="mt-3 text-sm text-amber-100/70">
+    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">{{ label }}</p>
+        <p class="mt-2 text-3xl font-semibold text-slate-900">{{ value }}</p>
+        <p v-if="subtitle || hasSubtitleSlot" class="mt-3 text-sm text-slate-500">
             <slot name="subtitle">{{ subtitle }}</slot>
         </p>
         <slot />

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,43 +1,41 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-100 text-sm uppercase tracking-widest">Panel personal Jesty</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white mt-2">Hola {{ user.name }}, tu día en Jesty está listo</h1>
-                        </div>
-                        <NavLink :href="route('user_tasks.create')" class="inline-flex items-center justify-center rounded-xl border border-white/20 bg-emerald-500/20 px-5 py-3 text-sm font-semibold text-white hover:bg-emerald-500/30 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="`Hola ${user.name}, tu día en Jesty está listo`"
+                    description="Panel personal Jesty con todas las prioridades y métricas clave al instante."
+                >
+                    <template #actions>
+                        <NavLink :href="route('user_tasks.create')" class="inline-flex items-center justify-center rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             Crear tarea Jesty
                         </NavLink>
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-emerald-500">Tareas abiertas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ openTasks }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ inProgressTasks }} en progreso • {{ pendingTasks }} pendientes</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-widest text-emerald-100">Tareas abiertas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ openTasks }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ inProgressTasks }} en progreso • {{ pendingTasks }} pendientes</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-widest text-emerald-100">Entregas de hoy</p>
-                            <p class="text-3xl font-semibold mt-2">{{ tasksDueToday }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ overdueTasks }} atrasadas sin finalizar</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-widest text-emerald-100">Tareas finalizadas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ completedTasks }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ completionRate }}% de avance</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-widest text-emerald-100">Alertas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ unreadNotifications }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Notificaciones pendientes por revisar</p>
-                        </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-emerald-500">Entregas de hoy</p>
+                        <p class="text-3xl font-semibold mt-2">{{ tasksDueToday }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ overdueTasks }} atrasadas sin finalizar</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-emerald-500">Tareas finalizadas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ completedTasks }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ completionRate }}% de avance</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-emerald-500">Alertas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ unreadNotifications }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Notificaciones pendientes por revisar</p>
                     </div>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <div class="xl:col-span-2 space-y-6">
                         <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
@@ -168,6 +166,7 @@ import { computed } from 'vue';
 import Calendar from '@/Components/Calendar.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import NavLink from "../Components/NavLink.vue";
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 import { Inertia } from "@inertiajs/inertia";
 import InfoIcon from "@/Components/Icons/InfoIcon.vue";
 import EditIcon from "@/Components/Icons/EditIcon.vue";

--- a/resources/js/Pages/DashboardAdmin.vue
+++ b/resources/js/Pages/DashboardAdmin.vue
@@ -1,52 +1,48 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div class="space-y-2">
-                            <p class="text-emerald-100 text-sm uppercase tracking-widest">Panel administrador Jesty</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">{{ company.name }}</h1>
-                            <p class="text-sm text-emerald-100">Gestiona cuenta, equipo y configuración corporativa con el estilo Jesty.</p>
-                        </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    :title="company.name"
+                    description="Gestiona cuenta, equipo y configuración corporativa con el estilo Jesty."
+                >
+                    <template #actions>
                         <div class="flex flex-wrap gap-4">
-                            <NavLink :href="route('companies.edit', company.id)" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500/30 transition">
+                            <NavLink :href="route('companies.edit', company.id)" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                                 <EditIcon class="w-4 h-4" /> Editar compañía
                             </NavLink>
-                            <NavLink :href="route('email-configurations.edit', emailConfig.id)" v-if="emailConfig" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500/30 transition">
+                            <NavLink :href="route('email-configurations.edit', emailConfig.id)" v-if="emailConfig" class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50">
                                 <EditIcon class="w-4 h-4" /> Editar correo
                             </NavLink>
                         </div>
+                    </template>
+                </CrudPageHeader>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Usuarios</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalUsers }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ activeRoles }} roles disponibles</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Plan actual</p>
+                        <p class="text-3xl font-semibold mt-2">{{ plan.name }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ plan.description }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Características activas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ features.length }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ highlightedFeature }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Estado de correo</p>
+                        <p class="text-3xl font-semibold mt-2">{{ emailConfig ? 'Configurado' : 'Pendiente' }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ emailConfig ? emailConfig.from_email : 'Sin configuración SMTP' }}</p>
                     </div>
 
-
-                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Usuarios</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalUsers }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ activeRoles }} roles disponibles</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Plan actual</p>
-                            <p class="text-3xl font-semibold mt-2">{{ plan.name }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ plan.description }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Características activas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ features.length }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ highlightedFeature }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Estado de correo</p>
-                            <p class="text-3xl font-semibold mt-2">{{ emailConfig ? 'Configurado' : 'Pendiente' }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ emailConfig ? emailConfig.from_email : 'Sin configuración SMTP' }}</p>
-                        </div>
-
-                    </div>
                 </div>
-            </div>
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
-                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                <div class="space-y-8">
+                    <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <div class="space-y-6 xl:col-span-2">
                         <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                             <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
@@ -160,6 +156,7 @@
                             <button @click="deleteCompany" class="w-full rounded-2xl bg-rose-600 px-4 py-3 text-sm font-semibold text-white shadow hover:bg-rose-700 transition">Eliminar empresa</button>
                         </div>
                     </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -175,6 +172,7 @@ import EditIcon from "@/Components/Icons/EditIcon.vue";
 import AddIcon from "@/Components/Icons/AddIcon.vue";
 import PieChart from '@/Components/PieChart.vue';
 import BarChart from '@/Components/BarChart.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     company: Object,

--- a/resources/js/Pages/DashboardClientes.vue
+++ b/resources/js/Pages/DashboardClientes.vue
@@ -1,32 +1,29 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
-                        <div>
-                            <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · Clientes</p>
-                            <h1 class="text-3xl sm:text-4xl font-semibold text-white">Visión 360º de tu cartera</h1>
-                            <p class="text-sm text-emerald-100 mt-2">Segmenta, analiza y decide con una vista clara de tus relaciones comerciales.</p>
-                        </div>
-                        <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500/30 transition">
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Visión 360º de tu cartera"
+                    description="Segmenta, analiza y decide con una vista clara de tus relaciones comerciales."
+                >
+                    <template #actions>
+                        <NavLink :href="route('clients.create')" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">
                             <AddIcon class="w-4 h-4" /> Nuevo cliente
                         </NavLink>
-                    </div>
+                    </template>
+                </CrudPageHeader>
 
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <SummaryCard
-                            v-for="card in summaryCards"
-                            :key="card.eyebrow"
-                            :eyebrow="card.eyebrow"
-                            :value="card.value"
-                            :description="card.description"
-                        />
-                    </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <SummaryCard
+                        v-for="card in summaryCards"
+                        :key="card.eyebrow"
+                        :eyebrow="card.eyebrow"
+                        :value="card.value"
+                        :description="card.description"
+                        variant="light"
+                    />
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <Panel title="Filtrado inteligente" description="Encuentra el cliente ideal combinando filtros avanzados.">
                     <template #actions>
                         <button @click="clearFilters" class="inline-flex items-center gap-2 rounded-lg border border-emerald-200 px-4 py-2 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 transition">
@@ -130,6 +127,7 @@ import BarChart from '@/Components/BarChart.vue';
 import SummaryCard from '@/Components/UI/SummaryCard.vue';
 import Panel from '@/Components/UI/Panel.vue';
 import DataTable from '@/Components/UI/DataTable.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     clients: {

--- a/resources/js/Pages/DashboardContabilidad.vue
+++ b/resources/js/Pages/DashboardContabilidad.vue
@@ -1,39 +1,35 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · Contabilidad</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Resumen contable integral</h1>
-                        <p class="text-sm text-emerald-100">Comprende la evolución de ingresos, gastos y rentabilidad en un vistazo.</p>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Resumen contable integral"
+                    description="Comprende la evolución de ingresos, gastos y rentabilidad en un vistazo."
+                />
+
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Ingresos</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ totalIncomes }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Promedio mensual €{{ averageIncome }}</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Ingresos</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ totalIncomes }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Promedio mensual €{{ averageIncome }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Gastos</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ totalExpenses }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Coste medio €{{ averageExpense }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Beneficio neto</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ profit }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Margen {{ profitMargin }}%</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Transacciones</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalTransactions }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ incomes.length }} ingresos • {{ expenses.length }} gastos</p>
-                        </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Gastos</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ totalExpenses }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Coste medio €{{ averageExpense }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Beneficio neto</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ profit }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Margen {{ profitMargin }}%</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Transacciones</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalTransactions }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ incomes.length }} ingresos • {{ expenses.length }} gastos</p>
                     </div>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
                         <div>
@@ -87,6 +83,7 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import BarChart from '@/Components/BarChart.vue';
 import LineChart from '@/Components/LineChart.vue';
 import AreaChart from '@/Components/AreaChart.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     incomes: Array,

--- a/resources/js/Pages/DashboardCrm.vue
+++ b/resources/js/Pages/DashboardCrm.vue
@@ -1,39 +1,35 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · CRM</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Rendimiento comercial en tiempo real</h1>
-                        <p class="text-sm text-emerald-100">Mide el pulso de leads, oportunidades y actividades clave para acelerar ventas.</p>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Rendimiento comercial en tiempo real"
+                    description="Mide el pulso de leads, oportunidades y actividades clave para acelerar ventas."
+                />
+
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Leads</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalLeads }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Tasa de conversión {{ conversionRate }}%</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Leads</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalLeads }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Tasa de conversión {{ conversionRate }}%</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Oportunidades</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalOpportunities }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ wonOpportunities }} ganadas</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Notas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalNotes }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Última nota {{ latestNoteDate }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Actividades</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalActivities }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ upcomingActivities.length }} próximas</p>
-                        </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Oportunidades</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalOpportunities }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ wonOpportunities }} ganadas</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Notas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalNotes }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Última nota {{ latestNoteDate }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Actividades</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalActivities }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ upcomingActivities.length }} próximas</p>
                     </div>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <div class="xl:col-span-2 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 border-b border-slate-200/70 pb-5">
@@ -98,6 +94,7 @@ import LineChart from '@/Components/LineChart.vue';
 import PieChart from '@/Components/PieChart.vue';
 import BarChart from '@/Components/BarChart.vue';
 import PolarChart from '@/Components/PolarChart.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     leads: Array,

--- a/resources/js/Pages/DashboardFacturacion.vue
+++ b/resources/js/Pages/DashboardFacturacion.vue
@@ -1,44 +1,40 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · Facturación</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Control total de presupuestos e ingresos</h1>
-                        <p class="text-sm text-emerald-100">Detecta tendencias, clientes clave y oportunidades para acelerar los cobros.</p>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Control total de presupuestos e ingresos"
+                    description="Detecta tendencias, clientes clave y oportunidades para acelerar los cobros."
+                />
+
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm xl:col-span-1">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Presupuestos</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalBudgets }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Importe medio €{{ averageBudget }}</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Presupuestos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalBudgets }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Importe medio €{{ averageBudget }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Facturas</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalInvoices }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Ticket medio €{{ averageInvoice }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Clientes</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalClients }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Top cliente {{ topClientName }}</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Cobros pendientes</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ outstandingAmount }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ outstandingInvoices }} facturas en trámite</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm xl:col-span-1">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Cobrado</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ totalIncome }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ paidPercentage }}% facturas cobradas</p>
-                        </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm xl:col-span-1">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Facturas</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalInvoices }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Ticket medio €{{ averageInvoice }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm xl:col-span-1">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Clientes</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalClients }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Top cliente {{ topClientName }}</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm xl:col-span-1">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Cobros pendientes</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ outstandingAmount }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ outstandingInvoices }} facturas en trámite</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm xl:col-span-1">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Cobrado</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ totalIncome }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ paidPercentage }}% facturas cobradas</p>
                     </div>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
                     <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Distribución de presupuestos</h2>
@@ -129,6 +125,7 @@ import PieChart from '@/Components/PieChart.vue';
 import LineChart from '@/Components/LineChart.vue';
 import DoughnutChart from '@/Components/DoughnutChart.vue';
 import NavLink from "@/Components/NavLink.vue";
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     budgets: Array,

--- a/resources/js/Pages/DashboardProductos.vue
+++ b/resources/js/Pages/DashboardProductos.vue
@@ -1,40 +1,36 @@
 <template>
     <AppLayout>
-        <div :class="['min-h-screen', palette.background]">
-            <div :class="['bg-gradient-to-r', palette.gradient, layout.heroWrapper]">
-                <div :class="layout.heroContainer">
-                    <div class="space-y-2 text-white">
-                        <p :class="typography.heroKicker">Jesty · Inventari</p>
-                        <h1 :class="typography.heroTitle">Visió global del catàleg de productes</h1>
-                        <p :class="typography.heroSubtitle">Controla categories, estoc i rendiment amb la nova experiència Jesty.</p>
-                    </div>
-                    <div :class="layout.kpiGrid">
-                        <InventoryKpiCard label="Categories" :value="totalCategories">
-                            <template #subtitle>
-                                {{ averageProductsPerCategory }} productes per categoria
-                            </template>
-                        </InventoryKpiCard>
-                        <InventoryKpiCard label="Productes" :value="totalProducts">
-                            <template #subtitle>
-                                {{ activeProducts }} actius
-                            </template>
-                        </InventoryKpiCard>
-                        <InventoryKpiCard label="Estoc disponible" :value="totalStock">
-                            <template #subtitle>
-                                {{ lowStockProducts.length }} productes en alerta
-                            </template>
-                        </InventoryKpiCard>
-                        <InventoryKpiCard label="Preu mitjà" :value="`€${averagePrice}`">
-                            <template #subtitle>
-                                Top vendes {{ topSellingProduct }}
-                            </template>
-                        </InventoryKpiCard>
-                    </div>
-                </div>
-            </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Visió global del catàleg de productes"
+                    description="Controla categories, estoc i rendiment amb la nova experiència Jesty."
+                />
 
-            <div :class="layout.bodyWrapper">
-                <div :class="layout.sectionGrid">
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <InventoryKpiCard label="Categories" :value="totalCategories">
+                        <template #subtitle>
+                            {{ averageProductsPerCategory }} productes per categoria
+                        </template>
+                    </InventoryKpiCard>
+                    <InventoryKpiCard label="Productes" :value="totalProducts">
+                        <template #subtitle>
+                            {{ activeProducts }} actius
+                        </template>
+                    </InventoryKpiCard>
+                    <InventoryKpiCard label="Estoc disponible" :value="totalStock">
+                        <template #subtitle>
+                            {{ lowStockProducts.length }} productes en alerta
+                        </template>
+                    </InventoryKpiCard>
+                    <InventoryKpiCard label="Preu mitjà" :value="`€${averagePrice}`">
+                        <template #subtitle>
+                            Top vendes {{ topSellingProduct }}
+                        </template>
+                    </InventoryKpiCard>
+                </div>
+
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <InventoryChartCard title="Quantitat per categoria" subtitle="Visualitza com es distribueix el catàleg.">
                         <BarChart :data="productsByCategoryData" />
                     </InventoryChartCard>
@@ -43,7 +39,7 @@
                     </InventoryChartCard>
                 </div>
 
-                <div :class="layout.sectionGrid">
+                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <InventoryChartCard title="Rendiment per categoria" subtitle="Vendes estimades segons la demanda registrada.">
                         <RadarChart :data="categorySalesRadar" />
                     </InventoryChartCard>
@@ -78,16 +74,12 @@ import RadarChart from '@/Components/RadarChart.vue';
 import InventoryKpiCard from '@/Components/Inventory/InventoryKpiCard.vue';
 import InventoryChartCard from '@/Components/Inventory/InventoryChartCard.vue';
 import InventoryStatusBadge from '@/Components/Inventory/InventoryStatusBadge.vue';
-import { inventoryLayout, inventoryTypography, inventoryPalette } from '@/Components/Inventory/inventoryTheme';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     categories: Array,
     products: Array,
 });
-
-const layout = inventoryLayout;
-const typography = inventoryTypography;
-const palette = inventoryPalette;
 
 const totalCategories = computed(() => props.categories.length);
 const totalProducts = computed(() => props.products.length);

--- a/resources/js/Pages/DashboardRRHH.vue
+++ b/resources/js/Pages/DashboardRRHH.vue
@@ -1,39 +1,35 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · RRHH</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Radiografía del equipo humano</h1>
-                        <p class="text-sm text-emerald-100">Analiza la composición, crecimiento y distribución de tu organización.</p>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Radiografía del equipo humano"
+                    description="Analiza la composición, crecimiento y distribución de tu organización."
+                />
+
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Empleados</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalEmployees }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ headcountGrowth }}% crecimiento anual</p>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mt-10">
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Empleados</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalEmployees }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ headcountGrowth }}% crecimiento anual</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Departamentos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalDepartments }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ averageTeamSize }} personas promedio</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Salario medio</p>
-                            <p class="text-3xl font-semibold mt-2">€{{ averageSalary.toFixed(2) }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">Brecha interdepartamental {{ salaryVariance }}%</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/15 bg-white/5 p-5 text-white shadow-sm">
-                            <p class="text-xs uppercase tracking-[0.3em] text-emerald-100">Activos</p>
-                            <p class="text-3xl font-semibold mt-2">{{ totalEmployeesActive }}</p>
-                            <p class="text-sm text-emerald-100 mt-3">{{ inactiveEmployees }} en pausa</p>
-                        </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Departamentos</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalDepartments }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ averageTeamSize }} personas promedio</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Salario medio</p>
+                        <p class="text-3xl font-semibold mt-2">€{{ averageSalary.toFixed(2) }}</p>
+                        <p class="text-sm text-slate-500 mt-3">Brecha interdepartamental {{ salaryVariance }}%</p>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-slate-800 shadow-sm">
+                        <p class="text-xs uppercase tracking-[0.3em] text-emerald-500">Activos</p>
+                        <p class="text-3xl font-semibold mt-2">{{ totalEmployeesActive }}</p>
+                        <p class="text-sm text-slate-500 mt-3">{{ inactiveEmployees }} en pausa</p>
                     </div>
                 </div>
-            </div>
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm">
                         <h2 class="text-xl font-semibold text-slate-800">Empleados por departamento</h2>
@@ -91,6 +87,7 @@ import { computed } from 'vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import BarChart from '@/Components/BarChart.vue';
 import PieChart from '@/Components/PieChart.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     employees: Array,

--- a/resources/js/Pages/DashboardTPV.vue
+++ b/resources/js/Pages/DashboardTPV.vue
@@ -1,28 +1,23 @@
 <template>
     <AppLayout>
-        <div class="min-h-screen bg-slate-950">
-            <div class="bg-gradient-to-r from-emerald-600 via-sky-600 to-indigo-700 pb-24">
-                <div class="max-w-7xl mx-auto px-6 pt-10">
-                    <div class="space-y-2">
-                        <p class="text-emerald-100 text-sm uppercase tracking-widest">Jesty · TPV</p>
-                        <h1 class="text-3xl sm:text-4xl font-semibold text-white">Actividad en punto de venta</h1>
-                        <p class="text-sm text-emerald-100">Monitoriza ventas, tickets y categorías para optimizar tu estrategia comercial.</p>
-                    </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6 mt-10">
-                        <KpiCard
-                            v-for="card in kpiCards"
-                            :key="card.key"
-                            gradient
-                            bordered
-                            :subtitle="card.subtitle"
-                            :value="card.value"
-                            :description="card.description"
-                        />
-                    </div>
-                </div>
-            </div>
+        <div class="min-h-screen bg-slate-100/80 py-12">
+            <div class="mx-auto flex max-w-7xl flex-col gap-10 px-6">
+                <CrudPageHeader
+                    title="Actividad en punto de venta"
+                    description="Monitoriza ventas, tickets y categorías para optimizar tu estrategia comercial."
+                />
 
-            <div class="max-w-7xl mx-auto px-6 -mt-16 pb-16 space-y-8">
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6">
+                    <KpiCard
+                        v-for="card in kpiCards"
+                        :key="card.key"
+                        :bordered="false"
+                        :subtitle="card.subtitle"
+                        :value="card.value"
+                        :description="card.description"
+                    />
+                </div>
+
                 <section class="sr-only" aria-label="Documentación visual del panel TPV">
                     <h2 class="text-base font-semibold">Resumen de elementos visuales</h2>
                     <p>{{ visualDocumentation.summary }}</p>
@@ -98,6 +93,7 @@ import PieChart from '@/Components/PieChart.vue';
 import LineChart from '@/Components/LineChart.vue';
 import AreaChart from '@/Components/AreaChart.vue';
 import KpiCard from '@/Components/KpiCard.vue';
+import CrudPageHeader from '@/Components/Crud/CrudPageHeader.vue';
 
 const props = defineProps({
     tickets: Array,


### PR DESCRIPTION
### Motivation
- Unify the visual language of all dashboard pages so they match the aesthetic and layout used in the `create` views (light cards, consistent header and actions). 
- Provide a coherent UI across modules (main, admin, billing, products, CRM, accounting, HR, TPV, clients) for a predictable user experience.

### Description
- Replaced the dark gradient hero sections with the reusable `CrudPageHeader` and a light page wrapper (`bg-slate-100/80 py-12`) across dashboard pages: `Dashboard.vue`, `DashboardAdmin.vue`, `DashboardFacturacion.vue`, `DashboardClientes.vue`, `DashboardContabilidad.vue`, `DashboardCrm.vue`, `DashboardProductos.vue`, `DashboardRRHH.vue`, `DashboardTPV.vue`.
- Converted KPI/summary cards to a lighter surface style (`border-slate-200/80 bg-white/80 text-slate-800`) and updated copy/labels to match the header context, including toggling `KpiCard` bordered behavior (`:bordered="false"`) for TPV and adding `variant="light"` to `SummaryCard` in clients.
- Updated inventory components to match the new style by restyling `InventoryKpiCard.vue` and simplifying `DashboardProductos.vue` to use `CrudPageHeader` (removed dependency on the old `inventoryTheme` layout variables for the hero area).
- Added `CrudPageHeader` imports where needed and adjusted action buttons (rounded-2xl, slate dark action buttons) to match the create-page look in all modified files.

### Testing
- Attempted to start the application with `php artisan serve --host 0.0.0.0 --port 8000`, which failed due to missing Composer dependencies (`vendor/autoload.php`), so the app was not launched and no runtime checks were performed.
- No automated unit or frontend build tests were executed in this rollout (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697238fa3bd883238b9430ce25a480bb)