### PR TITLE
Apply 15% IRPF retention in invoice print view

### DIFF
--- a/resources/js/Pages/Invoices/Print.vue
+++ b/resources/js/Pages/Invoices/Print.vue
@@ -223,24 +223,9 @@ const items = props.invoiceItems.map((item, index) => {
     };
 });
 
-const irpfRate = numberFrom(props.invoice.irpf_tax);
-const resolveIrpfRetention = () => {
-    const explicit = numberFrom(props.invoice.total_irpf, Number.NaN);
-
-    if (Number.isFinite(explicit)) {
-        return explicit;
-    }
-
-    if (irpfRate <= 0) {
-        return 0;
-    }
-
-    return +((invoice.base_imponible * irpfRate) / 100).toFixed(2);
-};
-
-const retencionIrpf = resolveIrpfRetention();
-const fallbackTotal = +(invoice.base_imponible + invoice.monto_iva - retencionIrpf).toFixed(2);
-const totalFinal = numberFrom(props.invoice.total, fallbackTotal);
+const irpfRate = 15;
+const retencionIrpf = +((invoice.base_imponible * irpfRate) / 100).toFixed(2);
+const totalFinal = +(invoice.base_imponible + invoice.monto_iva - retencionIrpf).toFixed(2);
 
 const buildTaxBreakdown = (lineItems) => {
     const map = new Map();


### PR DESCRIPTION
### Motivation
- Ensure the invoice print view applies a 15% IRPF retention so the displayed and printed totals reflect the required tax withholding.

### Description
- Updated `resources/js/Pages/Invoices/Print.vue` to enforce a fixed `irpfRate = 15` instead of reading `props.invoice.irpf_tax`.
- Replaced the previous `resolveIrpfRetention` logic and optional `props.invoice.total_irpf` handling with a direct calculation `retencionIrpf = (invoice.base_imponible * irpfRate) / 100`.
- Simplified the final amount computation to `totalFinal = invoice.base_imponible + invoice.monto_iva - retencionIrpf` and removed the fallback/override path.
- Removed related conditional branches and trimmed the code path to always apply the 15% retention in the print calculations.

### Testing
- Attempted to start the application using `php artisan serve` to validate runtime output, but it failed due to missing `vendor/autoload.php`, so no runtime verification could be completed.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698092ed40d883238070d3ab0413398a)